### PR TITLE
Fix live verification and adaptive VMAF sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,15 @@
   fullscreen, and downloads remain available. FFmpeg frame counts now provide a progress fallback
   when copied-stream timestamps remain at zero, while adaptive VMAF preparation reports its bounded
   candidate, window, and measurement work instead of appearing stuck during a real encode or score.
-- **Copied subtitles and artwork no longer create a false Duration failure for clipped video.**
-  Preview and personal-quality verification compare the measured primary-picture span with the exact
-  requested window even when a retained subtitle or attached picture extends the output container.
-  Normal full-file verification remains strict and continues to use the complete container duration.
+- **Subtitles and ancillary tracks no longer create false Duration or source-corruption failures.**
+  Normal, preview, and personal-quality video verification compare the measured primary-picture span
+  with the corresponding source window instead of a container duration that subtitles, chapters, or
+  attachments may extend. The separate source-timeline safety gate remains strict, but now requires
+  primary audio to materially outlast the picture before reporting an incomplete source video.
+- **Adaptive per-title quality now measures every planned VMAF window.** Removing one completed
+  sample no longer prunes the shared scratch directory needed by the next early, middle, or late
+  sample, so adaptive mode selects a proved per-title encoder value instead of silently falling back
+  to the library value after its first measurement.
 - **Intel QSV previews now compare the same source frames.** Short disposable video previews and
   personal-quality clips keep hardware encoding but use software source decoding, avoiding the
   reordered frames QSV can expose before a long-GOP input seek. The main encode pipeline retains

--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -13,7 +13,10 @@ video, and the final choice is the smallest actually encoded passing sample rath
 CRF/CQ/ICQ/QP-to-size mapping. The chosen value is job-bound for safe crash and quality-retry
 recovery; it is never shared across titles. The complete output still runs every structural, decode,
 duration, tail, stream, size, and configured VMAF gate before replacement. Cross-family evidence
-remains required before the experimental label can be removed.
+remains required before the experimental label can be removed. Live QSV validation additionally
+proved that each sample must be deleted without pruning the shared candidate workspace: the search
+now retains that directory through every planned window and removes it as one unit when preparation
+ends.
 
 **Recently shipped (2026-07-25) — repeatable NVENC profile evidence.** The `dev` image includes a
 guided NVIDIA quality-comparison harness created for issue #37. It prepares a dedicated folder under

--- a/docs/product-and-architecture.md
+++ b/docs/product-and-architecture.md
@@ -313,9 +313,10 @@ Before replacement, all required checks must pass:
 - Output exists and is non-empty.
 - ffprobe can parse it.
 - FFmpeg full decode returns success.
-- Duration delta is within tolerance.
-- The source picture stream reaches its declared container timeline; source corruption is reported
-  separately from an output-tail failure.
+- The source and output primary-picture spans are within the configured duration tolerance.
+- The source picture reaches its primary-audio timeline; source corruption is reported separately
+  from an output-tail failure, while subtitles, chapters, and attachments are never treated as
+  programme duration.
 - The output picture stream reaches the source picture stream's actual endpoint.
 - Required video stream exists.
 - Required audio streams are present or intentionally converted.
@@ -328,10 +329,10 @@ long video previews, the worker encodes a 60-second segment from the middle of
 the source and the verifier creates a temporary clipped reference from that same
 window before running the usual checks. The UI labels those scores as
 segment-only and maps both native players onto that exact source-relative window.
-Clipped-video duration uses the measured primary-picture span so a copied subtitle
-or attached picture cannot extend the container and create a false failure; full
-queue jobs always verify against the complete original and retain the strict
-container-duration check.
+Every video path uses the measured primary-picture span, so a copied subtitle or attached picture
+cannot extend the container and create a false failure. Full queue jobs still scan the complete
+source and output picture timelines, and independently compare the source picture against primary
+audio to catch a genuinely incomplete source without trusting ancillary-track duration.
 Sampled VMAF places the independently encoded source and output on the source's measured frame
 cadence before trimming each window, preventing differing FFmpeg timebases from pairing adjacent
 frames at motion or scene changes.

--- a/docs/troubleshooting/diagnostics.md
+++ b/docs/troubleshooting/diagnostics.md
@@ -61,9 +61,10 @@ sheet before retrying:
   on the library configuration page); image **SSIM/metadata** failures come from the default-on
   image gates. When a gate is enabled, a missing measurement fails closed, but an unmeasured VMAF
   result does not trigger a higher-quality re-encode or immediate automatic exclusion.
-- **Source video timeline** means the original's picture packets end materially before its declared
-  container duration. Optimisarr leaves that source untouched and does not misreport the inherited
-  gap as an output-tail truncation.
+- **Source video timeline** means the original's primary audio materially outlasts its picture
+  packets. Optimisarr leaves that source untouched and reports the inherited gap separately from an
+  output-tail truncation. Subtitle, chapter, data, and attachment timelines do not trigger this
+  failure because they may legitimately continue beyond the programme.
 
 Use **Retry** only after changing the underlying cause: preset, hardware mode,
 source file, mount access, or verification policy. Use **Exclude** for files you

--- a/src/Optimisarr.Api/Queue/AdaptiveQualityScratch.cs
+++ b/src/Optimisarr.Api/Queue/AdaptiveQualityScratch.cs
@@ -1,0 +1,22 @@
+namespace Optimisarr.Api.Queue;
+
+/// <summary>Owns cleanup of one adaptive-quality sample without removing its shared workspace.</summary>
+internal static class AdaptiveQualityScratch
+{
+    public static void DeleteSample(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // The enclosing adaptive search removes the complete scratch directory in its finally
+            // block. A transient sample-cleanup failure must not invalidate otherwise valid VMAF
+            // evidence or remove the workspace needed by the remaining windows.
+        }
+    }
+}

--- a/src/Optimisarr.Api/Queue/QueueDispatcher.cs
+++ b/src/Optimisarr.Api/Queue/QueueDispatcher.cs
@@ -1375,7 +1375,7 @@ public sealed class QueueDispatcher(
             }
 
             results.Add(result);
-            DeleteWorkOutput(outputPath);
+            AdaptiveQualityScratch.DeleteSample(outputPath);
         }
 
         var combined = QualityScoreAggregator.Combine(

--- a/src/Optimisarr.Api/Queue/VerificationService.cs
+++ b/src/Optimisarr.Api/Queue/VerificationService.cs
@@ -101,6 +101,11 @@ public sealed class VerificationService(
             var originalTimestampResult = reference.Kind == MediaKind.Video && clip is null
                 ? await timestamps.CheckAsync(reference.Path, cancellationToken)
                 : TimestampCheckResult.NotMeasured;
+            var originalAudioTimestampResult = reference.Kind == MediaKind.Video
+                && originalProbe.AudioTrackCount > 0
+                && clip is null
+                    ? await timestamps.CheckPrimaryAudioAsync(reference.Path, cancellationToken)
+                    : TimestampCheckResult.NotMeasured;
             var referenceVideoDuration = ReferenceVideoDurationForVerification(
                 originalProbe,
                 originalTimestampResult,
@@ -211,11 +216,10 @@ public sealed class VerificationService(
                 OutputVideoCodec: outputProbe.VideoCodec,
                 OriginalSizeBytes: reference.SizeBytes,
                 OutputSizeBytes: outputSize,
-                OriginalDurationSeconds: reference.DurationSeconds,
+                OriginalDurationSeconds: referenceVideoDuration,
                 OutputDurationSeconds: OutputDurationForVerification(
                     outputProbe,
                     reference.Kind,
-                    clippedVideoReference: clip is not null,
                     timestampResult),
                 OriginalAudioTrackCount: reference.AudioTrackCount,
                 OutputAudioTrackCount: outputProbe.AudioTrackCount,
@@ -259,6 +263,7 @@ public sealed class VerificationService(
                 OutputLastPresentationSeconds: timestampResult.LastPresentationSeconds,
                 OriginalTimestampsMeasured: originalTimestampResult.Measured,
                 OriginalLastPresentationSeconds: originalTimestampResult.LastPresentationSeconds,
+                OriginalAudioLastPresentationSeconds: originalAudioTimestampResult.LastPresentationSeconds,
                 Kind: reference.Kind,
                 AudioReencoded: reference.AudioReencoded,
                 AudioDownmixed: reference.AudioDownmixed,
@@ -364,18 +369,16 @@ public sealed class VerificationService(
     internal static double? OutputDurationForVerification(
         MediaProbeResult outputProbe,
         MediaKind kind,
-        bool clippedVideoReference,
         TimestampCheckResult? timestamps = null)
     {
-        if (kind != MediaKind.Video || !clippedVideoReference)
+        if (kind != MediaKind.Video)
         {
             return outputProbe.DurationSeconds;
         }
 
-        // A clipped encode may retain the source's non-zero stream epoch. In that case ffprobe's
-        // format duration is the absolute end timestamp, while copied subtitles or attachments can
-        // extend it further. The packet scan already provides the authoritative picture endpoint
-        // used by Tail integrity, so compare that span against the exact clip window.
+        // A video container's duration may be extended by subtitles, attachments, or audio padding.
+        // The packet scan already provides the authoritative picture endpoint used by Tail
+        // integrity, so use the same track-aware span for both normal and clipped encodes.
         if (timestamps?.LastPresentationSeconds is { } last)
         {
             return Math.Max(0, last - (outputProbe.VideoStartSeconds ?? 0));

--- a/src/Optimisarr.Core/Verification/PacketTimestampParser.cs
+++ b/src/Optimisarr.Core/Verification/PacketTimestampParser.cs
@@ -3,12 +3,12 @@ using System.Globalization;
 namespace Optimisarr.Core.Verification;
 
 /// <summary>
-/// The result of scanning a video stream's packet timestamps.
+/// The result of scanning one selected media stream's packet timestamps.
 /// </summary>
-/// <param name="TimestampCount">How many packets carried a readable decode timestamp.</param>
+/// <param name="TimestampCount">How many packets carried a readable presentation or decode timestamp.</param>
 /// <param name="NonMonotonicCount">How many packets stepped backward in decode order.</param>
 /// <param name="FirstRegressionDetail">A human-readable description of the first backward step, or null.</param>
-/// <param name="LastPresentationSeconds">The latest presentation time seen, or null — i.e. where the video actually ends.</param>
+/// <param name="LastPresentationSeconds">The latest packet endpoint seen, or null — i.e. where the selected media timeline actually ends.</param>
 public sealed record TimestampIntegrity(
     int TimestampCount,
     int NonMonotonicCount,
@@ -16,8 +16,8 @@ public sealed record TimestampIntegrity(
     double? LastPresentationSeconds);
 
 /// <summary>
-/// Pure parser for one packet per line as <c>pts_time,dts_time</c>, as emitted by
-/// <c>ffprobe -select_streams v:0 -show_entries packet=pts_time,dts_time -of csv=p=0</c>.
+/// Pure parser for one packet per line as <c>pts_time,dts_time,duration_time</c>, as emitted by
+/// <c>ffprobe -select_streams v:0 -show_entries packet=pts_time,dts_time,duration_time -of csv=p=0</c>.
 /// Two faults are read from the same pass:
 /// <list type="bullet">
 /// <item>A well-formed stream's <b>decode</b> timestamps (DTS) never go backward; a
@@ -40,27 +40,40 @@ public static class PacketTimestampParser
             return new TimestampIntegrity(0, 0, null, null);
         }
 
-        var dtsCount = 0;
+        var timestampCount = 0;
         var regressions = 0;
         string? firstRegression = null;
         double? previousDts = null;
-        double? maxPts = null;
+        double? maxPresentation = null;
 
         foreach (var line in csv.Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
         {
             var fields = line.Split(',', StringSplitOptions.TrimEntries);
+            var pts = 0d;
+            var dts = 0d;
+            var hasPts = fields.Length > 0 && TryParseSeconds(fields[0], out pts);
+            var hasDts = fields.Length > 1 && TryParseSeconds(fields[1], out dts);
 
-            if (fields.Length > 0 && TryParseSeconds(fields[0], out var pts) && (maxPts is not { } max || pts > max))
+            if (hasPts || hasDts)
             {
-                maxPts = pts;
+                timestampCount++;
             }
 
-            if (fields.Length < 2 || !TryParseSeconds(fields[1], out var dts))
+            if (hasPts)
+            {
+                var endpoint = fields.Length > 2 && TryParseSeconds(fields[2], out var duration)
+                    ? pts + Math.Max(duration, 0)
+                    : pts;
+                if (maxPresentation is not { } max || endpoint > max)
+                {
+                    maxPresentation = endpoint;
+                }
+            }
+
+            if (!hasDts)
             {
                 continue; // No decode timestamp on this packet; it carries no decode order.
             }
-
-            dtsCount++;
 
             if (previousDts is { } prev && dts < prev)
             {
@@ -74,7 +87,7 @@ public static class PacketTimestampParser
             previousDts = dts;
         }
 
-        return new TimestampIntegrity(dtsCount, regressions, firstRegression, maxPts);
+        return new TimestampIntegrity(timestampCount, regressions, firstRegression, maxPresentation);
     }
 
     private static bool TryParseSeconds(string field, out double value) =>

--- a/src/Optimisarr.Core/Verification/TimestampIntegrityCheck.cs
+++ b/src/Optimisarr.Core/Verification/TimestampIntegrityCheck.cs
@@ -6,7 +6,7 @@ namespace Optimisarr.Core.Verification;
 /// <param name="Measured">True when ffprobe returned a packet timestamp stream to judge.</param>
 /// <param name="NonMonotonicCount">How many packets stepped backward in decode order.</param>
 /// <param name="FirstRegressionDetail">A description of the first backward step, or null.</param>
-/// <param name="LastPresentationSeconds">The latest presentation time, i.e. where the video ends, or null.</param>
+/// <param name="LastPresentationSeconds">The latest packet endpoint, i.e. where the selected stream ends, or null.</param>
 public sealed record TimestampCheckResult(
     bool Measured,
     int NonMonotonicCount,
@@ -36,6 +36,22 @@ public sealed class TimestampIntegrityCheck
     }
 
     public async Task<TimestampCheckResult> CheckAsync(string path, CancellationToken cancellationToken)
+        => await CheckAsync(path, "v:0", cancellationToken);
+
+    /// <summary>
+    /// Reads the primary audio packet endpoint. This deliberately excludes subtitles and secondary
+    /// audio tracks so an unusually long ancillary stream cannot make a complete picture look
+    /// truncated.
+    /// </summary>
+    public async Task<TimestampCheckResult> CheckPrimaryAudioAsync(
+        string path,
+        CancellationToken cancellationToken)
+        => await CheckAsync(path, "a:0", cancellationToken);
+
+    private async Task<TimestampCheckResult> CheckAsync(
+        string path,
+        string streamSpecifier,
+        CancellationToken cancellationToken)
     {
         if (!File.Exists(path))
         {
@@ -54,8 +70,8 @@ public sealed class TimestampIntegrityCheck
                 ArgumentList =
                 {
                     "-v", "error",
-                    "-select_streams", "v:0",
-                    "-show_entries", "packet=pts_time,dts_time",
+                    "-select_streams", streamSpecifier,
+                    "-show_entries", "packet=pts_time,dts_time,duration_time",
                     "-of", "csv=p=0",
                     path
                 },

--- a/src/Optimisarr.Core/Verification/VerificationEvaluator.cs
+++ b/src/Optimisarr.Core/Verification/VerificationEvaluator.cs
@@ -126,13 +126,13 @@ public static class VerificationEvaluator
             checks.Add(MonotonicTimestamps(input));
         }
 
-        // Keep malformed source timelines distinct from output truncation. A file whose audio or
-        // container continues materially beyond its final video packet is unsafe to optimise, but
-        // blaming that inherited gap on the new encode sends the operator in the wrong direction.
+        // Keep malformed source timelines distinct from output truncation. Primary audio that
+        // materially outlasts the final video packet is meaningful evidence of a damaged picture
+        // stream; container duration is not, because subtitles and attachments may end much later.
         if (isVideo
             && input.OriginalTimestampsMeasured
             && input.OriginalLastPresentationSeconds is not null
-            && input.OriginalDurationSeconds is > 0)
+            && input.OriginalAudioLastPresentationSeconds is not null)
         {
             checks.Add(SourceVideoTimelineComplete(input));
         }
@@ -376,15 +376,17 @@ public static class VerificationEvaluator
         const double absoluteFloorSeconds = 1.0;
         const double tolerancePercent = 2.0;
 
-        var containerDuration = input.OriginalDurationSeconds!.Value;
         var videoDuration = OriginalVideoSpanSeconds(input)!.Value;
-        var shortfall = containerDuration - videoDuration;
-        var shortfallPercent = shortfall / containerDuration * 100.0;
+        var audioDuration = Math.Max(
+            0,
+            input.OriginalAudioLastPresentationSeconds!.Value - (input.OriginalAudioStartSeconds ?? 0));
+        var shortfall = audioDuration - videoDuration;
+        var shortfallPercent = audioDuration > 0 ? shortfall / audioDuration * 100.0 : 0;
         var detail = string.Format(
             CultureInfo.InvariantCulture,
-            "The source video ends at {0:0.###}s while its container lasts {1:0.###}s ({2:0.##}% short, tolerance {3:0.##}%).",
+            "The source video spans {0:0.###}s while its primary audio spans {1:0.###}s ({2:0.##}% short, tolerance {3:0.##}%).",
             videoDuration,
-            containerDuration,
+            audioDuration,
             Math.Max(shortfallPercent, 0),
             tolerancePercent);
 

--- a/src/Optimisarr.Core/Verification/VerificationInput.cs
+++ b/src/Optimisarr.Core/Verification/VerificationInput.cs
@@ -58,6 +58,10 @@ public sealed record VerificationInput(
     double? OutputLastPresentationSeconds = null,
     bool OriginalTimestampsMeasured = false,
     double? OriginalLastPresentationSeconds = null,
+    // The primary audio endpoint provides the meaningful comparison for detecting a source whose
+    // picture genuinely ends early. Container duration is excluded because subtitles, chapters,
+    // and attachments may legitimately continue beyond the programme.
+    double? OriginalAudioLastPresentationSeconds = null,
     MediaKind Kind = MediaKind.Video,
     bool AudioReencoded = false,
     bool AudioDownmixed = false,

--- a/tests/Optimisarr.Tests/AdaptiveQualityScratchTests.cs
+++ b/tests/Optimisarr.Tests/AdaptiveQualityScratchTests.cs
@@ -1,0 +1,34 @@
+using Optimisarr.Api.Queue;
+
+namespace Optimisarr.Tests;
+
+public sealed class AdaptiveQualityScratchTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), "optimisarr-tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void Sample_cleanup_preserves_the_workspace_for_the_next_window()
+    {
+        Directory.CreateDirectory(_root);
+        var firstSample = Path.Combine(_root, "q20-window0.mp4");
+        File.WriteAllText(firstSample, "sample");
+
+        AdaptiveQualityScratch.DeleteSample(firstSample);
+
+        Assert.False(File.Exists(firstSample));
+        Assert.True(Directory.Exists(_root));
+
+        var nextSample = Path.Combine(_root, "q20-window1.mp4");
+        File.WriteAllText(nextSample, "next");
+        Assert.True(File.Exists(nextSample));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+}

--- a/tests/Optimisarr.Tests/MediaProbeParseTests.cs
+++ b/tests/Optimisarr.Tests/MediaProbeParseTests.cs
@@ -59,22 +59,23 @@ public sealed class MediaProbeParseTests
     }
 
     [Fact]
-    public void Video_duration_for_sampling_prefers_the_picture_timeline_over_the_container()
+    public void Reference_video_duration_ignores_a_subtitle_inflated_container_timeline()
     {
         var probe = MediaProbeService.Parse("""
         {
           "streams": [
-            { "codec_type": "video", "codec_name": "h264", "duration": "2881.366000" },
-            { "codec_type": "audio", "codec_name": "aac", "duration": "2881.366000" }
+            { "codec_type": "video", "codec_name": "h264" },
+            { "codec_type": "audio", "codec_name": "aac" },
+            { "codec_type": "subtitle", "codec_name": "subrip", "duration": "3892.171000" }
           ],
-          "format": { "duration": "2881.366000" }
+          "format": { "duration": "3892.171000" }
         }
         """, ".mkv");
 
-        Assert.Equal(2362.85, VerificationService.ReferenceVideoDurationForVerification(
+        Assert.Equal(1405.112, VerificationService.ReferenceVideoDurationForVerification(
             probe,
-            new TimestampCheckResult(true, 0, null, 2362.85),
-            fallbackDurationSeconds: 2881.366));
+            new TimestampCheckResult(true, 0, null, 1405.112),
+            fallbackDurationSeconds: 3892.171));
     }
 
     [Fact]
@@ -111,7 +112,7 @@ public sealed class MediaProbeParseTests
     }
 
     [Fact]
-    public void Calibration_video_duration_uses_the_picture_stream_instead_of_audio_padded_container()
+    public void Video_duration_uses_the_picture_stream_instead_of_audio_padded_container()
     {
         const string json = """
         {
@@ -127,9 +128,9 @@ public sealed class MediaProbeParseTests
 
         Assert.Equal(12.0, result.VideoDurationSeconds);
         Assert.Equal(12.0, VerificationService.OutputDurationForVerification(
-            result, MediaKind.Video, clippedVideoReference: true));
-        Assert.Equal(12.531, VerificationService.OutputDurationForVerification(
-            result, MediaKind.Video, clippedVideoReference: false));
+            result, MediaKind.Video));
+        Assert.Equal(12.0, VerificationService.OutputDurationForVerification(
+            result, MediaKind.Video));
     }
 
     [Fact]
@@ -154,14 +155,13 @@ public sealed class MediaProbeParseTests
         Assert.Equal(11.928, VerificationService.OutputDurationForVerification(
             result,
             MediaKind.Video,
-            clippedVideoReference: true,
             timestamps)!.Value,
             precision: 3);
-        Assert.Equal(22.929, VerificationService.OutputDurationForVerification(
+        Assert.Equal(11.928, VerificationService.OutputDurationForVerification(
             result,
             MediaKind.Video,
-            clippedVideoReference: false,
-            timestamps));
+            timestamps)!.Value,
+            precision: 3);
     }
 
     [Fact]
@@ -193,14 +193,13 @@ public sealed class MediaProbeParseTests
         Assert.Equal(59.935, VerificationService.OutputDurationForVerification(
             result,
             MediaKind.Video,
-            clippedVideoReference: true,
             timestamps)!.Value,
             precision: 3);
-        Assert.Equal(62.193, VerificationService.OutputDurationForVerification(
+        Assert.Equal(59.935, VerificationService.OutputDurationForVerification(
             result,
             MediaKind.Video,
-            clippedVideoReference: false,
-            timestamps));
+            timestamps)!.Value,
+            precision: 3);
     }
 
     [Fact]

--- a/tests/Optimisarr.Tests/PacketTimestampParserTests.cs
+++ b/tests/Optimisarr.Tests/PacketTimestampParserTests.cs
@@ -4,7 +4,7 @@ namespace Optimisarr.Tests;
 
 public sealed class PacketTimestampParserTests
 {
-    // ffprobe emits "pts_time,dts_time" per packet at -of csv=p=0.
+    // ffprobe emits "pts_time,dts_time,duration_time" per packet at -of csv=p=0.
     [Fact]
     public void A_strictly_increasing_stream_has_no_regressions()
     {
@@ -110,6 +110,21 @@ public sealed class PacketTimestampParserTests
     }
 
     [Fact]
+    public void Presentation_only_packets_still_provide_a_measured_timeline()
+    {
+        const string csv = """
+        12.000000,N/A,0.020000
+        12.020000,N/A,0.020000
+        """;
+
+        var integrity = PacketTimestampParser.Parse(csv);
+
+        Assert.Equal(2, integrity.TimestampCount);
+        Assert.Equal(0, integrity.NonMonotonicCount);
+        Assert.Equal(12.04, integrity.LastPresentationSeconds);
+    }
+
+    [Fact]
     public void Last_presentation_is_the_maximum_pts_not_the_final_line()
     {
         const string csv = """
@@ -121,6 +136,19 @@ public sealed class PacketTimestampParserTests
         var integrity = PacketTimestampParser.Parse(csv);
 
         Assert.Equal(0.200000, integrity.LastPresentationSeconds);
+    }
+
+    [Fact]
+    public void Last_presentation_includes_the_final_packets_duration()
+    {
+        const string csv = """
+        0.000000,0.000000,0.041708
+        0.041708,0.041708,0.041708
+        """;
+
+        var integrity = PacketTimestampParser.Parse(csv);
+
+        Assert.Equal(0.083416, integrity.LastPresentationSeconds);
     }
 
     [Theory]

--- a/tests/Optimisarr.Tests/VerificationEvaluatorTests.cs
+++ b/tests/Optimisarr.Tests/VerificationEvaluatorTests.cs
@@ -476,6 +476,7 @@ public sealed class VerificationEvaluatorTests
         OutputSizeBytes: 600_000_000,
         OriginalDurationSeconds: 3600,
         OutputDurationSeconds: 3600,
+        OriginalAudioLastPresentationSeconds: 3600,
         OriginalAudioTrackCount: 2,
         OutputAudioTrackCount: 2,
         OriginalSubtitleTrackCount: 1,
@@ -714,10 +715,11 @@ public sealed class VerificationEvaluatorTests
     {
         var input = Healthy() with
         {
-            OriginalDurationSeconds = 2881.366,
-            OutputDurationSeconds = 2881.365,
+            OriginalDurationSeconds = 2362.9,
+            OutputDurationSeconds = 2362.9,
             OriginalTimestampsMeasured = true,
             OriginalLastPresentationSeconds = 2362.9,
+            OriginalAudioLastPresentationSeconds = 2881.366,
             TimestampsMeasured = true,
             OutputLastPresentationSeconds = 2361.568
         };
@@ -727,9 +729,31 @@ public sealed class VerificationEvaluatorTests
         Assert.Equal(CheckOutcome.Failed, Outcome(report, "Source video timeline"));
         Assert.Equal(CheckOutcome.Passed, Outcome(report, "Tail integrity"));
         Assert.Contains(
-            "source video ends",
+            "primary audio",
             report.Checks.Single(check => check.Name == "Source video timeline").Detail,
             StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void A_subtitle_longer_than_the_picture_does_not_make_a_complete_source_look_corrupt()
+    {
+        var input = Healthy() with
+        {
+            OriginalDurationSeconds = 1405.112,
+            OutputDurationSeconds = 1405.088,
+            OriginalTimestampsMeasured = true,
+            OriginalLastPresentationSeconds = 1405.112,
+            OriginalAudioLastPresentationSeconds = 1405.109,
+            TimestampsMeasured = true,
+            OutputLastPresentationSeconds = 1405.088
+        };
+
+        var report = VerificationEvaluator.Evaluate(input, VerificationPolicy.Default);
+
+        Assert.True(report.Passed);
+        Assert.Equal(CheckOutcome.Passed, Outcome(report, "Duration"));
+        Assert.Equal(CheckOutcome.Passed, Outcome(report, "Source video timeline"));
+        Assert.Equal(CheckOutcome.Passed, Outcome(report, "Tail integrity"));
     }
 
     [Fact]


### PR DESCRIPTION
## Outcome

Video jobs no longer fail when subtitles, chapters, or attachments extend the container beyond the actual programme, and adaptive per-title VMAF now completes all planned windows instead of falling back after its first sample.

## Scope

- **Included:**
  - Use measured source/output picture spans for video duration verification.
  - Compare the source picture against primary audio—not container duration—when identifying a genuinely incomplete source timeline.
  - Include packet duration in measured stream endpoints and accept presentation-only packet timelines.
  - Preserve the adaptive candidate workspace while individual sample files are removed.
  - Update operator, architecture, engineering-history, and changelog documentation.
- **Explicitly excluded:**
  - No verification thresholds were weakened.
  - No database/schema or frontend behaviour changes.
  - Existing auto-exclusions are not automatically removed.
- **Issue or roadmap outcome:** Resolves the live Riker Duration/Source video timeline false failures and restores the experimental adaptive-VMAF path.

## Root cause

FFprobe's format duration was being treated as programme duration even when a subtitle stream extended it far beyond the primary picture. Separately, adaptive sampling reused the persisted-output cleanup helper; deleting window one therefore pruned the empty shared scratch directory required by window two.

The implementation follows FFprobe's distinction between container, stream, and packet evidence and Netflix VMAF's requirement for timestamp-aligned comparisons:

- https://ffmpeg.org/ffprobe-all.html
- https://github.com/Netflix/vmaf/blob/master/resource/doc/ffmpeg.md

## Verification

```text
dotnet build Optimisarr.slnx --no-restore -warnaserror
Build succeeded. 0 warnings, 0 errors.

dotnet test Optimisarr.slnx --no-build --no-restore
Passed: 1476, Failed: 0, Skipped: 0.

npm --prefix web run check
svelte-check: 0 errors, 0 warnings.
Locale and setup tests passed.

git diff --check
Clean.
```

Live Riker evidence:

- Reproduced a source whose subtitle/container duration was 3892.171s while the real picture ended at approximately 1405.112s.
- Confirmed the retained output contains the complete picture rather than a truncated encode.
- Re-ran the exact 40-second timestamp-aligned production VMAF window against retained failed output: minimum 93.42, harmonic mean 97.17. No threshold relaxation is justified.
- Paused the live queue with its active encode safely suspended until the reviewed `dev` image is deployed and verified.

## Safety and risk

- Original-file, replacement, or rollback risk: Strengthened. Replacement still requires every configured gate; only track-appropriate evidence replaces subtitle-inflated container duration.
- Migration/recovery path, if data changes: None; no schema or persisted-data changes.
- Security or secret-handling risk: None.
- Deployment verification, if deployed: Pending reviewed `dev` image deployment and retry of a retained live failure.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a backwards-safe, idempotent migration. (No schema change.)
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Pull-request code cannot replace or delete an original without the normal verification and rollback path.