### PR TITLE
Define the versioned worker protocol contract

### DIFF
--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -3,6 +3,21 @@
 Detailed, dated engineering record: what shipped, the per-phase plan, and current status.
 The forward-looking summary lives in [`../roadmap.md`](../roadmap.md).
 
+**Started on dev (2026-08-24) — versioned worker protocol groundwork for remote transcoding.**
+The first slice of the distributed-transcoding contract (roadmap item 9) lands as pure
+`Optimisarr.Core.Workers` logic with no HTTP, persistence, or queue wiring, so no job can reach a
+sidecar yet and no destructive path is touched. `WorkerProtocol.Negotiate` compares a worker's
+supported version range against this build's and picks the highest both speak; a worker that is
+entirely older or entirely newer, or that reports an inverted range, is refused with a reason
+rather than assumed compatible, because the control plane owns the contract and a silent
+assumption here is what would schedule a job onto an incompatible sidecar. `WorkerCapabilityMatcher`
+decides whether an assignment may be offered at all, failing closed on encoder, hardware decoder,
+VMAF mode, scratch space, and concurrency, and naming every unmet requirement rather than the first
+so an operator can see why a paired sidecar sits idle. VMAF capability is ordered so a proved CUDA
+backend satisfies a CPU requirement but never the reverse; a drained worker is expressed as zero
+concurrency. Registration, pairing, heartbeats, leases, progress, cancellation, hashes, the
+resolved-policy payload, evidence, and acknowledgement are all still to define.
+
 **Decision (2026-08-24) — Adaptive per-title VMAF stays the default for new libraries while
 Experimental.** Release 0.2.11 made the adaptive path the default for new video re-encode libraries.
 The prototype-acceptance comparison the roadmap asks for — total work, selected quality, size, VMAF,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -457,12 +457,19 @@ the replacement workflow is trustworthy.
    quarantine, move, or delete an original. This remains post-MVP and opt-in: one container must
    continue to be the complete, uncomplicated default.
 
-   - **Versioned worker protocol and explicit ownership.** Define a platform-neutral contract before
-     either app: registration, capability discovery, heartbeats, leases, progress, cancellation,
-     source/output hashes, the fully resolved encode and verification policy, structured FFmpeg
-     evidence, and result acknowledgement. The main app owns job state, scheduling, rules, and every
-     destructive transition. Protocol versions and worker capabilities must be negotiated so an
-     upgrade cannot silently schedule a job onto an incompatible sidecar.
+   - **Versioned worker protocol and explicit ownership: started.** Define a platform-neutral
+     contract before either app: registration, capability discovery, heartbeats, leases, progress,
+     cancellation, source/output hashes, the fully resolved encode and verification policy,
+     structured FFmpeg evidence, and result acknowledgement. The main app owns job state,
+     scheduling, rules, and every destructive transition. Protocol versions and worker capabilities
+     must be negotiated so an upgrade cannot silently schedule a job onto an incompatible sidecar.
+     **Landed so far:** version negotiation and capability matching as pure `Optimisarr.Core.Workers`
+     logic — the control plane owns the contract and a newer sidecar falls back to what this build
+     speaks, non-overlapping ranges are refused with a reason, and an assignment is offered only
+     when the encoder, hardware decoder, VMAF mode, scratch space, and concurrency all clear, with
+     every unmet requirement named. Nothing is wired to HTTP, persistence, or the queue yet, so no
+     work can currently reach a sidecar. **Still to define:** registration, heartbeats, leases,
+     progress and cancellation, hashes, the resolved-policy payload, evidence, and acknowledgement.
    - **Secure pairing and revocation.** Register a sidecar through a short-lived, single-use code
      displayed by the main app, then issue it a unique revocable credential. Bind every assignment
      and result to the registered worker and job lease; redact credentials from diagnostics and

--- a/src/Optimisarr.Core/Workers/WorkerCapabilities.cs
+++ b/src/Optimisarr.Core/Workers/WorkerCapabilities.cs
@@ -1,0 +1,91 @@
+namespace Optimisarr.Core.Workers;
+
+/// <summary>
+/// How a worker can score VMAF. Ordered by strength: a machine that proves the CUDA backend can
+/// always also score on the CPU, so a stronger capability satisfies a weaker requirement.
+/// Apple GPUs have no VMAF compute backend, so a macOS sidecar advertises <see cref="Cpu"/>.
+/// </summary>
+public enum VmafCapability
+{
+    None = 0,
+    Cpu = 1,
+    Cuda = 2
+}
+
+/// <summary>
+/// What a sidecar has proved it can do. These are discovered by probing the worker's own tools,
+/// never assumed from its platform — an advertised capability the bundled build cannot actually
+/// run would send jobs somewhere they fail.
+/// </summary>
+public sealed record WorkerCapabilities(
+    string OperatingSystem,
+    string Architecture,
+    IReadOnlyList<string> VideoEncoders,
+    IReadOnlyList<string> HardwareDecoders,
+    VmafCapability Vmaf,
+    long FreeScratchBytes,
+    int MaxConcurrency);
+
+/// <summary>
+/// The fully resolved demands of one assignment. The control plane resolves these from the
+/// library profile before offering work, so a worker never re-derives policy for itself.
+/// </summary>
+public sealed record JobRequirements(
+    string VideoEncoder,
+    string? HardwareDecoder,
+    VmafCapability Vmaf,
+    long ScratchBytes);
+
+/// <summary>The decision, with every unmet requirement named rather than only the first.</summary>
+public sealed record CapabilityMatch(bool Accepted, IReadOnlyList<string> Reasons);
+
+/// <summary>
+/// Decides whether an assignment may be offered to a worker at all. Fails closed: an unproved
+/// capability is an unmet one, and every rejection carries a reason so an operator can see why a
+/// paired sidecar is sitting idle.
+/// </summary>
+public static class WorkerCapabilityMatcher
+{
+    public static CapabilityMatch Match(WorkerCapabilities worker, JobRequirements required)
+    {
+        var reasons = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(required.VideoEncoder))
+        {
+            // An unnamed encoder is a malformed assignment, not a wildcard.
+            reasons.Add("The assignment named no video encoder.");
+        }
+        else if (!Advertises(worker.VideoEncoders, required.VideoEncoder))
+        {
+            reasons.Add($"The worker does not advertise the video encoder '{required.VideoEncoder}'.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(required.HardwareDecoder)
+            && !Advertises(worker.HardwareDecoders, required.HardwareDecoder))
+        {
+            reasons.Add($"The worker does not advertise the hardware decoder '{required.HardwareDecoder}'.");
+        }
+
+        if (worker.Vmaf < required.Vmaf)
+        {
+            reasons.Add($"The worker's VMAF support ({worker.Vmaf}) is weaker than the required {required.Vmaf}.");
+        }
+
+        if (worker.FreeScratchBytes < required.ScratchBytes)
+        {
+            reasons.Add(
+                $"The worker has {worker.FreeScratchBytes} bytes of free scratch space, " +
+                $"below the {required.ScratchBytes} this job needs.");
+        }
+
+        if (worker.MaxConcurrency <= 0)
+        {
+            reasons.Add("The worker accepts no concurrent work (drained or disabled).");
+        }
+
+        return new CapabilityMatch(reasons.Count == 0, reasons);
+    }
+
+    private static bool Advertises(IReadOnlyList<string> advertised, string wanted) =>
+        advertised.Any(a => string.Equals(a, wanted, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/Optimisarr.Core/Workers/WorkerProtocol.cs
+++ b/src/Optimisarr.Core/Workers/WorkerProtocol.cs
@@ -1,0 +1,57 @@
+namespace Optimisarr.Core.Workers;
+
+/// <summary>
+/// The outcome of comparing a sidecar's supported protocol range against this control plane's.
+/// <see cref="AgreedVersion"/> is zero whenever <see cref="Compatible"/> is false, so a caller
+/// cannot mistake a refusal for a usable version.
+/// </summary>
+public sealed record ProtocolNegotiation(bool Compatible, int AgreedVersion, string? Reason)
+{
+    public static ProtocolNegotiation Agreed(int version) => new(true, version, null);
+
+    public static ProtocolNegotiation Refused(string reason) => new(false, 0, reason);
+}
+
+/// <summary>
+/// The versioned wire contract between the control plane and a remote transcoding sidecar.
+/// The main app owns the contract: a worker built against a newer protocol falls back to what
+/// this build speaks, never the other way round.
+/// </summary>
+public static class WorkerProtocol
+{
+    /// <summary>The newest contract version this build speaks.</summary>
+    public const int Current = 1;
+
+    /// <summary>The oldest contract version this build still accepts.</summary>
+    public const int MinimumSupported = 1;
+
+    /// <summary>
+    /// Picks the highest version both sides support, or refuses with a reason. Refusal is the
+    /// safe outcome: assuming an unknown sidecar is compatible is exactly the silent-upgrade
+    /// failure this negotiation exists to prevent.
+    /// </summary>
+    public static ProtocolNegotiation Negotiate(int workerMinimum, int workerMaximum)
+    {
+        if (workerMinimum > workerMaximum)
+        {
+            return ProtocolNegotiation.Refused(
+                $"The worker reported an inverted protocol range ({workerMinimum}–{workerMaximum}).");
+        }
+
+        if (workerMaximum < MinimumSupported)
+        {
+            return ProtocolNegotiation.Refused(
+                $"The worker speaks an older protocol than this build supports " +
+                $"(worker up to {workerMaximum}, minimum supported {MinimumSupported}). Upgrade the worker.");
+        }
+
+        if (workerMinimum > Current)
+        {
+            return ProtocolNegotiation.Refused(
+                $"The worker requires a newer protocol than this build speaks " +
+                $"(worker from {workerMinimum}, current {Current}). Upgrade Optimisarr.");
+        }
+
+        return ProtocolNegotiation.Agreed(Math.Min(workerMaximum, Current));
+    }
+}

--- a/tests/Optimisarr.Tests/WorkerCapabilityMatcherTests.cs
+++ b/tests/Optimisarr.Tests/WorkerCapabilityMatcherTests.cs
@@ -1,0 +1,166 @@
+using Optimisarr.Core.Workers;
+
+namespace Optimisarr.Tests;
+
+/// <summary>
+/// Capability matching decides whether a job may be offered to a worker at all. It must fail
+/// closed — an unproved capability is an unmet one — and every rejection must name its reason so
+/// an operator can see why a paired sidecar is sitting idle.
+/// </summary>
+public class WorkerCapabilityMatcherTests
+{
+    private static WorkerCapabilities Capable() => new(
+        OperatingSystem: "linux",
+        Architecture: "x64",
+        VideoEncoders: ["libx265", "hevc_nvenc"],
+        HardwareDecoders: ["hevc_cuvid"],
+        Vmaf: VmafCapability.Cuda,
+        FreeScratchBytes: 100L * 1024 * 1024 * 1024,
+        MaxConcurrency: 2);
+
+    private static JobRequirements Wanted() => new(
+        VideoEncoder: "libx265",
+        HardwareDecoder: null,
+        Vmaf: VmafCapability.Cpu,
+        ScratchBytes: 10L * 1024 * 1024 * 1024);
+
+    [Fact]
+    public void Match_accepts_a_worker_that_satisfies_every_requirement()
+    {
+        var match = WorkerCapabilityMatcher.Match(Capable(), Wanted());
+
+        Assert.True(match.Accepted);
+        Assert.Empty(match.Reasons);
+    }
+
+    [Fact]
+    public void Match_rejects_a_missing_video_encoder()
+    {
+        var match = WorkerCapabilityMatcher.Match(Capable(), Wanted() with { VideoEncoder = "av1_qsv" });
+
+        Assert.False(match.Accepted);
+        Assert.Contains(match.Reasons, r => r.Contains("av1_qsv", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Match_rejects_a_missing_hardware_decoder_when_one_is_required()
+    {
+        var match = WorkerCapabilityMatcher.Match(Capable(), Wanted() with { HardwareDecoder = "av1_qsv" });
+
+        Assert.False(match.Accepted);
+        Assert.Contains(match.Reasons, r => r.Contains("av1_qsv", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Match_allows_software_decode_when_no_hardware_decoder_is_required()
+    {
+        var noDecoders = Capable() with { HardwareDecoders = [] };
+
+        var match = WorkerCapabilityMatcher.Match(noDecoders, Wanted());
+
+        Assert.True(match.Accepted);
+    }
+
+    [Fact]
+    public void Match_treats_cuda_vmaf_as_satisfying_a_cpu_requirement()
+    {
+        // CPU VMAF is the portable fallback, so a worker proving the CUDA backend can always
+        // also score on the CPU. The reverse must not hold.
+        var match = WorkerCapabilityMatcher.Match(Capable(), Wanted() with { Vmaf = VmafCapability.Cpu });
+
+        Assert.True(match.Accepted);
+    }
+
+    [Fact]
+    public void Match_rejects_a_cpu_only_worker_when_cuda_vmaf_is_required()
+    {
+        var cpuOnly = Capable() with { Vmaf = VmafCapability.Cpu };
+
+        var match = WorkerCapabilityMatcher.Match(cpuOnly, Wanted() with { Vmaf = VmafCapability.Cuda });
+
+        Assert.False(match.Accepted);
+        Assert.Contains(match.Reasons, r => r.Contains("VMAF", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Match_rejects_a_worker_with_no_vmaf_when_scoring_is_required()
+    {
+        var noVmaf = Capable() with { Vmaf = VmafCapability.None };
+
+        var match = WorkerCapabilityMatcher.Match(noVmaf, Wanted());
+
+        Assert.False(match.Accepted);
+        Assert.Contains(match.Reasons, r => r.Contains("VMAF", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Match_accepts_a_worker_with_no_vmaf_when_the_job_does_not_score()
+    {
+        var noVmaf = Capable() with { Vmaf = VmafCapability.None };
+
+        var match = WorkerCapabilityMatcher.Match(noVmaf, Wanted() with { Vmaf = VmafCapability.None });
+
+        Assert.True(match.Accepted);
+    }
+
+    [Fact]
+    public void Match_rejects_insufficient_scratch_space()
+    {
+        var tiny = Capable() with { FreeScratchBytes = 1024 };
+
+        var match = WorkerCapabilityMatcher.Match(tiny, Wanted());
+
+        Assert.False(match.Accepted);
+        Assert.Contains(match.Reasons, r => r.Contains("scratch", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Match_rejects_a_worker_that_accepts_no_concurrent_work()
+    {
+        // Drain/disable is expressed by dropping concurrency to zero, so this is the path an
+        // operator takes to stop new assignments without unpairing the sidecar.
+        var drained = Capable() with { MaxConcurrency = 0 };
+
+        var match = WorkerCapabilityMatcher.Match(drained, Wanted());
+
+        Assert.False(match.Accepted);
+        Assert.Contains(match.Reasons, r => r.Contains("concurren", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Match_reports_every_unmet_requirement_rather_than_only_the_first()
+    {
+        var poor = Capable() with
+        {
+            VideoEncoders = [],
+            Vmaf = VmafCapability.None,
+            FreeScratchBytes = 0,
+            MaxConcurrency = 0
+        };
+
+        var match = WorkerCapabilityMatcher.Match(poor, Wanted());
+
+        Assert.False(match.Accepted);
+        Assert.Equal(4, match.Reasons.Count);
+    }
+
+    [Fact]
+    public void Match_compares_encoder_names_case_insensitively()
+    {
+        var shouty = Capable() with { VideoEncoders = ["LIBX265"] };
+
+        var match = WorkerCapabilityMatcher.Match(shouty, Wanted());
+
+        Assert.True(match.Accepted);
+    }
+
+    [Fact]
+    public void Match_rejects_a_worker_advertising_no_encoder_for_an_unnamed_requirement()
+    {
+        // An empty required encoder is a malformed assignment, not a wildcard. Fail closed.
+        var match = WorkerCapabilityMatcher.Match(Capable(), Wanted() with { VideoEncoder = "  " });
+
+        Assert.False(match.Accepted);
+        Assert.Contains(match.Reasons, r => r.Contains("encoder", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/Optimisarr.Tests/WorkerProtocolTests.cs
+++ b/tests/Optimisarr.Tests/WorkerProtocolTests.cs
@@ -1,0 +1,79 @@
+using Optimisarr.Core.Workers;
+
+namespace Optimisarr.Tests;
+
+/// <summary>
+/// Version negotiation is the gate that stops an upgraded control plane from silently scheduling
+/// a job onto a sidecar that cannot speak the same contract. It must fail closed: when the two
+/// ranges do not overlap, no version is agreed and the reason says which side is out of range.
+/// </summary>
+public class WorkerProtocolTests
+{
+    [Fact]
+    public void Negotiate_agrees_the_current_version_when_the_worker_supports_it()
+    {
+        var result = WorkerProtocol.Negotiate(
+            workerMinimum: WorkerProtocol.MinimumSupported,
+            workerMaximum: WorkerProtocol.Current);
+
+        Assert.True(result.Compatible);
+        Assert.Equal(WorkerProtocol.Current, result.AgreedVersion);
+        Assert.Null(result.Reason);
+    }
+
+    [Fact]
+    public void Negotiate_agrees_the_highest_version_both_sides_support()
+    {
+        // A worker built against a newer contract must fall back to what this control plane speaks,
+        // never the other way round — the main app owns the contract.
+        var result = WorkerProtocol.Negotiate(
+            workerMinimum: WorkerProtocol.MinimumSupported,
+            workerMaximum: WorkerProtocol.Current + 5);
+
+        Assert.True(result.Compatible);
+        Assert.Equal(WorkerProtocol.Current, result.AgreedVersion);
+    }
+
+    [Fact]
+    public void Negotiate_refuses_a_worker_that_is_too_old()
+    {
+        var result = WorkerProtocol.Negotiate(
+            workerMinimum: WorkerProtocol.MinimumSupported - 2,
+            workerMaximum: WorkerProtocol.MinimumSupported - 1);
+
+        Assert.False(result.Compatible);
+        Assert.Equal(0, result.AgreedVersion);
+        Assert.Contains("older", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Negotiate_refuses_a_worker_that_is_entirely_newer()
+    {
+        // The worker cannot speak anything this build understands. Refusing is the safe outcome;
+        // guessing that a newer sidecar is backwards compatible is exactly the silent-upgrade
+        // failure this negotiation exists to prevent.
+        var result = WorkerProtocol.Negotiate(
+            workerMinimum: WorkerProtocol.Current + 1,
+            workerMaximum: WorkerProtocol.Current + 3);
+
+        Assert.False(result.Compatible);
+        Assert.Equal(0, result.AgreedVersion);
+        Assert.Contains("newer", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Negotiate_refuses_an_inverted_range()
+    {
+        var result = WorkerProtocol.Negotiate(workerMinimum: 9, workerMaximum: 2);
+
+        Assert.False(result.Compatible);
+        Assert.Equal(0, result.AgreedVersion);
+        Assert.Contains("range", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Current_is_at_least_the_minimum_supported()
+    {
+        Assert.True(WorkerProtocol.Current >= WorkerProtocol.MinimumSupported);
+    }
+}


### PR DESCRIPTION
## Outcome

First slice of roadmap item 9 (remote transcoding sidecars). The roadmap requires a
platform-neutral contract to exist **before** either sidecar app, so this defines the two pieces
that gate whether work may be offered to a worker at all — as pure `Optimisarr.Core.Workers` logic
with no HTTP, persistence, or queue wiring.

**`WorkerProtocol.Negotiate`** compares a worker's supported version range against this build's and
agrees the highest version both speak. A worker that is entirely older, entirely newer, or that
reports an inverted range is refused with a reason. The control plane owns the contract: a newer
sidecar falls back to what this build speaks, never the reverse. Assuming an unknown sidecar is
backwards compatible is exactly the silent-upgrade failure the roadmap asks negotiation to prevent.

**`WorkerCapabilityMatcher.Match`** decides whether an assignment may be offered, failing closed on
video encoder, hardware decoder, VMAF mode, scratch space, and concurrency. Design points worth
review:

- It names **every** unmet requirement, not just the first, so an operator can see the full reason a
  paired sidecar is sitting idle rather than fixing one problem at a time.
- `VmafCapability` is **ordered** (`None < Cpu < Cuda`) so a worker that proved the CUDA backend
  satisfies a CPU requirement, but a CPU-only worker never satisfies a CUDA one. This matches the
  roadmap's position that CPU VMAF is the portable fallback and that Apple GPUs have no VMAF compute
  backend.
- A **drained or disabled** worker is expressed as zero concurrency, which is the path an operator
  takes to stop new assignments without unpairing.
- An **unnamed** required encoder is treated as a malformed assignment, not a wildcard.

## Safety

Nothing here can reach a file. There is no HTTP surface, no persistence, no queue integration, and
no destructive transition — a job cannot currently be dispatched to a sidecar at all. The safety
model is untouched, and the verification boundary the roadmap insists on (main app re-probes and
re-gates any returned candidate) is not weakened because no result path exists yet.

## Included scope

- `src/Optimisarr.Core/Workers/WorkerProtocol.cs` — version range negotiation.
- `src/Optimisarr.Core/Workers/WorkerCapabilities.cs` — capability/requirement records and the
  fail-closed matcher.
- `tests/Optimisarr.Tests/WorkerProtocolTests.cs`, `WorkerCapabilityMatcherTests.cs` — 19 tests.
- `docs/roadmap.md` — item 9's protocol bullet marked **started**, with what landed and what
  remains stated explicitly.
- `docs/engineering/history.md` — dated entry.

## Excluded scope — deliberately

- **Registration, pairing, and revocation.** Security-sensitive and its own roadmap bullet; it
  deserves a focused review rather than riding along here.
- **Heartbeats, leases, progress, cancellation, hashes, resolved-policy payload, evidence,
  acknowledgement.** Named in the roadmap entry as still to define.
- **No changelog entry.** There is no operator-visible behaviour — nothing is wired up — so this is
  recorded in `engineering/history.md`, which the roadmap designates for engineering detail. Flagging
  it because §6 of `CLAUDE.md` lists a changelog entry unconditionally; say the word if you would
  rather it appear there.

## Verification

- `dotnet build Optimisarr.slnx` — succeeds, **zero warnings**.
- `dotnet test Optimisarr.slnx` — **1521 passed, 0 failed** (1502 before; the 19 new tests are the
  difference). Tests were written first and confirmed failing to compile before the implementation
  existed.
- `python3 scripts/check_docs.py` passes.
- Frontend untouched, so `npm run check` is unaffected. No schema change, so no migration.

## Migration risk

None. No schema, no persisted state, no configuration.
