### PR TITLE
Ignore macOS Finder metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/Optimisarr.Api/wwwroot/
 config/
 .env
 *.user
+.DS_Store


### PR DESCRIPTION
## Outcome

`.DS_Store` files are created by Finder in any directory browsed on macOS and were appearing as
untracked noise in `git status` for contributors working on a Mac. One had already been sitting
untracked in the repository root. This adds the ignore rule so they stop surfacing.

A bare `.DS_Store` pattern (no slash) matches at every depth, so nested directories are covered
without needing a `**/` prefix. This matches the style of the existing bare entries in the file
(`.env`, `*.user`).

## Included scope

- `.gitignore` — one line.

## Excluded scope

- **No other OS-junk patterns.** AppleDouble files (`._*`), `Thumbs.db`, and similar are not added;
  none have actually appeared in this repository, and speculative ignore rules can mask real files.
  Worth adding if and when they show up.
- **No changelog entry.** This is contributor hygiene with no user-facing or operator-facing
  behaviour change.

## Verification

Created `.DS_Store` at the repository root and at `docs/.DS_Store`, confirmed
`git status --untracked-files=all` reported neither, then removed both.

No code changed, so `dotnet build`, `dotnet test`, and `npm run check` are unaffected.

## Safety and migration risk

None. No code, schema, or default is touched.
