### PR TITLE
Fix adaptive VMAF sample timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,9 @@
   primary audio to materially outlast the picture before reporting an incomplete source video.
 - **Adaptive per-title quality now measures every planned VMAF window.** Removing one completed
   sample no longer prunes the shared scratch directory needed by the next early, middle, or late
-  sample, so adaptive mode selects a proved per-title encoder value instead of silently falling back
+  sample. Sample positions also follow the primary picture duration rather than a container timeline
+  that subtitles or ancillary tracks may extend, so a middle or late seek cannot land beyond video
+  EOF. Adaptive mode now selects a proved per-title encoder value instead of silently falling back
   to the library value after its first measurement.
 - **Intel QSV previews now compare the same source frames.** Short disposable video previews and
   personal-quality clips keep hardware encoding but use software source decoding, avoiding the

--- a/src/Optimisarr.Api/Queue/AdaptiveQualityDuration.cs
+++ b/src/Optimisarr.Api/Queue/AdaptiveQualityDuration.cs
@@ -1,0 +1,17 @@
+namespace Optimisarr.Api.Queue;
+
+/// <summary>Selects the picture timeline used to place adaptive VMAF samples.</summary>
+internal static class AdaptiveQualityDuration
+{
+    public static double? Resolve(double? videoDurationSeconds, double? containerDurationSeconds)
+    {
+        if (videoDurationSeconds is > 0 && double.IsFinite(videoDurationSeconds.Value))
+        {
+            return videoDurationSeconds;
+        }
+
+        return containerDurationSeconds is > 0 && double.IsFinite(containerDurationSeconds.Value)
+            ? containerDurationSeconds
+            : null;
+    }
+}

--- a/src/Optimisarr.Api/Queue/QueueDispatcher.cs
+++ b/src/Optimisarr.Api/Queue/QueueDispatcher.cs
@@ -1139,12 +1139,6 @@ public sealed class QueueDispatcher(
 
         try
         {
-            if (work.DurationSeconds is not > 0)
-            {
-                return await FinishAdaptiveSelectionAsync(
-                    jobId, work, baseline, fellBack: true, "source duration is unavailable", cancellationToken);
-            }
-
             await using var scope = scopeFactory.CreateAsyncScope();
             var probeService = scope.ServiceProvider.GetRequiredService<MediaProbeService>();
             var qualityService = scope.ServiceProvider.GetRequiredService<QualityScoreService>();
@@ -1160,6 +1154,18 @@ public sealed class QueueDispatcher(
                     cancellationToken);
             }
 
+            // A subtitle, chapter, attachment, or data stream may extend the container far beyond
+            // the actual programme. Place every adaptive sample on the primary picture timeline so
+            // a middle/late seek cannot land after EOF and create an empty, unscorable candidate.
+            var samplingDuration = AdaptiveQualityDuration.Resolve(
+                sourceProbe.VideoDurationSeconds,
+                work.DurationSeconds);
+            if (samplingDuration is not > 0)
+            {
+                return await FinishAdaptiveSelectionAsync(
+                    jobId, work, baseline, fellBack: true, "source video duration is unavailable", cancellationToken);
+            }
+
             var policy = work.VerificationPolicy;
             if (!policy.QualityGateEnabled)
             {
@@ -1167,7 +1173,7 @@ public sealed class QueueDispatcher(
                     jobId, work, baseline, fellBack: true, "the VMAF target is disabled", cancellationToken);
             }
 
-            var windows = VmafWindowPlanner.PlanAdaptive(work.DurationSeconds.Value);
+            var windows = VmafWindowPlanner.PlanAdaptive(samplingDuration.Value);
             if (windows.Count == 0)
             {
                 return await FinishAdaptiveSelectionAsync(
@@ -1196,6 +1202,7 @@ public sealed class QueueDispatcher(
                     decision.NextQuality!.Value,
                     measured.Count,
                     windows,
+                    samplingDuration.Value,
                     sourceProbe,
                     policy,
                     qualityService,
@@ -1247,6 +1254,7 @@ public sealed class QueueDispatcher(
         int qualityValue,
         int candidateIndex,
         IReadOnlyList<VmafWindow> windows,
+        double sourceVideoDurationSeconds,
         MediaProbeResult sourceProbe,
         VerificationPolicy policy,
         QualityScoreService qualityService,
@@ -1290,7 +1298,7 @@ public sealed class QueueDispatcher(
                 window.DurationSeconds,
                 FfmpegProgressCalculator.ExpectedFramesForWindow(
                     sourceProbe.FrameCount,
-                    sourceProbe.DurationSeconds,
+                    sourceVideoDurationSeconds,
                     window.DurationSeconds,
                     sourceProbe.VideoFrameRate),
                 IsHardwareEncoder(work.VideoEncoder),
@@ -1330,7 +1338,7 @@ public sealed class QueueDispatcher(
                 work.Original.IsHdr,
                 work.Original.HdrConvertedToSdr,
                 ReferenceStartSeconds: window.StartSeconds,
-                ReferenceDurationSeconds: work.DurationSeconds,
+                ReferenceDurationSeconds: sourceVideoDurationSeconds,
                 DistortedStartSeconds: null,
                 MeasureDurationSeconds: window.DurationSeconds,
                 FrameSubsample: policy.VmafFrameSubsample,

--- a/tests/Optimisarr.Tests/AdaptiveQualityDurationTests.cs
+++ b/tests/Optimisarr.Tests/AdaptiveQualityDurationTests.cs
@@ -1,0 +1,31 @@
+using Optimisarr.Api.Queue;
+
+namespace Optimisarr.Tests;
+
+public sealed class AdaptiveQualityDurationTests
+{
+    [Fact]
+    public void Primary_picture_duration_wins_when_subtitles_extend_the_container()
+    {
+        var duration = AdaptiveQualityDuration.Resolve(
+            videoDurationSeconds: 1_405.321,
+            containerDurationSeconds: 3_896.275);
+
+        Assert.Equal(1_405.321, duration);
+    }
+
+    [Theory]
+    [InlineData(null, 1_405.321, 1_405.321)]
+    [InlineData(double.NaN, 1_405.321, 1_405.321)]
+    [InlineData(0d, 1_405.321, 1_405.321)]
+    [InlineData(null, null, null)]
+    public void Invalid_or_missing_picture_duration_uses_the_available_container_fallback(
+        double? videoDurationSeconds,
+        double? containerDurationSeconds,
+        double? expected)
+    {
+        Assert.Equal(
+            expected,
+            AdaptiveQualityDuration.Resolve(videoDurationSeconds, containerDurationSeconds));
+    }
+}


### PR DESCRIPTION
## Summary

- place adaptive early/middle/late samples on the primary video-stream duration instead of the container duration
- keep frame-progress and VMAF measurement context on that same picture clock
- fall back safely when no usable picture or container duration exists
- document the corrected behavior

## Live evidence

Riker job 4531 used a source whose video ends at 1405.321s while a subtitle extends the Matroska container to 3896.275s. The old planner put sample 2 beyond picture EOF, producing an empty MP4 and:

`adaptive sample 2 at quality 20 could not be scored ... matches no streams`

This change selects 1405.321s for planning while retaining 3896.275s only as a fallback if no picture duration is available.

## Verification

- `dotnet build Optimisarr.slnx --no-restore -warnaserror`
- `dotnet test Optimisarr.slnx --no-build --no-restore` — 1481 passed
- `npm --prefix web run check` — 0 errors and 0 warnings
- `python3 scripts/check_docs.py`
- `git diff --check`

## Safety

No verification threshold, database schema, replacement rule, or UI/API contract changes. Adaptive preparation remains fail-open to the configured library quality; final verification remains fail-closed.
