### PR TITLE
Synchronise release 0.2.10 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.10 — 2026-07-29
+
 ### Fixed
 
 - **Personal quality checks no longer run an adaptive VMAF search inside every

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Shared metadata for all projects. Version drives the /api/health response and the
        "optimisarr=<version>" marker stamped into optimised files. -->
   <PropertyGroup>
-    <Version>0.2.9</Version>
+    <Version>0.2.10</Version>
     <Product>Optimisarr</Product>
     <Authors>Optimisarr contributors</Authors>
     <Copyright>Copyright (C) 2026 Optimisarr contributors</Copyright>

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1750,7 +1750,7 @@
   "info": {
     "description": "HTTP API for Optimisarr \u2014 safe, verified FFmpeg transcoding for self-hosted media libraries. This contract is still pre-1.0 and may change between releases.",
     "title": "Optimisarr API",
-    "version": "0.2.9.0"
+    "version": "0.2.10.0"
   },
   "openapi": "3.1.1",
   "paths": {


### PR DESCRIPTION
## Outcome

Synchronise the released 0.2.10 metadata from `main` back into `dev`, completing
the codified release flow and preventing the moving `:dev` image from reporting
the previous version.

## Included

- set the application version to `0.2.10`
- set the generated OpenAPI version to `0.2.10.0`
- retain the dated `0.2.10` changelog section
- restore a fresh, empty `Unreleased` section for subsequent development

## Excluded

This PR contains no runtime, media-processing, database, configuration, or
documentation-content change beyond the three released metadata files.

## Verification

- release metadata validation passes in development mode against tag `v0.2.10`
- generated OpenAPI is current
- documentation and diff checks pass

After merge, protected `dev` CI must publish `ghcr.io/jellman86/optimisarr:dev`
and that image must report application version `0.2.10`.
