### PR TITLE
Close Phase 13 on the roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -247,15 +247,19 @@ the replacement workflow is trustworthy.
      apply transaction explicitly rolls back on an exception, and applying setup leaves a sentinel
      source file byte-for-byte unchanged while preview work remains disposable under `/work`.
 
-3. **Phase 13 release hardening** — release controls are in progress; dry-run mode,
-   config-and-secrets backups, migration smoke coverage, synthetic-media integration
-  coverage, GHCR publishing, README quickstart hardening, troubleshooting, and security
-  notes are shipped. Backups intentionally omit media, jobs, replacements, quarantine,
-  and rollback history. CI stays on standard GitHub-hosted public-repo runners and avoids
-  paid external services. **Status needs confirming:** this entry still reads "in progress", but
-  every control it names is recorded as shipped and no outstanding scope is written down. Either
-  name what remains or mark the entry done — an "in progress" label with nothing behind it sends
-  work at an entry that has none.
+3. **Phase 13 release hardening: done.** Dry-run mode, config-and-secrets backups, migration
+   smoke coverage, synthetic-media integration coverage, GHCR publishing, README quickstart
+  hardening, troubleshooting, and security notes are all shipped, and the exit criterion is met:
+  a careful user can run Optimisarr against a real library with dry-run, verification, quarantine,
+  and rollback available. Every deliverable in
+  [`engineering/history.md`](engineering/history.md#phase-13-release-hardening) is marked done.
+
+   Two deliverables are deliberately narrower than their one-line names suggest, and those bounds
+   are the intended scope rather than outstanding work: config backup covers portable
+   config-and-secrets snapshots, leaving raw SQLite state backup external and operator-owned; and
+   migration testing covers empty-database smoke. Backups intentionally omit media, jobs,
+   replacements, quarantine, and rollback history. CI stays on standard GitHub-hosted public-repo
+   runners and avoids paid external services.
 
 4. **First-class diagnostics & observability API: done.** "Why did this fail?" is answerable
    from the API alone, without SSH-ing the host or reading container logs. Failed-job detail was


### PR DESCRIPTION
## Outcome

Resolves the `Status needs confirming` flag raised in #79. Item 3 read *"release controls are in
progress"* while naming eight controls as shipped and describing no outstanding scope.

`engineering/history.md` settles it. Every Phase 13 deliverable is marked **Done** — dry-run mode,
config backup, migration testing, synthetic-media integration tests, GHCR publishing, README
quickstart, troubleshooting guide, and security notes — and the exit criterion is met: *a careful
user can run Optimisarr against a real library with dry-run, verification, quarantine, and rollback
available.* The entry is closed.

## The two qualified deliverables

Two are deliberately narrower than their one-line names suggest, which is likely why the entry felt
unfinished:

- **Config backup** covers portable config-and-secrets snapshots. Raw SQLite state backup stays
  external and operator-owned.
- **Migration testing** covers empty-database migration smoke.

Both bounds were recorded as intentional in `history.md`, so they are the scope rather than gaps.
I moved them inline into the roadmap entry so a reader meets the caveat where they read the claim,
instead of inferring unfinished work from a name that promises more than the deliverable did.

## Included scope

- `docs/roadmap.md` — item 3 marked done, the qualifications stated inline, the flag removed.

## Excluded scope

- **No code or test change.** Nothing about the release controls is modified.
- **No changelog entry**, matching the `fba6b8d` precedent for records-only docs.

## Verification

- `python3 scripts/check_docs.py` passes.
- Each of the eight deliverables checked against
  `docs/engineering/history.md#phase-13-release-hardening` rather than against the roadmap.

## Safety and migration risk

None. Documentation only.
