### PR TITLE
Parse Matroska stream durations reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,10 @@
   sample no longer prunes the shared scratch directory needed by the next early, middle, or late
   sample. Sample positions also follow the primary picture duration rather than a container timeline
   that subtitles or ancillary tracks may extend, so a middle or late seek cannot land beyond video
-  EOF. Adaptive mode now selects a proved per-title encoder value instead of silently falling back
-  to the library value after its first measurement.
+  EOF. Matroska's nanosecond-precision stream duration tags are parsed across multi-minute and
+  multi-hour values instead of intermittently falling back to format duration. Adaptive mode now
+  selects a proved per-title encoder value instead of silently falling back to the library value
+  after its first measurement.
 - **Intel QSV previews now compare the same source frames.** Short disposable video previews and
   personal-quality clips keep hardware encoding but use software source decoding, avoiding the
   reordered frames QSV can expose before a long-GOP input seek. The main encode pipeline retains

--- a/src/Optimisarr.Core/Library/MediaProbeService.cs
+++ b/src/Optimisarr.Core/Library/MediaProbeService.cs
@@ -476,12 +476,39 @@ public sealed class MediaProbeService
             && tags.ValueKind == JsonValueKind.Object
             && tags.TryGetProperty("DURATION", out var taggedDuration)
             && taggedDuration.ValueKind == JsonValueKind.String
-            && TimeSpan.TryParse(taggedDuration.GetString(), CultureInfo.InvariantCulture, out var parsed))
+            && TryParseFfmpegDurationTag(taggedDuration.GetString(), out var parsed))
         {
-            return parsed.TotalSeconds;
+            return parsed;
         }
 
         return null;
+    }
+
+    // Matroska's demuxer emits stream duration tags as HH:MM:SS.nnnnnnnnn. TimeSpan.TryParse
+    // accepts some nine-digit values but rejects others once minutes are non-zero, so parse the
+    // documented clock fields directly and preserve their sub-second precision as a double.
+    private static bool TryParseFfmpegDurationTag(string? value, out double durationSeconds)
+    {
+        durationSeconds = 0;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var fields = value.Split(':');
+        if (fields.Length != 3
+            || !long.TryParse(fields[0], NumberStyles.None, CultureInfo.InvariantCulture, out var hours)
+            || !int.TryParse(fields[1], NumberStyles.None, CultureInfo.InvariantCulture, out var minutes)
+            || !double.TryParse(fields[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds)
+            || hours < 0
+            || minutes is < 0 or >= 60
+            || seconds is < 0 or >= 60)
+        {
+            return false;
+        }
+
+        durationSeconds = (hours * 3_600d) + (minutes * 60d) + seconds;
+        return double.IsFinite(durationSeconds);
     }
 
     private static bool? DetectVariableFrameRate(JsonElement stream)

--- a/tests/Optimisarr.Tests/MediaProbeParseTests.cs
+++ b/tests/Optimisarr.Tests/MediaProbeParseTests.cs
@@ -224,6 +224,55 @@ public sealed class MediaProbeParseTests
     }
 
     [Fact]
+    public void Parse_reads_real_world_matroska_episode_duration_tag()
+    {
+        const string json = """
+        {
+          "streams": [
+            {
+              "codec_type": "video",
+              "codec_name": "h264",
+              "time_base": "1/1000",
+              "tags": { "DURATION": "00:23:25.321000000" }
+            },
+            {
+              "codec_type": "subtitle",
+              "duration": "3819.431000",
+              "tags": { "DURATION": "01:03:37.263000000" }
+            }
+          ],
+          "format": { "format_name": "matroska,webm", "duration": "3819.431000" }
+        }
+        """;
+
+        var result = MediaProbeService.Parse(json, ".mkv");
+
+        Assert.Equal(1_405.321, result.VideoDurationSeconds);
+        Assert.Equal(3_819.431, result.DurationSeconds);
+    }
+
+    [Fact]
+    public void Parse_reads_matroska_stream_duration_beyond_one_day()
+    {
+        const string json = """
+        {
+          "streams": [
+            {
+              "codec_type": "video",
+              "codec_name": "h264",
+              "tags": { "DURATION": "27:01:02.123456789" }
+            }
+          ],
+          "format": { "format_name": "matroska,webm", "duration": "97262.5" }
+        }
+        """;
+
+        var result = MediaProbeService.Parse(json, ".mkv");
+
+        Assert.Equal(97_262.123456789, result.VideoDurationSeconds);
+    }
+
+    [Fact]
     public void Parse_reads_the_audio_bitrate_from_the_stream()
     {
         const string json = """


### PR DESCRIPTION
## Summary

- parse FFprobe Matroska `DURATION` tags as explicit `HH:MM:SS.nnnnnnnnn` fields
- preserve nanosecond-style fractional input across multi-minute and multi-hour durations
- keep strict minute/second bounds and reject invalid/non-finite values
- cover the exact Riker stream/container mismatch and a duration beyond one day

## Live evidence

Riker's untouched job 4532 has:

- primary video: `00:23:25.321000000` (1405.321s)
- primary audio: `00:23:25.344000000`
- subtitle/container: 3819.431s

`TimeSpan.TryParse` returned no video duration for that real multi-minute nine-fractional-digit value even though a 12-second fixture happened to pass. Adaptive planning therefore used 3819.431s and placed its first window at 361s instead of 120s. The new parser returns 1405.321s deterministically.

## Verification

- targeted duration/adaptive regressions: 8 passed
- `dotnet build Optimisarr.slnx --no-restore -warnaserror`
- `dotnet test Optimisarr.slnx --no-build --no-restore` — 1483 passed
- `npm --prefix web run check` — 0 errors and 0 warnings
- `python3 scripts/check_docs.py`
- `git diff --check`

## Safety

No threshold, schema, queue, replacement, UI, or API contract changes. Invalid tags remain unavailable rather than being guessed; existing stream fields and container duration remain fallback evidence.
