### PR TITLE
Acknowledge reviewed historical Gitleaks findings

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+17ad4bd87139d001ed5dc550eb4bfa6d2df278d9:docs/setup/configuration.md:curl-auth-header:26
+17ad4bd87139d001ed5dc550eb4bfa6d2df278d9:docs/setup/reverse-proxy.md:curl-auth-header:31
+17ad4bd87139d001ed5dc550eb4bfa6d2df278d9:docs/api.md:curl-auth-header:61

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- **The weekly secret scan now acknowledges three reviewed historical documentation examples.**
+  Exact Gitleaks fingerprints suppress only the known placeholder authorization headers; new or
+  changed findings continue to fail the scan.
+
 ## 0.2.11 — 2026-08-13
 
 ### Fixed


### PR DESCRIPTION
## Outcome

The weekly scheduled Gitleaks scan (failing since 2026-08-17, run 31999321343) is acknowledged clean: a new `.gitleaksignore` suppresses the three findings by exact fingerprint.

## Scope

- All three findings are placeholder `Authorization: Bearer change-this-long-random-token` examples in docs (`docs/setup/configuration.md`, `docs/setup/reverse-proxy.md`, `docs/api.md`) introduced by historical commit `17ad4bd`. Each was reviewed: none is a real credential.
- Suppression is per-commit fingerprint only — new or changed findings, including future edits to these same doc lines, still fail the scan.
- Excluded: no workflow changes, no doc rewrites.

## Verification

- Fingerprints match the failed scheduled run's output verbatim.
- CI's PR-event secret scan runs on this branch as the gate.

## Notes

- The scheduled scan checks out `main`, so the Monday run stays red until the next release promotes this file to `main`.
- Known follow-up (deliberately out of scope): a `.gitleaks.toml` allowlist for the documented placeholder value would durably cover future edits to these examples; fingerprints are the minimal change for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)