### PR TITLE
Sync Optimisarr 0.2.9 metadata to dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.9 — 2026-07-29
 
 ### Added
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Shared metadata for all projects. Version drives the /api/health response and the
        "optimisarr=<version>" marker stamped into optimised files. -->
   <PropertyGroup>
-    <Version>0.2.8</Version>
+    <Version>0.2.9</Version>
     <Product>Optimisarr</Product>
     <Authors>Optimisarr contributors</Authors>
     <Copyright>Copyright (C) 2026 Optimisarr contributors</Copyright>

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1750,7 +1750,7 @@
   "info": {
     "description": "HTTP API for Optimisarr \u2014 safe, verified FFmpeg transcoding for self-hosted media libraries. This contract is still pre-1.0 and may change between releases.",
     "title": "Optimisarr API",
-    "version": "0.2.8.0"
+    "version": "0.2.9.0"
   },
   "openapi": "3.1.1",
   "paths": {


### PR DESCRIPTION
## What changed

- sync the released application version to `0.2.9` on `dev`
- mark the `0.2.9` changelog section as released
- keep the generated OpenAPI version aligned with the application

## Why

The `v0.2.9` release metadata was committed on the release branch and reached
`main`, but was not synchronized back to `dev`. As a result, the current
`ghcr.io/jellman86/optimisarr:dev` image contains the latest development code
while `/api/health` still reports version `0.2.8`.

Merging this PR lets the normal `dev` branch workflow rebuild and publish the
tag from the correct source state.

## Validation

- `dotnet build Optimisarr.slnx --configuration Release --warnaserror`
- `python3 scripts/check_openapi.py --configuration Release --no-build`
- `python3 scripts/check_docs.py`
