### PR TITLE
Add PIN pairing and worker credential primitives

### DIFF
--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -3,6 +3,29 @@
 Detailed, dated engineering record: what shipped, the per-phase plan, and current status.
 The forward-looking summary lives in [`../roadmap.md`](../roadmap.md).
 
+**Started on dev (2026-08-24) — PIN pairing and worker credentials for remote transcoding.**
+The security primitives behind roadmap item 9's pairing bullet, as pure `Optimisarr.Core.Workers`
+logic with no HTTP, persistence, or UI wiring, so no machine can pair yet. The intended flow is the
+familiar one: Optimisarr displays a PIN, the operator types it into the sidecar along with this
+server's URL, and the sidecar exchanges it for a credential.
+
+The design problem is that a PIN short enough to retype by hand — eight digits — has too little
+entropy to survive sustained guessing on its own. Security therefore rests on three properties
+together rather than on length: the code lives five minutes, redeems exactly once, and is
+**destroyed** after five wrong guesses rather than rate-limited, so the attempt budget is a
+vanishing fraction of the code space and a burned code refuses even the genuine PIN. Malformed
+input spends an attempt too, otherwise probing the format would be cheaper than guessing digits;
+operator spacing is tolerated because people read grouped digits. A dead code (used, expired, or
+burned) reports that without comparing, so nothing can be learned by racing a spent code. A
+regression test asserts the attempt-budget-to-code-space ratio directly, so shortening the PIN or
+raising the cap fails the suite rather than quietly weakening the argument.
+
+Credentials are 32 random bytes, returned to the worker once and stored only as a SHA-256
+fingerprint compared in constant time, matching the existing admin-token approach. A leaked
+database therefore yields no usable credential, and revocation is total: an absent fingerprint
+matches nothing. Endpoints, the worker table, the PIN display, assignment/lease binding, rotation,
+and TLS guidance all remain to build.
+
 **Decision (2026-08-24) — Adaptive per-title VMAF stays the default for new libraries while
 Experimental.** Release 0.2.11 made the adaptive path the default for new video re-encode libraries.
 The prototype-acceptance comparison the roadmap asks for — total work, selected quality, size, VMAF,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -467,12 +467,22 @@ the replacement workflow is trustworthy.
      evidence, and result acknowledgement. The main app owns job state, scheduling, rules, and every
      destructive transition. Protocol versions and worker capabilities must be negotiated so an
      upgrade cannot silently schedule a job onto an incompatible sidecar.
-   - **Secure pairing and revocation.** Register a sidecar through a short-lived, single-use code
-     displayed by the main app, then issue it a unique revocable credential. Bind every assignment
-     and result to the registered worker and job lease; redact credentials from diagnostics and
-     logs. Document TLS expectations, certificate trust, credential rotation, and the difference
-     between a private LAN and an authenticated secure connection rather than treating LAN access
-     as authentication.
+   - **Secure pairing and revocation: started.** Register a sidecar through a short-lived,
+     single-use code displayed by the main app, then issue it a unique revocable credential. Bind
+     every assignment and result to the registered worker and job lease; redact credentials from
+     diagnostics and logs. Document TLS expectations, certificate trust, credential rotation, and
+     the difference between a private LAN and an authenticated secure connection rather than
+     treating LAN access as authentication.
+     **Landed so far:** the pairing PIN and credential primitives as pure
+     `Optimisarr.Core.Workers` logic. The operator reads an eight-digit PIN from Optimisarr and
+     types it into the sidecar with this server's URL; the PIN lives five minutes, redeems once,
+     and is destroyed after five wrong guesses rather than throttled, so a typed-length code stays
+     safe on its attempt budget rather than its length. Credentials are stored only as SHA-256
+     fingerprints and compared in constant time, which makes revocation total — discarding the
+     fingerprint ends the worker's access. Nothing is wired to HTTP, persistence, or the UI yet, so
+     no machine can actually pair. **Still to build:** the pair/revoke endpoints and worker table,
+     the UI panel that displays a live PIN, binding assignments and results to the credential and
+     lease, credential rotation, and the TLS/LAN guidance.
    - **Efficient, integrity-checked media delivery.** Support resumable, bounded, checksummed
      streaming when the sidecar cannot see the library. Also offer an explicit shared-storage path
      mapping for SMB/NFS-mounted media so multi-gigabyte sources need not cross the network twice.

--- a/src/Optimisarr.Core/Workers/WorkerPairing.cs
+++ b/src/Optimisarr.Core/Workers/WorkerPairing.cs
@@ -1,0 +1,129 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Optimisarr.Core.Workers;
+
+/// <summary>Why a pairing attempt was accepted or refused.</summary>
+public enum PairingRedemption
+{
+    Accepted,
+    IncorrectCode,
+    Expired,
+    AlreadyRedeemed,
+    TooManyAttempts
+}
+
+/// <summary>The outcome plus the code's new state, since redemption always consumes something.</summary>
+public sealed record PairingResult(PairingRedemption Outcome, PairingCode Code);
+
+/// <summary>
+/// A short-lived, single-use PIN the operator reads from Optimisarr and types into a sidecar,
+/// alongside this server's URL. The PIN is deliberately short enough to type, so its security
+/// rests on three things together and not on length: a short life, single use, and a hard attempt
+/// cap that burns the code rather than throttling it.
+/// </summary>
+public sealed record PairingCode(
+    string Code,
+    DateTimeOffset IssuedUtc,
+    DateTimeOffset ExpiresUtc,
+    int FailedAttempts,
+    bool Redeemed)
+{
+    /// <summary>Digits in a PIN. Long enough that the attempt cap is a vanishing slice of the space.</summary>
+    public const int Digits = 8;
+
+    /// <summary>Wrong guesses before the code is dead — not merely delayed.</summary>
+    public const int MaxAttempts = 5;
+
+    /// <summary>How long a displayed PIN stays usable.</summary>
+    public static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(5);
+
+    /// <summary>Mints a fresh PIN from a cryptographic generator.</summary>
+    public static PairingCode Issue(DateTimeOffset nowUtc)
+    {
+        var digits = new char[Digits];
+        for (var i = 0; i < Digits; i++)
+        {
+            digits[i] = (char)('0' + RandomNumberGenerator.GetInt32(0, 10));
+        }
+
+        return new PairingCode(new string(digits), nowUtc, nowUtc + Lifetime, 0, false);
+    }
+
+    /// <summary>
+    /// Checks a typed PIN and returns the code's new state. Order matters: a dead code (used,
+    /// expired, or burned) is reported as such without comparing, so a caller cannot learn
+    /// anything by racing a spent code.
+    /// </summary>
+    public PairingResult Redeem(string supplied, DateTimeOffset nowUtc)
+    {
+        if (Redeemed)
+        {
+            return new PairingResult(PairingRedemption.AlreadyRedeemed, this);
+        }
+
+        if (FailedAttempts >= MaxAttempts)
+        {
+            return new PairingResult(PairingRedemption.TooManyAttempts, this);
+        }
+
+        if (nowUtc >= ExpiresUtc)
+        {
+            return new PairingResult(PairingRedemption.Expired, this);
+        }
+
+        // Operators read the PIN in groups, so tolerate the spacing they type. Everything else
+        // counts as a wrong guess: probing the format must not be cheaper than guessing digits.
+        var normalised = new string(supplied.Where(char.IsAsciiDigit).ToArray());
+
+        if (normalised.Length == Digits && FixedTimeEquals(normalised, Code))
+        {
+            return new PairingResult(PairingRedemption.Accepted, this with { Redeemed = true });
+        }
+
+        return new PairingResult(
+            PairingRedemption.IncorrectCode,
+            this with { FailedAttempts = FailedAttempts + 1 });
+    }
+
+    private static bool FixedTimeEquals(string supplied, string expected) =>
+        CryptographicOperations.FixedTimeEquals(
+            SHA256.HashData(Encoding.UTF8.GetBytes(supplied)),
+            SHA256.HashData(Encoding.UTF8.GetBytes(expected)));
+}
+
+/// <summary>
+/// The long-lived secret a paired worker presents on every later call. Optimisarr stores only the
+/// fingerprint, so a leaked database yields no usable credential, and revoking a worker is simply
+/// discarding its fingerprint.
+/// </summary>
+public static class WorkerCredential
+{
+    private const int SecretBytes = 32;
+
+    /// <summary>Mints a credential. Returned to the worker once and never recoverable afterwards.</summary>
+    public static string Issue() => Base64Url(RandomNumberGenerator.GetBytes(SecretBytes));
+
+    /// <summary>The stored form of a credential.</summary>
+    public static string Fingerprint(string secret) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(secret)));
+
+    /// <summary>
+    /// Constant-time check of a presented secret against a stored fingerprint. An absent
+    /// fingerprint matches nothing, which is what makes revocation total.
+    /// </summary>
+    public static bool Matches(string supplied, string storedFingerprint)
+    {
+        if (string.IsNullOrWhiteSpace(supplied) || string.IsNullOrWhiteSpace(storedFingerprint))
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(
+            SHA256.HashData(Encoding.UTF8.GetBytes(Fingerprint(supplied))),
+            SHA256.HashData(Encoding.UTF8.GetBytes(storedFingerprint)));
+    }
+
+    private static string Base64Url(byte[] bytes) =>
+        Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+}

--- a/tests/Optimisarr.Tests/WorkerPairingTests.cs
+++ b/tests/Optimisarr.Tests/WorkerPairingTests.cs
@@ -1,0 +1,209 @@
+using Optimisarr.Core.Workers;
+
+namespace Optimisarr.Tests;
+
+/// <summary>
+/// Pairing is the moment an unknown machine becomes trusted to receive media, so the PIN must be
+/// hard to guess inside its short life and must burn itself rather than allow indefinite attempts.
+/// A human types this code, so it is deliberately short — which makes the attempt cap, not the
+/// length, the thing that actually stops a brute force.
+/// </summary>
+public class WorkerPairingTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 24, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Issue_produces_a_code_of_the_advertised_length_and_only_digits()
+    {
+        var code = PairingCode.Issue(Now);
+
+        Assert.Equal(PairingCode.Digits, code.Code.Length);
+        Assert.All(code.Code, c => Assert.True(char.IsAsciiDigit(c)));
+    }
+
+    [Fact]
+    public void Issue_expires_the_code_after_the_pairing_window()
+    {
+        var code = PairingCode.Issue(Now);
+
+        Assert.Equal(Now, code.IssuedUtc);
+        Assert.Equal(Now + PairingCode.Lifetime, code.ExpiresUtc);
+        Assert.False(code.Redeemed);
+        Assert.Equal(0, code.FailedAttempts);
+    }
+
+    [Fact]
+    public void Issue_does_not_repeat_itself_across_many_codes()
+    {
+        // Not a statistical proof, but a wired-constant or clock-seeded generator would collapse
+        // this set immediately.
+        var codes = Enumerable.Range(0, 200).Select(_ => PairingCode.Issue(Now).Code).ToHashSet();
+
+        Assert.True(codes.Count > 190, $"Only {codes.Count} distinct codes in 200 draws.");
+    }
+
+    [Fact]
+    public void Redeem_accepts_the_correct_code_and_marks_it_used()
+    {
+        var code = PairingCode.Issue(Now);
+
+        var result = code.Redeem(code.Code, Now.AddSeconds(30));
+
+        Assert.Equal(PairingRedemption.Accepted, result.Outcome);
+        Assert.True(result.Code.Redeemed);
+    }
+
+    [Fact]
+    public void Redeem_refuses_a_code_that_has_already_been_used()
+    {
+        var code = PairingCode.Issue(Now);
+        var first = code.Redeem(code.Code, Now.AddSeconds(30));
+
+        var second = first.Code.Redeem(code.Code, Now.AddSeconds(31));
+
+        Assert.Equal(PairingRedemption.AlreadyRedeemed, second.Outcome);
+    }
+
+    [Fact]
+    public void Redeem_refuses_an_expired_code_even_when_it_is_correct()
+    {
+        var code = PairingCode.Issue(Now);
+
+        var result = code.Redeem(code.Code, code.ExpiresUtc);
+
+        Assert.Equal(PairingRedemption.Expired, result.Outcome);
+        Assert.False(result.Code.Redeemed);
+    }
+
+    [Fact]
+    public void Redeem_counts_a_wrong_code_against_the_attempt_cap()
+    {
+        var code = PairingCode.Issue(Now);
+
+        var result = code.Redeem(WrongCodeFor(code), Now.AddSeconds(1));
+
+        Assert.Equal(PairingRedemption.IncorrectCode, result.Outcome);
+        Assert.Equal(1, result.Code.FailedAttempts);
+        Assert.False(result.Code.Redeemed);
+    }
+
+    [Fact]
+    public void Redeem_burns_the_code_once_the_attempt_cap_is_reached()
+    {
+        var code = PairingCode.Issue(Now);
+        var wrong = WrongCodeFor(code);
+
+        for (var i = 0; i < PairingCode.MaxAttempts; i++)
+        {
+            code = code.Redeem(wrong, Now.AddSeconds(1)).Code;
+        }
+
+        // Even the genuine code must now be refused: a burned code is dead, not merely throttled.
+        var result = code.Redeem(code.Code, Now.AddSeconds(2));
+
+        Assert.Equal(PairingRedemption.TooManyAttempts, result.Outcome);
+        Assert.False(result.Code.Redeemed);
+    }
+
+    [Fact]
+    public void Redeem_treats_a_malformed_attempt_as_a_spent_attempt()
+    {
+        // Otherwise probing the format is free and the cap only limits well-formed guesses.
+        var code = PairingCode.Issue(Now);
+
+        var result = code.Redeem("nonsense", Now.AddSeconds(1));
+
+        Assert.Equal(PairingRedemption.IncorrectCode, result.Outcome);
+        Assert.Equal(1, result.Code.FailedAttempts);
+    }
+
+    [Fact]
+    public void Redeem_ignores_spacing_the_operator_may_have_typed()
+    {
+        var code = PairingCode.Issue(Now);
+        var spaced = code.Code[..4] + " " + code.Code[4..];
+
+        var result = code.Redeem(spaced, Now.AddSeconds(5));
+
+        Assert.Equal(PairingRedemption.Accepted, result.Outcome);
+    }
+
+    [Fact]
+    public void MaxAttempts_keeps_a_brute_force_far_below_the_code_space()
+    {
+        // The whole security argument: a short human-typed PIN is safe only because the attempt
+        // budget is a vanishing fraction of the space, inside a short window.
+        var space = Math.Pow(10, PairingCode.Digits);
+
+        Assert.True(PairingCode.MaxAttempts / space < 0.0001);
+        Assert.True(PairingCode.Lifetime <= TimeSpan.FromMinutes(15));
+    }
+
+    private static string WrongCodeFor(PairingCode code) =>
+        new(code.Code.Select(c => c == '0' ? '1' : '0').ToArray());
+}
+
+/// <summary>
+/// The credential a paired worker keeps. Only its fingerprint is ever stored, so a leaked database
+/// does not yield usable worker credentials, and revocation is simply forgetting the fingerprint.
+/// </summary>
+public class WorkerCredentialTests
+{
+    [Fact]
+    public void Issue_produces_a_secret_with_real_entropy()
+    {
+        var secrets = Enumerable.Range(0, 100).Select(_ => WorkerCredential.Issue()).ToHashSet();
+
+        Assert.Equal(100, secrets.Count);
+        Assert.All(secrets, s => Assert.True(s.Length >= 32, $"Secret too short: {s.Length}"));
+    }
+
+    [Fact]
+    public void Fingerprint_is_stable_for_the_same_secret()
+    {
+        var secret = WorkerCredential.Issue();
+
+        Assert.Equal(WorkerCredential.Fingerprint(secret), WorkerCredential.Fingerprint(secret));
+    }
+
+    [Fact]
+    public void Fingerprint_does_not_contain_the_secret()
+    {
+        var secret = WorkerCredential.Issue();
+
+        Assert.DoesNotContain(secret, WorkerCredential.Fingerprint(secret), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Matches_accepts_the_issued_secret()
+    {
+        var secret = WorkerCredential.Issue();
+
+        Assert.True(WorkerCredential.Matches(secret, WorkerCredential.Fingerprint(secret)));
+    }
+
+    [Fact]
+    public void Matches_rejects_a_different_secret()
+    {
+        var stored = WorkerCredential.Fingerprint(WorkerCredential.Issue());
+
+        Assert.False(WorkerCredential.Matches(WorkerCredential.Issue(), stored));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Matches_rejects_an_empty_secret(string supplied)
+    {
+        var stored = WorkerCredential.Fingerprint(WorkerCredential.Issue());
+
+        Assert.False(WorkerCredential.Matches(supplied, stored));
+    }
+
+    [Fact]
+    public void Matches_rejects_anything_when_no_fingerprint_is_stored()
+    {
+        // A revoked worker's fingerprint is cleared, so this is the revocation path.
+        Assert.False(WorkerCredential.Matches(WorkerCredential.Issue(), ""));
+    }
+}


### PR DESCRIPTION
## Outcome

Implements the pairing flow you described — Optimisarr displays a PIN, the operator types it into
the sidecar together with this server's URL, and the sidecar trades it for a credential. This is the
security core of roadmap item 9's pairing bullet, as pure `Optimisarr.Core.Workers` logic.

## The design problem, and the argument

An eight-digit PIN is short enough to retype by hand and **far too weak to survive sustained
guessing on entropy alone**. So the security does not rest on length. It rests on three properties
together:

1. **Five-minute life.** The window closes fast.
2. **Single use.** A redeemed code is dead.
3. **Destroyed after five wrong guesses — not throttled.** A burned code refuses even the *genuine*
   PIN. Rate-limiting merely slows an attacker; destruction ends the attempt.

Two details that matter more than they look:

- **Malformed input spends an attempt.** Otherwise probing the format is cheaper than guessing
  digits, and the cap only limits well-formed guesses.
- **A dead code reports that without comparing.** Used, expired, and burned are all decided before
  any comparison, so nothing can be learned by racing a spent code.

Operator spacing is tolerated (`1234 5678`) because people read grouped digits and will type them
that way.

`MaxAttempts_keeps_a_brute_force_far_below_the_code_space` asserts the attempt-budget-to-code-space
ratio and the lifetime bound **directly**. Shortening the PIN or raising the cap fails the suite
rather than quietly weakening the argument above. That test is the guard on the reasoning, not just
on the code.

## Credentials

32 random bytes, handed to the worker once and never recoverable. Stored only as a SHA-256
fingerprint, compared in constant time — the same approach `AdminTokenAuth` already uses, so there
is one crypto pattern in the codebase rather than two. A leaked database yields no usable
credential, and **revocation is total**: an absent fingerprint matches nothing, so discarding it
ends the worker's access outright.

## Safety

Nothing is wired to HTTP, persistence, or the UI. **No machine can actually pair yet**, no
credential is issued to anything, and no destructive path is touched.

## Included scope

- `src/Optimisarr.Core/Workers/WorkerPairing.cs` — `PairingCode` (issue/redeem state machine) and
  `WorkerCredential` (issue/fingerprint/verify).
- `tests/Optimisarr.Tests/WorkerPairingTests.cs` — 19 tests.
- `docs/roadmap.md` — pairing bullet marked **started**, with what landed and what remains.
- `docs/engineering/history.md` — dated entry recording the entropy argument.

## Excluded scope — deliberately

- **Pair/revoke endpoints and the worker table.** Needs an EF migration and its own review.
- **The UI panel** that displays a live PIN with its countdown.
- **Binding assignments and results** to the credential and job lease.
- **Credential rotation, TLS and LAN guidance.** Named in the roadmap entry as still to build.
- **No changelog entry** — no operator-visible behaviour yet. Same call as #81; happy to move both.

## Relationship to #81

Independent. This branches from `dev` and touches only new files, so the two can merge in either
order despite sharing the `Optimisarr.Core.Workers` namespace.

## Verification

- `dotnet build Optimisarr.slnx` — succeeds, **zero warnings**.
- `dotnet test Optimisarr.slnx` — **1521 passed, 0 failed** (1502 on `dev` plus the 19 new). Tests
  written first and confirmed failing to compile before the implementation existed.
- `python3 scripts/check_docs.py` passes. Frontend untouched; no schema change.

## Migration risk

None. No schema, no persisted state, no configuration.
