### PR TITLE
Fix full-width VMAF strategy layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- **The video quality strategy now uses the full library editor width and leads with Adaptive
+  per-title VMAF.** Adaptive and Fixed choices share aligned card structure at desktop widths,
+  while retaining a clear stacked layout on smaller screens.
 - **Frontend build dependencies no longer resolve known PostCSS and nanoid advisories.** The locked
   Vite toolchain now uses PostCSS 8.5.26 and nanoid 3.3.18; neither package is included in the final
   runtime layer, and both development and production dependency audits now report zero findings.

--- a/web/e2e/libraries.spec.ts
+++ b/web/e2e/libraries.spec.ts
@@ -97,6 +97,26 @@ test('new video libraries start on the adaptive VMAF-first path', async ({ page 
   await expect(page.getByText('This is the direct, predictable path with no preparation encodes.')).toBeVisible()
 })
 
+test('quality strategy choices lead with Adaptive VMAF and fill the editor width', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 })
+  await mockLibraries(page)
+  await page.goto('/#/libraries/1/configure')
+
+  const strategies = page.getByTestId('video-quality-strategies')
+  const radios = strategies.getByRole('radio')
+  await expect(radios.nth(0)).toHaveAttribute('value', 'AdaptiveVmaf')
+  await expect(radios.nth(1)).toHaveAttribute('value', 'Fixed')
+
+  const widths = await strategies.evaluate((element) => {
+    const fieldset = element.closest('fieldset')
+    return {
+      strategies: element.getBoundingClientRect().width,
+      fieldset: fieldset?.getBoundingClientRect().width ?? 0,
+    }
+  })
+  expect(widths.strategies).toBeGreaterThanOrEqual(widths.fieldset - 1)
+})
+
 test('adaptive quality path enables a concrete VMAF target and remains exclusive', async ({ page }) => {
   await mockLibraries(page)
   await page.goto('/#/libraries/1/configure')

--- a/web/src/lib/pages/Libraries.svelte
+++ b/web/src/lib/pages/Libraries.svelte
@@ -1365,37 +1365,9 @@
           {i18n.m.libraries.quality_strategy_intro}
         </p>
 
-        <div class="mt-3 grid max-w-4xl gap-3 lg:grid-cols-2">
+        <div class="mt-3 grid w-full gap-3 md:grid-cols-2" data-testid="video-quality-strategies">
           <label
-            class="relative min-h-44 cursor-pointer rounded-xl border p-4 transition-colors focus-within:ring-2 focus-within:ring-cyan-500 focus-within:ring-offset-2 dark:focus-within:ring-offset-slate-900 {form.videoQualityStrategy === 'Fixed' ? 'border-cyan-500 bg-cyan-50/70 dark:border-cyan-500 dark:bg-cyan-950/25' : 'border-slate-200 bg-white hover:border-slate-300 dark:border-slate-700 dark:bg-slate-900/20 dark:hover:border-slate-600'}"
-          >
-            <div class="flex items-start gap-3">
-              <input
-                type="radio"
-                name="video-quality-strategy"
-                value="Fixed"
-                class="mt-0.5 h-5 w-5 flex-shrink-0 accent-cyan-600"
-                checked={form.videoQualityStrategy === 'Fixed'}
-                onchange={() => setVideoQualityStrategy('Fixed')}
-              />
-              <div>
-                <span class="font-semibold text-slate-900 dark:text-slate-100">{i18n.m.libraries.quality_strategy_fixed}</span>
-                <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
-                  {i18n.m.libraries.quality_strategy_fixed_desc}
-                </p>
-              </div>
-            </div>
-            <div class="mt-4 flex flex-wrap items-center gap-1.5 pl-8 text-xs font-medium text-slate-600 dark:text-slate-300">
-              <span class="rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-800">{i18n.m.libraries.path_selected_quality}</span>
-              <span aria-hidden="true" class="text-slate-400">→</span>
-              <span class="rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-800">{i18n.m.libraries.path_full_encode}</span>
-              <span aria-hidden="true" class="text-slate-400">→</span>
-              <span class="rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-800">{i18n.m.libraries.path_verify}</span>
-            </div>
-          </label>
-
-          <label
-            class="relative min-h-44 cursor-pointer rounded-xl border p-4 transition-colors focus-within:ring-2 focus-within:ring-cyan-500 focus-within:ring-offset-2 dark:focus-within:ring-offset-slate-900 {form.videoQualityStrategy === 'AdaptiveVmaf' ? 'border-cyan-500 bg-cyan-50/70 dark:border-cyan-500 dark:bg-cyan-950/25' : 'border-slate-200 bg-white hover:border-slate-300 dark:border-slate-700 dark:bg-slate-900/20 dark:hover:border-slate-600'}"
+            class="relative flex min-h-44 cursor-pointer flex-col rounded-xl border p-4 transition-colors focus-within:ring-2 focus-within:ring-cyan-500 focus-within:ring-offset-2 dark:focus-within:ring-offset-slate-900 {form.videoQualityStrategy === 'AdaptiveVmaf' ? 'border-cyan-500 bg-cyan-50/70 dark:border-cyan-500 dark:bg-cyan-950/25' : 'border-slate-200 bg-white hover:border-slate-300 dark:border-slate-700 dark:bg-slate-900/20 dark:hover:border-slate-600'}"
           >
             <div class="flex items-start gap-3">
               <input
@@ -1416,7 +1388,7 @@
                 </p>
               </div>
             </div>
-            <div class="mt-4 flex flex-wrap items-center gap-1.5 pl-8 text-xs font-medium text-slate-600 dark:text-slate-300">
+            <div class="mt-auto flex flex-wrap items-center gap-1.5 pl-8 pt-4 text-xs font-medium text-slate-600 dark:text-slate-300">
               <span class="rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-800">{i18n.m.libraries.path_sample}</span>
               <span aria-hidden="true" class="text-slate-400">→</span>
               <span class="rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-800">{i18n.m.libraries.path_choose_quality}</span>
@@ -1426,16 +1398,44 @@
               <span class="rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-800">{i18n.m.libraries.path_verify}</span>
             </div>
           </label>
+
+          <label
+            class="relative flex min-h-44 cursor-pointer flex-col rounded-xl border p-4 transition-colors focus-within:ring-2 focus-within:ring-cyan-500 focus-within:ring-offset-2 dark:focus-within:ring-offset-slate-900 {form.videoQualityStrategy === 'Fixed' ? 'border-cyan-500 bg-cyan-50/70 dark:border-cyan-500 dark:bg-cyan-950/25' : 'border-slate-200 bg-white hover:border-slate-300 dark:border-slate-700 dark:bg-slate-900/20 dark:hover:border-slate-600'}"
+          >
+            <div class="flex items-start gap-3">
+              <input
+                type="radio"
+                name="video-quality-strategy"
+                value="Fixed"
+                class="mt-0.5 h-5 w-5 flex-shrink-0 accent-cyan-600"
+                checked={form.videoQualityStrategy === 'Fixed'}
+                onchange={() => setVideoQualityStrategy('Fixed')}
+              />
+              <div>
+                <span class="font-semibold text-slate-900 dark:text-slate-100">{i18n.m.libraries.quality_strategy_fixed}</span>
+                <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                  {i18n.m.libraries.quality_strategy_fixed_desc}
+                </p>
+              </div>
+            </div>
+            <div class="mt-auto flex flex-wrap items-center gap-1.5 pl-8 pt-4 text-xs font-medium text-slate-600 dark:text-slate-300">
+              <span class="rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-800">{i18n.m.libraries.path_selected_quality}</span>
+              <span aria-hidden="true" class="text-slate-400">→</span>
+              <span class="rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-800">{i18n.m.libraries.path_full_encode}</span>
+              <span aria-hidden="true" class="text-slate-400">→</span>
+              <span class="rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-800">{i18n.m.libraries.path_verify}</span>
+            </div>
+          </label>
         </div>
 
         {#if form.videoQualityStrategy === 'AdaptiveVmaf'}
-          <p class="mt-3 max-w-4xl rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs leading-relaxed text-amber-900 dark:border-amber-900/70 dark:bg-amber-950/30 dark:text-amber-200">
+          <p class="mt-3 w-full rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs leading-relaxed text-amber-900 dark:border-amber-900/70 dark:bg-amber-950/30 dark:text-amber-200">
             {i18n.m.libraries.quality_strategy_adaptive_cost}
           </p>
         {/if}
       </fieldset>
 
-      <div class="max-w-3xl">
+      <div class="w-full">
         <div class="mt-5 border-t border-slate-200 pt-5 dark:border-slate-700">
           <label class="label" for="lib-vmaf-policy">
             {i18n.m.settings.vmaf_label}


### PR DESCRIPTION
## Summary

- make the video quality strategy selector span the full library editor width
- present Adaptive per-title VMAF before Fixed quality
- align the two strategy cards and preserve a clear stacked layout on smaller screens
- extend the VMAF policy and adaptive cost note to the available editor width
- add browser regression coverage for order and width

## Validation

- regression test failed before the implementation and passes after it
- `dotnet build Optimisarr.sln -c Release -warnaserror`
- `dotnet test Optimisarr.sln -c Release --no-build`
- `npm run check`
- `npm run build`
- full Playwright suite: 51 passed
- production and full npm audits: 0 vulnerabilities
- Python script tests: 6 passed
- OpenAPI, docs links, release metadata, and whitespace checks

## Risk

Frontend-only presentation change plus browser coverage. No API, database, queue, or transcoding behavior changes.
