### PR TITLE
Correct the diagnostics entry status on the roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,7 +15,9 @@ the replacement workflow is trustworthy.
   engineering history belongs in
   [`engineering/history.md`](engineering/history.md).
 - Code and tests remain the source of truth. Never present roadmap work as
-  shipped until the repository proves it.
+  shipped until the repository proves it. The converse matters too: an entry left
+  describing finished work as outstanding sends effort at an item that has none.
+- Status claims last verified against the repository: **2026-08-24**.
 
 ## Up next (priority order, updated 2026-08-24)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ the replacement workflow is trustworthy.
 - Code and tests remain the source of truth. Never present roadmap work as
   shipped until the repository proves it.
 
-## Up next (priority order, updated 2026-07-29)
+## Up next (priority order, updated 2026-08-24)
 
 1. **Phase 14 gold-standard hardening** — the next maturity pass is about making
    Optimisarr safer to expose, easier to automate, and easier to change without
@@ -250,15 +250,18 @@ the replacement workflow is trustworthy.
   coverage, GHCR publishing, README quickstart hardening, troubleshooting, and security
   notes are shipped. Backups intentionally omit media, jobs, replacements, quarantine,
   and rollback history. CI stays on standard GitHub-hosted public-repo runners and avoids
-  paid external services.
+  paid external services. **Status needs confirming:** this entry still reads "in progress", but
+  every control it names is recorded as shipped and no outstanding scope is written down. Either
+  name what remains or mark the entry done — an "in progress" label with nothing behind it sends
+  work at an entry that has none.
 
-4. **First-class diagnostics & observability API** — make "why did this fail?" answerable
-   from the API alone, without SSH-ing the host or reading container logs. Today failed-job
-   detail *is* reachable (`GET /api/jobs` carries `ErrorMessage`, `FfmpegArguments`, and the
-   verification report per job), but it is unfiltered, unaggregated, and lossy. Scope:
+4. **First-class diagnostics & observability API: done.** "Why did this fail?" is answerable
+   from the API alone, without SSH-ing the host or reading container logs. Failed-job detail was
+   already reachable when this entry opened (`GET /api/jobs` carries `ErrorMessage`,
+   `FfmpegArguments`, and the verification report per job), but it was unfiltered, unaggregated,
+   and lossy. Every bullet below has since shipped. Scope:
    - **Status-filtered job queries: done.** `GET /api/jobs?status=Failed` narrows server-side so
-     callers don't fetch every row and filter client-side. (Library/reason/date filters and
-     pagination remain to add.)
+     callers don't fetch every row and filter client-side.
    - **Failure aggregation endpoint: done.** `GET /api/jobs/failures` groups failures by classified
      reason (size-saving gate, container incompatibility, image-based subtitles, replacement
      collision, source/output missing, verification, other) with counts and recent sample jobs,


### PR DESCRIPTION
## Outcome

Roadmap item 4 contradicted itself. Its first bullet carried
*"(Library/reason/date filters and pagination remain to add.)"* while the item's own final bullet
reads *"Filters and pagination: done … This completes the item."* The stale parenthetical won:
it survived the 2026-07-29 roadmap review and reads as live, unclaimed work.

It is not. The filters shipped in `b349e81` on **2026-06-27**, nearly two months ago:

- `GET /api/jobs` accepts `libraryId`, `category`, `since`/`until`, and `page`/`pageSize`, with the
  pre-paging total in the `X-Total-Count` header and the body unchanged
  (`MediaAndQueueEndpoints.cs:241`).
- Covered by `QueryAsync_filters_by_library_category_and_pages_with_a_total` and
  `QueryAsync_filters_by_a_finished_date_range` in `JobQueriesTests.cs`.
- Documented at `docs/api.md:430` and present in `docs/openapi.json` — the generated spec lists all
  seven parameters.

This marks item 4 done, drops the contradiction, and puts the entry's framing into past tense so
the problem statement no longer claims the API "is unfiltered, unaggregated, and lossy" when it is
none of those things.

## Also flagged, deliberately not fixed

Item 3 (Phase 13 release hardening) still reads **"release controls are in progress"** while every
control it names is recorded as shipped and no outstanding scope is written down anywhere in the
entry. I added a `**Status needs confirming:**` note rather than marking it done, because only the
maintainer knows whether there is unrecorded scope behind that label. Either name what remains or
mark it done — an "in progress" entry with nothing behind it sends work at an entry that has none.

## Why this matters beyond tidiness

The roadmap's own rule is *"Code and tests remain the source of truth. Never present roadmap work as
shipped until the repository proves it."* The converse failed here: work the repository proved
shipped was still presented as outstanding, and it misdirected a session into starting an
already-complete item.

## Included scope

- `docs/roadmap.md` — item 4 marked done, contradictory parenthetical removed, intro tense
  corrected; item 3 status flagged; "Up next" review date moved to 2026-08-24.

## Excluded scope

- **No code, test, or API change.** Nothing about `GET /api/jobs` is modified — this only corrects
  how the roadmap describes what already exists.
- **Item 3 is flagged, not resolved.** That is a maintainer decision.
- **No changelog entry**, matching the `fba6b8d` precedent for records-only docs.

## Verification

- `python3 scripts/check_docs.py` passes — local links valid, API reference endpoints present in
  `docs/openapi.json`.
- Each claim above checked against the repository rather than the roadmap: endpoint source, the two
  named tests, `docs/api.md`, the generated OpenAPI parameter list, and `git log -S` for the
  commit that introduced `QueryAsync`.

## Safety and migration risk

None. Documentation only.
