### PR TITLE
Sync release metadata for v0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.11 — 2026-08-13
+
 ### Fixed
 
 - **The video quality strategy now uses the full library editor width and leads with Adaptive

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Shared metadata for all projects. Version drives the /api/health response and the
        "optimisarr=<version>" marker stamped into optimised files. -->
   <PropertyGroup>
-    <Version>0.2.10</Version>
+    <Version>0.2.11</Version>
     <Product>Optimisarr</Product>
     <Authors>Optimisarr contributors</Authors>
     <Copyright>Copyright (C) 2026 Optimisarr contributors</Copyright>

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1750,7 +1750,7 @@
   "info": {
     "description": "HTTP API for Optimisarr \u2014 safe, verified FFmpeg transcoding for self-hosted media libraries. This contract is still pre-1.0 and may change between releases.",
     "title": "Optimisarr API",
-    "version": "0.2.10.0"
+    "version": "0.2.11.0"
   },
   "openapi": "3.1.1",
   "paths": {


### PR DESCRIPTION
## Summary
- advance development metadata to 0.2.11
- regenerate the OpenAPI version from the released application metadata
- restore an empty Unreleased section above the v0.2.11 changelog

## Validation
- `dotnet build Optimisarr.slnx -c Release -warnaserror`
- `python3 scripts/check_openapi.py --configuration Release`
- `python3 scripts/check_release_metadata.py`
- `python3 -m unittest discover -s scripts/tests -p "test_*.py"`
- `python3 scripts/check_docs.py`

Release: https://github.com/Jellman86/optimisarr/releases/tag/v0.2.11