### PR TITLE
Standardise post-release dev synchronisation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Release metadata validation compares development state with the
+          # newest version tag, so this job needs the complete tag set.
+          fetch-depth: 0
       - run: bash scripts/test_nvenc_benchmark.sh
+      - run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+      - run: python3 scripts/check_release_metadata.py
       - run: python3 scripts/check_docs.py
       - run: |
           for file in compose*.example.yml; do

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 **/.vs/
 **/.vscode/
 **/TestResults/
+**/__pycache__/
+*.py[cod]
 web/node_modules/
 web/test-results/
 web/playwright-report/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Release metadata can no longer silently drift between `main` and `dev`.**
+  CI now keeps the application, generated OpenAPI contract, changelog state, and
+  newest release tag aligned. The release flow explicitly synchronises released
+  metadata back to `dev`, restores this `Unreleased` section, and verifies the
+  rebuilt `dev` image before a release is considered complete.
+
 ## 0.2.9 — 2026-07-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,12 @@ the repo's package settings if anonymous `docker pull` is expected.
   branch to one reviewable behaviour change or tightly related maintenance slice.
 - Open a pull request into `dev`. Release pull requests alone target `main`;
   release tags are created from the reviewed release state.
+- **A release is not complete when the tag is published.** After the exact tag's
+  CI and image publication pass, synchronise its released version, changelog,
+  and generated OpenAPI metadata back to `dev` through a short-lived pull
+  request; restore a fresh `## Unreleased` changelog section; and verify the
+  rebuilt `:dev` image reports the released application version. Follow
+  [`docs/development/releasing.md`](docs/development/releasing.md).
 - Pull requests state the outcome, included and excluded scope, verification
   results, and material safety or migration risk. Do not merge while a required
   check is failing or a blocking review conversation is unresolved.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -24,6 +24,32 @@ Before writing, collect:
 - any migration, configuration, downtime, or compatibility action;
 - the most important safety boundary or opt-in default affected by the release.
 
+## Branch and image flow
+
+1. Start `release/vX.Y.Z` from the exact reviewed `dev` commit. Change
+   `Directory.Build.props` to `X.Y.Z`, rename the leading `## Unreleased`
+   changelog section to `## X.Y.Z — YYYY-MM-DD`, and regenerate
+   `docs/openapi.json`.
+2. Run the Definition of Done, then open the release pull request into `main`.
+   No everyday feature or fix pull request targets `main`.
+3. Merge only with every required check green. Tag the exact reviewed merge
+   commit as `vX.Y.Z`, then wait for the tag build, container smoke test, and
+   versioned image publication before publishing the GitHub Release.
+4. Immediately start a short-lived branch from current `dev` and synchronise
+   only the released version metadata from `main`: the application version, the
+   dated changelog heading, and the generated OpenAPI version. Add a fresh,
+   empty `## Unreleased` section above the released section and open a pull
+   request back into `dev`.
+5. Merge the synchronization pull request only when its checks pass. Wait for
+   the protected `dev` build to publish `ghcr.io/jellman86/optimisarr:dev`, then
+   verify that image reports `X.Y.Z`.
+
+This final synchronization is part of the release, not optional housekeeping.
+Without it, the moving `dev` image can contain new code while continuing to
+advertise the previous application version. CI checks the application, OpenAPI,
+changelog, and newest Git tag together so the drift cannot pass the next
+protected-branch build unnoticed.
+
 ## Write for the update decision
 
 Start from [the release-notes template](../../.github/RELEASE_NOTES_TEMPLATE.md).
@@ -69,4 +95,6 @@ when, and whether there is a tradeoff.
 - [ ] The full changelog link points at the released tag.
 - [ ] Empty template sections and all HTML comments are removed.
 - [ ] The rendered GitHub preview has been read from top to bottom.
-
+- [ ] Released metadata is synchronized back to `dev` through a green pull
+      request and a fresh `## Unreleased` section exists.
+- [ ] The rebuilt `:dev` image reports the released application version.

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Keep application, API, changelog, branch, and release-tag versions aligned."""
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+ROOT = Path(__file__).resolve().parents[1]
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+RELEASE_HEADING = re.compile(r"^(?P<version>\d+\.\d+\.\d+) — \d{4}-\d{2}-\d{2}$")
+
+
+@dataclass(frozen=True)
+class ReleaseContext:
+    mode: str
+    latest_tag: str | None = None
+    tag_name: str | None = None
+
+    @classmethod
+    def development(cls, *, latest_tag: str | None) -> "ReleaseContext":
+        return cls(mode="development", latest_tag=latest_tag)
+
+    @classmethod
+    def release(cls, *, tag_name: str | None = None) -> "ReleaseContext":
+        return cls(mode="release", tag_name=tag_name)
+
+
+def read_application_version(root: Path) -> str:
+    document = ET.parse(root / "Directory.Build.props")
+    element = document.find(".//Version")
+    if element is None or not element.text:
+        raise ValueError("Directory.Build.props does not contain a Version element")
+    return element.text.strip()
+
+
+def read_openapi_version(root: Path) -> str:
+    document = json.loads((root / "docs" / "openapi.json").read_text(encoding="utf-8"))
+    version = document.get("info", {}).get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("docs/openapi.json does not contain info.version")
+    return version
+
+
+def read_changelog_headings(root: Path) -> list[str]:
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8-sig")
+    return re.findall(r"^## (.+)$", changelog, re.MULTILINE)
+
+
+def validate(root: Path, context: ReleaseContext) -> list[str]:
+    application_version = read_application_version(root)
+    openapi_version = read_openapi_version(root)
+    headings = read_changelog_headings(root)
+    errors: list[str] = []
+
+    if not SEMVER.fullmatch(application_version):
+        errors.append(
+            f"application version {application_version!r} must be a numeric X.Y.Z version"
+        )
+
+    expected_openapi_version = f"{application_version}.0"
+    if openapi_version != expected_openapi_version:
+        errors.append(
+            f"OpenAPI version {openapi_version} must match application version "
+            f"{expected_openapi_version}"
+        )
+
+    if not headings:
+        errors.append("CHANGELOG.md must contain a level-two release heading")
+        return errors
+
+    if context.mode == "development":
+        if headings[0] != "Unreleased":
+            errors.append("development changelog must begin with '## Unreleased'")
+
+        if context.latest_tag:
+            latest_version = context.latest_tag.removeprefix("v")
+            if application_version != latest_version:
+                errors.append(
+                    f"development version {application_version} must match the latest "
+                    f"release tag {context.latest_tag}"
+                )
+            if not any(
+                heading.startswith(f"{latest_version} — ") for heading in headings[1:]
+            ):
+                errors.append(
+                    f"development changelog must retain the {latest_version} release section"
+                )
+    elif context.mode == "release":
+        match = RELEASE_HEADING.fullmatch(headings[0])
+        if match is None or match.group("version") != application_version:
+            errors.append(
+                "release changelog must begin with the dated application version "
+                f"'## {application_version} — YYYY-MM-DD'"
+            )
+
+        if context.tag_name and context.tag_name != f"v{application_version}":
+            errors.append(
+                f"release tag {context.tag_name} must match application version "
+                f"{application_version}"
+            )
+    else:
+        errors.append(f"unknown release metadata mode {context.mode!r}")
+
+    return errors
+
+
+def git_output(root: Path, *arguments: str) -> str:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def latest_release_tag(root: Path) -> str | None:
+    tags = git_output(root, "tag", "--list", "v[0-9]*.[0-9]*.[0-9]*").splitlines()
+    valid_tags = [tag for tag in tags if SEMVER.fullmatch(tag.removeprefix("v"))]
+    if not valid_tags:
+        return None
+    return max(
+        valid_tags,
+        key=lambda tag: tuple(int(part) for part in tag.removeprefix("v").split(".")),
+    )
+
+
+def current_context(root: Path) -> ReleaseContext:
+    base_ref = os.environ.get("GITHUB_BASE_REF", "")
+    ref_name = os.environ.get("GITHUB_REF_NAME", "")
+    ref_type = os.environ.get("GITHUB_REF_TYPE", "")
+    branch = ref_name or git_output(root, "branch", "--show-current")
+
+    if ref_type == "tag":
+        return ReleaseContext.release(tag_name=ref_name)
+    if base_ref == "main" or branch == "main" or branch.startswith("release/"):
+        return ReleaseContext.release()
+    return ReleaseContext.development(latest_tag=latest_release_tag(root))
+
+
+def main() -> int:
+    context = current_context(ROOT)
+    errors = validate(ROOT, context)
+    if errors:
+        print("Release metadata validation failed:", *errors, sep="\n  ")
+        return 1
+
+    application_version = read_application_version(ROOT)
+    print(
+        f"Release metadata is consistent for {context.mode} "
+        f"(application {application_version})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_release_metadata.py
+++ b/scripts/tests/test_release_metadata.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from check_release_metadata import ReleaseContext, validate
+
+
+class ReleaseMetadataTests(unittest.TestCase):
+    def write_repository(
+        self,
+        root: Path,
+        *,
+        version: str = "0.2.9",
+        openapi_version: str = "0.2.9.0",
+        changelog_heading: str = "Unreleased",
+        released_version: str | None = "0.2.9",
+    ) -> None:
+        (root / "docs").mkdir()
+        (root / "Directory.Build.props").write_text(
+            f"<Project><PropertyGroup><Version>{version}</Version></PropertyGroup></Project>",
+            encoding="utf-8",
+        )
+        (root / "docs" / "openapi.json").write_text(
+            f'{{"info": {{"version": "{openapi_version}"}}}}',
+            encoding="utf-8",
+        )
+        released_heading = (
+            f"\n\n## {released_version} — 2026-07-29\n\n### Fixed\n\n- Previous release."
+            if released_version
+            else ""
+        )
+        (root / "CHANGELOG.md").write_text(
+            f"# Changelog\n\n## {changelog_heading}\n\n### Changed\n\n- Current work."
+            f"{released_heading}\n",
+            encoding="utf-8",
+        )
+
+    def validate_fixture(self, context: ReleaseContext, **fixture: object) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_repository(root, **fixture)
+            return validate(root, context)
+
+    def test_development_accepts_unreleased_section_at_latest_release_version(self) -> None:
+        errors = self.validate_fixture(
+            ReleaseContext.development(latest_tag="v0.2.9"),
+        )
+
+        self.assertEqual([], errors)
+
+    def test_development_rejects_missing_unreleased_section(self) -> None:
+        errors = self.validate_fixture(
+            ReleaseContext.development(latest_tag="v0.2.9"),
+            changelog_heading="0.2.9 — 2026-07-29",
+            released_version=None,
+        )
+
+        self.assertIn("development changelog must begin with '## Unreleased'", errors)
+
+    def test_development_rejects_version_older_than_latest_release_tag(self) -> None:
+        errors = self.validate_fixture(
+            ReleaseContext.development(latest_tag="v0.2.9"),
+            version="0.2.8",
+            openapi_version="0.2.8.0",
+            released_version="0.2.8",
+        )
+
+        self.assertIn(
+            "development version 0.2.8 must match the latest release tag v0.2.9",
+            errors,
+        )
+
+    def test_release_accepts_matching_version_heading_and_tag(self) -> None:
+        errors = self.validate_fixture(
+            ReleaseContext.release(tag_name="v0.2.9"),
+            changelog_heading="0.2.9 — 2026-07-29",
+            released_version=None,
+        )
+
+        self.assertEqual([], errors)
+
+    def test_release_rejects_tag_that_does_not_match_application_version(self) -> None:
+        errors = self.validate_fixture(
+            ReleaseContext.release(tag_name="v0.2.8"),
+            changelog_heading="0.2.9 — 2026-07-29",
+            released_version=None,
+        )
+
+        self.assertIn(
+            "release tag v0.2.8 must match application version 0.2.9",
+            errors,
+        )
+
+    def test_all_refs_reject_openapi_version_drift(self) -> None:
+        errors = self.validate_fixture(
+            ReleaseContext.development(latest_tag="v0.2.9"),
+            openapi_version="0.2.8.0",
+        )
+
+        self.assertIn(
+            "OpenAPI version 0.2.8.0 must match application version 0.2.9.0",
+            errors,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Post-release synchronization is now an explicit, enforced part of the Optimisarr
release flow. A release cannot quietly leave `dev` publishing the previous
application version again.

## What changed

- document the complete release → tag → `dev` synchronization sequence
- require a fresh `Unreleased` section after every release
- validate application, OpenAPI, changelog, and Git tag versions together in CI
- fetch release tags in the documentation job
- add focused tests for stale development versions, missing changelog state,
  OpenAPI drift, and mismatched release tags
- ignore Python bytecode created by the new checks

## Root cause

Release `0.2.9` correctly bumped its version on the release branch and `main`,
but that metadata did not flow back to `dev`. The `dev` image therefore
contained the current code while truthfully compiling the stale `0.2.8`
application version.

The new guard requires development state to match the newest release tag and
requires release/tag state to match its dated changelog heading. The protected
Docker publish job depends on this check.

## Scope and safety

This changes release metadata validation and contributor guidance only. It does
not change media processing, database state, replacement safety, or runtime
configuration.

## Validation

- `dotnet build Optimisarr.slnx --configuration Release --warnaserror`
  — zero warnings
- `dotnet test Optimisarr.slnx --configuration Release --no-build`
  — 1,487 passed
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`
  — 6 passed
- `python3 scripts/check_release_metadata.py`
- `python3 scripts/check_docs.py`
- `git diff --check`

The existing NVENC harness test requires Bash 4's `mapfile`, which macOS's
system Bash does not provide; the unchanged test remains part of the Ubuntu CI
documentation job.
