### PR TITLE
Record the adaptive VMAF default as a deliberate exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,13 @@ Optimisarr's entire reason to exist is that it is safer than the alternatives.
   promise. Any change that could break it must be rejected.
 - Every destructive action (replace, delete, move-to-trash) must have a recorded
   rollback path before it runs, not after.
-- Defaults are conservative. When in doubt, do nothing and report why.
+- Defaults are conservative. When in doubt, do nothing and report why. There is
+  one recorded exception — Adaptive per-title VMAF is the default for new video
+  re-encode libraries while still labelled Experimental. It is deliberate and its
+  reasoning is documented in
+  [`docs/roadmap.md`](docs/roadmap.md) under adaptive per-title VMAF quality
+  targeting. Do not treat it as licence to default other unproven paths on;
+  a new exception needs the same explicit reasoning and a matching record.
 - FFmpeg/ffprobe are invoked through explicit argument arrays
   (`ProcessStartInfo.ArgumentList`), **never** a shell string and never string
   interpolation of a path. Treat every file path as untrusted input.

--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -3,6 +3,19 @@
 Detailed, dated engineering record: what shipped, the per-phase plan, and current status.
 The forward-looking summary lives in [`../roadmap.md`](../roadmap.md).
 
+**Decision (2026-08-24) — Adaptive per-title VMAF stays the default for new libraries while
+Experimental.** Release 0.2.11 made the adaptive path the default for new video re-encode libraries.
+The prototype-acceptance comparison the roadmap asks for — total work, selected quality, size, VMAF,
+and repeatability against the fixed path — has not been recorded on any encoder family, and the
+2026-08-11 Intel QSV record validates the sampled-VMAF seek-alignment correction rather than quality
+targeting. The default was reviewed against that gap and deliberately kept, as a recorded exception
+to the conservative-default rule in [`../../CLAUDE.md`](../../CLAUDE.md) §1 and
+[`../roadmap.md`](../roadmap.md). The safety model is unchanged: the search falls back to the fixed
+quality when evidence is missing or non-monotonic, and every structural, decode, duration, tail,
+stream, size, and configured VMAF gate still runs before replacement. The exposure is probing time
+and choice stability on newly created libraries only. The Experimental label and the acceptance
+requirement both stand; removing either still needs the cross-family evidence described below.
+
 **Experimental on dev (2026-07-27) — per-library adaptive VMAF quality path.** Video re-encode
 libraries can keep the fixed preset/custom quality or explicitly opt into a bounded per-title search.
 The editor presents the alternatives as radio cards with their actual processing paths and cost.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -512,6 +512,19 @@ the replacement workflow is trustworthy.
       their saved path and Fixed remains available. The per-library radio path states the upper bound
       of four qualities across three 40-second scenes and the Queue uses its
       probing stage during preparation. Cancellation follows the normal active-job control.
+    - **Defaulting an Experimental path on is a deliberate, recorded exception.** It is the one
+      accepted departure from "defaults should be conservative" below and from the same rule in
+      [`CLAUDE.md`](../CLAUDE.md) §1, taken with the prototype-acceptance evidence below still
+      outstanding on every encoder family. The reasoning: the safety model is unchanged, because the
+      search falls back to the fixed quality whenever evidence is missing or non-monotonic, and the
+      finished output still clears every structural, decode, duration, tail, stream, size, and
+      configured VMAF gate before any replacement. What is unproven is cost and predictability —
+      probing time and the stability of the selected quality — not whether an original can be lost.
+      The blast radius is bounded to newly created libraries, existing saved choices are untouched,
+      and Fixed stays one selection away. Defaulting it on is also what produces the real-world
+      evidence this entry needs; left opt-in, too few libraries would exercise it for the acceptance
+      comparison to ever arrive. The Experimental label stays until that evidence does, so the
+      default is an evidence-gathering decision rather than a claim the path is proved.
     - **Representative evidence, not a favourable frame search.** Reuse deterministic early, middle,
       and late windows selected before any scores are known. Apply the complete picture contract
       (codec, bit depth, resolution, HDR treatment, encoder effort, and relevant filters) to every
@@ -541,7 +554,9 @@ the replacement workflow is trustworthy.
 - Safety beats savings.
 - No original file is deleted until verification has passed.
 - Every destructive action must have a rollback path.
-- Defaults should be conservative and understandable.
+- Defaults should be conservative and understandable. One recorded exception stands: Adaptive
+  per-title VMAF defaults on for new video re-encode libraries while still labelled Experimental,
+  for the reasons given under adaptive per-title VMAF quality targeting above.
 - The app should feel familiar to Docker media-stack users.
 - One container should be enough for normal use.
 


### PR DESCRIPTION
## Outcome

Adaptive per-title VMAF has been the default for new video re-encode libraries since 0.2.11, while
still carrying the **Experimental** badge and with roadmap item 10's prototype-acceptance comparison
unrecorded on every encoder family. That combination contradicted the conservative-default rule in
`CLAUDE.md` §1 and the roadmap's guiding principles, and nothing said so. This documents it as the
one accepted exception, with its reasoning, so the contradiction is explicit rather than implicit.

The reasoning recorded:

- The safety model is unchanged. The bounded search falls back to the fixed quality whenever evidence
  is missing or non-monotonic, and the finished output still clears every structural, decode,
  duration, tail, stream, size, and configured VMAF gate before any replacement.
- What is unproven is cost and predictability — probing time and the stability of the selected
  quality — not whether an original can be lost.
- The blast radius is bounded to newly created libraries. Existing saved choices are untouched and
  Fixed stays one selection away.
- Defaulting it on is what produces the real-world evidence item 10 needs; left opt-in, too few
  libraries would exercise it for the acceptance comparison to arrive.

The Experimental label and the acceptance requirement both stand. Removing either still needs the
cross-family evidence item 10 describes.

## Included scope

- `CLAUDE.md` §1 — the "Defaults are conservative" bullet names the exception and points at the
  reasoning, with a guard against treating it as licence to default other unproven paths on.
- `docs/roadmap.md` — a new bullet under item 10 carrying the reasoning, plus a matching note on the
  "Defaults should be conservative and understandable" guiding principle so the exception is
  discoverable from both places.
- `docs/engineering/history.md` — a dated 2026-08-24 decision entry, the repo's stated home for
  dated engineering records. It sits directly above the 2026-07-27 entry whose "cross-family
  evidence remains required" line this decision interacts with.

## Excluded scope

- **No behaviour change.** The default, the Experimental badge, and the adaptive code paths are all
  untouched. This is a records-only change.
- **No changelog entry**, matching the precedent set by `fba6b8d` for engineering-record docs. No
  user-facing or operator-facing behaviour changed.
- **The prototype-acceptance evidence itself is still outstanding** on CPU, QSV, NVENC, and VA-API.
  This PR records the decision to proceed without it; it does not satisfy item 10.

## Verification

- `python3 scripts/check_docs.py` passes — local documentation links valid, API reference endpoints
  present in `docs/openapi.json`.
- Relative links checked by hand in both directions (`CLAUDE.md` → `docs/roadmap.md`,
  `docs/roadmap.md` → `../CLAUDE.md`, `docs/engineering/history.md` → `../../CLAUDE.md` and
  `../roadmap.md`).
- No code changed, so `dotnet build`, `dotnet test`, and `npm run check` are unaffected.

## Safety and migration risk

None. No code, schema, migration, or default is modified — the safety model is described here, not
altered.
