### PR TITLE
Fix VMAF cadence origin alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@
 
 ### Fixed
 
+- **VMAF now compares the same decoded picture across container timestamp origins.** Before
+  cadence normalisation, each decoded input is rebased to zero; FFmpeg's `fps(start_time=0)` can no
+  longer pad an MP4 candidate while leaving its Matroska reference untouched and accidentally score
+  adjacent frames. This corrects false low VMAF results seen with otherwise frame-aligned QSV
+  H.264/HEVC Personal quality samples and applies to Preview, adaptive sampling, and normal VMAF
+  verification through their shared scorer.
 - **Preview and Personal quality video clips now keep copied audio on the exact picture timeline.**
   A bounded coarse seek still avoids decoding from the beginning of a long source, followed by an
   exact output seek that trims re-encoded video and copied audio/subtitles to the same requested

--- a/docs/product-and-architecture.md
+++ b/docs/product-and-architecture.md
@@ -336,9 +336,10 @@ Every video path uses the measured primary-picture span, so a copied subtitle or
 cannot extend the container and create a false failure. Full queue jobs still scan the complete
 source and output picture timelines, and independently compare the source picture against primary
 audio to catch a genuinely incomplete source without trusting ancillary-track duration.
-Sampled VMAF places the independently encoded source and output on the source's measured frame
-cadence before trimming each window, preventing differing FFmpeg timebases from pairing adjacent
-frames at motion or scene changes.
+VMAF first rebases each independently decoded source and output to its own first picture, then places
+both on the source's measured frame cadence before trimming each window. Resetting the origins before
+FFmpeg's cadence filter prevents differing MP4/Matroska start timestamps or timebases from padding
+only one input and pairing adjacent frames at motion or scene changes.
 
 Blind-calibration jobs are also disposable and replacement-ineligible. Video calibration encodes the
 complete output contract of each library-slider preset, including codec, container, and audio rules.

--- a/src/Optimisarr.Core/Verification/QualityScoreCommandBuilder.cs
+++ b/src/Optimisarr.Core/Verification/QualityScoreCommandBuilder.cs
@@ -255,18 +255,21 @@ public static class QualityScoreCommandBuilder
         int? windowDurationSeconds,
         double? referenceFrameRate)
     {
-        // ffprobe frequently reports a millisecond source timebase while the encode uses an exact
-        // codec clock (for example 1/1000 versus 1/24000). Trimming those timelines directly can
-        // choose adjacent pictures and collapse VMAF at motion or scene changes. Resample both
-        // decoded inputs onto the source cadence first; start_time=0 gives each pre-rolled input
-        // the same frame grid without guessing or accepting the best of several quality scores.
+        // FFmpeg's fps(start_time=0) pads or trims from each input's existing first PTS. MP4 and
+        // Matroska can expose the same first picture at different non-zero PTS values, so applying
+        // fps before resetting the origins can manufacture a one-frame VMAF misalignment. Rebase
+        // each decoded input first, then resample both onto the source cadence and trim matching
+        // pre-roll. The final reset leaves libvmaf with two zero-based timelines.
+        const string origin = "settb=AVTB,setpts=PTS-STARTPTS";
         var cadence = referenceFrameRate is { } frameRate
             ? $"fps=fps={frameRate.ToString("G17", CultureInfo.InvariantCulture)}:start_time=0,"
             : string.Empty;
         var alignment = windowStartSeconds is { } start && windowDurationSeconds is > 0
             ? $"trim=start={start - (inputStartSeconds ?? 0)}:duration={windowDurationSeconds.Value},"
             : string.Empty;
-        return $"{cadence}{alignment}settb=AVTB,setpts=PTS-STARTPTS";
+        return cadence.Length == 0 && alignment.Length == 0
+            ? origin
+            : $"{origin},{cadence}{alignment}{origin}";
     }
 
     private static string DescribePreprocessing(

--- a/tests/Optimisarr.Tests/QualityScoreCommandBuilderTests.cs
+++ b/tests/Optimisarr.Tests/QualityScoreCommandBuilderTests.cs
@@ -158,6 +158,25 @@ public sealed class QualityScoreCommandBuilderTests
         Assert.Equal("120", ValueAfter(args, "-t", occurrence: 1));
     }
 
+    [Fact]
+    public void Cadence_alignment_rebases_each_decoded_timeline_before_fps_rounding()
+    {
+        var command = QualityScoreCommandBuilder.Build(
+            "/work/output.mp4", "/data/original.mkv", "/tmp/vmaf.json",
+            new QualityMeasurementContext(
+                1920, 1080, ReferenceIsHdr: false, HdrConvertedToSdr: false,
+                ReferenceStartSeconds: 39,
+                ReferenceFrameRate: 25),
+            threads: 4);
+
+        // MP4 and Matroska may expose the same first picture at different non-zero PTS values.
+        // fps(start_time=0) pads or trims from those PTS values, so rebase both decoded streams
+        // first or the scorer can compare adjacent frames even when the clips are correctly cut.
+        const string orderedTimeline =
+            "settb=AVTB,setpts=PTS-STARTPTS,fps=fps=25:start_time=0";
+        Assert.Equal(2, command.FilterGraph.Split(orderedTimeline).Length - 1);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-23.976)]


### PR DESCRIPTION
## What changed

- rebase each decoded VMAF input to its own first picture before `fps(start_time=0)` cadence normalisation
- keep the existing common-cadence and bounded-window trimming after that origin reset
- add a regression test covering an MP4 candidate against a Matroska reference
- document the shared Preview, Personal quality, adaptive, and normal verification behaviour

## Why

Riker live validation exposed a false VMAF result after the clipped-timeline fix: QSV H.264/HEVC samples were correctly cut and had SSIM ≈0.998 against the requested source scene, but VMAF reported ≈32. The same software AV1 scene reported ≈98.8.

FFmpeg documents that `fps(start_time=0)` may pad or trim based on the input's existing first PTS. Applying it before `PTS-STARTPTS` allowed MP4 and Matroska inputs with different timestamp origins to select adjacent pictures. Rebasing first makes cadence rounding deterministic.

Official references:
- https://ffmpeg.org/ffmpeg-filters.html#fps
- https://ffmpeg.org/ffmpeg-filters.html#setpts_002c-asetpts
- https://ffmpeg.org/ffmpeg-filters.html#libvmaf

## Evidence

Using the exact completed Riker calibration sample without re-encoding:

| Path | Before | After origin-first cadence |
|---|---:|---:|
| QSV H.264 | VMAF mean 31.96 | VMAF mean 99.36 |
| QSV HEVC | VMAF mean 31.87 | VMAF mean 99.54 |
| software AV1 | VMAF mean 98.77 | VMAF mean 98.77 |

This isolates the correction to the scorer: the encoded files are unchanged.

## Verification

- `dotnet build Optimisarr.slnx --no-restore -warnaserror` — 0 warnings, 0 errors
- `dotnet test Optimisarr.slnx --no-build --no-restore` — 1,487 passed
- `npm --prefix web run check` — clean, including locale/setup checks
- `python3 scripts/check_docs.py` — links and OpenAPI references valid
- `git diff --check` — clean

## Safety

No database, replacement, retry, exclusion, quality-threshold, or encoder changes. This corrects the shared VMAF measurement timeline only.