### PR TITLE
Refresh vulnerable frontend build dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- **Frontend build dependencies no longer resolve known PostCSS and nanoid advisories.** The locked
+  Vite toolchain now uses PostCSS 8.5.26 and nanoid 3.3.18; neither package is included in the final
+  runtime layer, and both development and production dependency audits now report zero findings.
 - **Sampled VMAF now preserves the real presentation offset produced by accurate input seeks.**
   Source and output GOPs can retain their first decoded picture at different offsets from the same
   pre-roll target; Optimisarr now keeps those offsets through cadence alignment instead of

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1405,9 +1405,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1525,9 +1525,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1545,7 +1545,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Outcome

Refreshes the existing Vite transitive lock entries from PostCSS 8.5.20 to 8.5.26 and nanoid 3.3.16 to 3.3.18. This clears the current PostCSS path-disclosure and nanoid denial-of-service advisories without changing direct dependencies. Both packages are development/build-only and are not copied into the final runtime layer.

## Validation

- baseline `npm audit`: 2 findings (1 high, 1 moderate)
- patched `npm audit`: 0 findings
- patched `npm audit --omit=dev`: 0 findings
- clean `npm ci`
- `npm run check`: zero errors/warnings
- `npm run build`
- `npm run test:e2e`: 50 passed
- documentation/release checks and `git diff --check`