### PR TITLE
Keep Personal quality checks on concrete preset qualities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Personal quality checks no longer run an adaptive VMAF search inside every
+  anonymous video clip.** Each preset now encodes its three planned 12-second
+  scenes at the concrete quality shown after reveal, even when the library uses
+  Adaptive per-title VMAF for normal jobs. The completed scenes still receive
+  structural verification and measure-only VMAF evidence, preserving the blind
+  comparison while avoiding up to 144 redundant 40-second encode-and-score
+  passes for one check.
+
 ### Changed
 
 - **Release metadata can no longer silently drift between `main` and `dev`.**

--- a/docs/api.md
+++ b/docs/api.md
@@ -381,8 +381,11 @@ free space, a manual pause, or active-media protection.
 Video calibration creates three 12-second scenes for the four shuffled library-slider presets plus one marked original reference.
 Its reference is the unchanged video bitstream; when a mid-file stream copy needs packets from the
 preceding keyframe, its sample `startSeconds` identifies the matching presentation window. Video
-samples retain the complete preset output, including its container and audio contract. Each scene is
-also measured with VMAF. Scores remain absent from the API until classifications reveal the lineup;
+samples retain the complete preset output, including its container, audio contract, and concrete
+configured quality. Calibration deliberately bypasses the library's Adaptive per-title VMAF search:
+normal jobs retain that path, while a personal check measures VMAF once on each completed 12-second
+scene instead of recursively preparing three 40-second quality-search windows inside every scene.
+Scores remain absent from the API until classifications reveal the lineup;
 then every non-original `result.variants[]` entry includes a `vmaf` summary and its three underlying
 `samples`. `harmonicMean` is frame-weighted across measured scenes, `fifthPercentile` is the lowest
 scene fifth percentile, and `minimum` is the lowest individual-frame score. `measuredSamples` and

--- a/docs/product-and-architecture.md
+++ b/docs/product-and-architecture.md
@@ -342,7 +342,10 @@ FFmpeg's cadence filter prevents differing MP4/Matroska start timestamps or time
 only one input and pairing adjacent frames at motion or scene changes.
 
 Blind-calibration jobs are also disposable and replacement-ineligible. Video calibration encodes the
-complete output contract of each library-slider preset, including codec, container, and audio rules.
+complete output contract of each library-slider preset, including codec, container, audio rules, and
+its concrete configured quality. It never nests the normal Adaptive per-title VMAF search inside a
+calibration scene; the exact 12-second output receives one measure-only VMAF pass after structural
+verification instead.
 Session creation freshly probes the selected source and places all three scenes on its primary
 picture duration; the authoritative value also refreshes the inventory cache for that file.
 Its reference remains a stream copy of the original compressed frames;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -406,10 +406,13 @@ the replacement workflow is trustworthy.
      [ISO 20462-1](https://www.iso.org/standard/38330.html) without claiming laboratory compliance.
    - **Cheap and safe by construction is shipped.** Candidates are disposable jobs isolated under
      `/work/calibration`; they bypass normal candidate scheduling but still receive structural
-     verification. They cannot replace, move, or delete a source and are hidden from the normal
-     queue. Every saved Film, TV, Music, Photo, and mixed library exposes the compatible personal
-     check from its own configuration page. Leaving the full-page lab or restarting Optimisarr removes the
-     session's database rows and scratch files. The original is only read.
+     verification. Video candidates use each preset's concrete quality and one measure-only VMAF
+     pass per completed scene rather than recursively running the library's adaptive per-title
+     search inside every comparison clip. They cannot replace, move, or delete a source and are
+     hidden from the normal queue. Every saved Film, TV, Music, Photo, and mixed library exposes the
+     compatible personal check from its own configuration page. Leaving the full-page lab or
+     restarting Optimisarr removes the session's database rows and scratch files. The original is
+     only read.
    - **Next research and implementation.** Select representative sources using spatial/temporal
      complexity rather than file size alone and support a small multi-source result; correlate the
      revealed choice with sampled VMAF without turning the metric into a hint. Extend toward a

--- a/docs/usage/personal-quality-check.md
+++ b/docs/usage/personal-quality-check.md
@@ -33,6 +33,13 @@ ladders. It structurally verifies every candidate before the comparison becomes 
 video, preparation also requires Preserve HDR handling, a browser-reported HDR display path, and
 your confirmation that the intended display is actually presenting HDR.
 
+Each video preset uses its concrete configured quality for all three scenes. A library configured
+for **Adaptive per-title VMAF** still uses adaptive selection for normal optimisation jobs, but the
+personal check does not start another early/middle/late quality search inside every comparison
+scene. That would change the preset being judged and multiply a short check into dozens of unrelated
+sample encodes. Optimisarr instead measures VMAF on each completed 12-second scene and reveals that
+objective evidence only after you classify the anonymous candidates.
+
 Video scene positions come from a fresh probe of the primary picture stream, not the outer
 container. This matters for Matroska sources whose subtitles or attachments continue after the
 programme. Each candidate uses a bounded coarse seek followed by an exact trim, keeping copied audio

--- a/src/Optimisarr.Api/Queue/QueueDispatcher.cs
+++ b/src/Optimisarr.Api/Queue/QueueDispatcher.cs
@@ -532,10 +532,12 @@ public sealed class QueueDispatcher(
             }
 
             var preparedWork = work.Value;
-            if (preparedWork.VideoQualityStrategy == VideoQualityStrategy.AdaptiveVmaf
-                && preparedWork.Spec.VideoCodec is not null
-                && preparedWork.VideoQuality is not null
-                && preparedWork.AdaptiveVideoQuality is null)
+            if (ShouldSelectAdaptiveQuality(
+                preparedWork.VideoQualityStrategy,
+                preparedWork.Spec.VideoCodec is not null,
+                preparedWork.VideoQuality is not null,
+                preparedWork.AdaptiveVideoQuality is not null,
+                preparedWork.IsCalibration))
             {
                 preparedWork = await SelectAdaptiveQualityAsync(jobId, preparedWork, cancellationToken);
             }
@@ -689,6 +691,21 @@ public sealed class QueueDispatcher(
             Wake(); // a slot just freed up
         }
     }
+
+    internal static bool ShouldSelectAdaptiveQuality(
+        VideoQualityStrategy strategy,
+        bool hasVideoCodec,
+        bool hasVideoQuality,
+        bool hasAdaptiveQuality,
+        bool isCalibration) =>
+        strategy == VideoQualityStrategy.AdaptiveVmaf
+        && hasVideoCodec
+        && hasVideoQuality
+        && !hasAdaptiveQuality
+        // Calibration already prepares three exact source scenes for each concrete preset. Running
+        // a second early/middle/late search inside every scene both multiplies the work and changes
+        // the quality being compared. Its normal clip verification still measures VMAF after encode.
+        && !isCalibration;
 
     private readonly record struct JobWork(
         TranscodeSpec Spec,

--- a/tests/Optimisarr.Tests/QueueDispatcherSafetyTests.cs
+++ b/tests/Optimisarr.Tests/QueueDispatcherSafetyTests.cs
@@ -1,5 +1,6 @@
 using Optimisarr.Api.Queue;
 using Optimisarr.Core.Domain;
+using Optimisarr.Core.Queue;
 
 namespace Optimisarr.Tests;
 
@@ -29,5 +30,27 @@ public sealed class QueueDispatcherSafetyTests
             RuleProfile.RemuxCleanup,
             audioRemovalCount: 0,
             subtitleRemovalCount: 0));
+    }
+
+    [Fact]
+    public void Calibration_uses_its_concrete_preset_quality_without_an_adaptive_search()
+    {
+        Assert.False(QueueDispatcher.ShouldSelectAdaptiveQuality(
+            VideoQualityStrategy.AdaptiveVmaf,
+            hasVideoCodec: true,
+            hasVideoQuality: true,
+            hasAdaptiveQuality: false,
+            isCalibration: true));
+    }
+
+    [Fact]
+    public void Normal_and_preview_jobs_keep_the_selected_adaptive_quality_path()
+    {
+        Assert.True(QueueDispatcher.ShouldSelectAdaptiveQuality(
+            VideoQualityStrategy.AdaptiveVmaf,
+            hasVideoCodec: true,
+            hasVideoQuality: true,
+            hasAdaptiveQuality: false,
+            isCalibration: false));
     }
 }


### PR DESCRIPTION
## Outcome

Personal quality checks now compare each video preset at its concrete configured
quality without recursively running Adaptive per-title VMAF inside every
12-second scene.

Normal optimisation jobs retain Adaptive per-title VMAF. Preview jobs also
retain it so a requested Preview can still reflect the library's selected
quality path.

## Root cause

The dispatcher started adaptive quality selection for every video re-encode
whose library used `AdaptiveVmaf`. Calibration jobs are deliberately associated
with their library so they can resolve each complete preset, which unintentionally
made every one of their planned scene jobs eligible for another
early/middle/late adaptive search.

For an 8-bit video check, 4 presets × 3 scenes × up to 4 qualities × 3 adaptive
windows could prepare as many as 144 redundant 40-second encode-and-score
passes before producing the intended clips.

## What changed

- calibration jobs are excluded from adaptive quality selection
- each anonymous preset keeps one concrete quality across its three scenes
- completed video scenes still receive structural verification and measure-only
  VMAF evidence
- normal and Preview adaptive behaviour remains unchanged
- user, API, architecture, and roadmap documentation now state the boundary

## Safety

Calibration remains disposable and replacement-ineligible. This change removes
preparation work; it does not weaken structural verification, alter normal-job
VMAF gates, or permit any source mutation.

## Validation

- regression test failed before the fix and passes after it
- `dotnet build Optimisarr.slnx --configuration Release --warnaserror`
  — zero warnings
- `dotnet test Optimisarr.slnx --configuration Release --no-build`
  — 1,489 passed
- OpenAPI, release-metadata, documentation-link, and diff checks passed
- live read-only diagnosis confirmed that one old calibration session had
  entered the nested adaptive search while its session progress remained near 4%
