### PR TITLE
Wire worker pairing to the API and storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- **Remote transcoding sidecars can now be paired with a PIN.** Issue a code in Optimisarr, then
+  type it into a sidecar along with this server's URL. The code lasts five minutes, works once, and
+  is destroyed after five wrong entries, so a code short enough to retype stays safe. Paired workers
+  can be listed and revoked; revoking ends a worker's access immediately and keeps the record.
+  Optimisarr remains the only thing that replaces, quarantines, moves, or deletes a file — a worker
+  never can. **No work is sent to a sidecar yet**, so pairing has no effect on your library today.
+  There is no interface for this yet either; it is API-only while the feature is built.
+
 ### Fixed
 
 - **The weekly secret scan now acknowledges three reviewed historical documentation examples.**

--- a/docs/api.md
+++ b/docs/api.md
@@ -517,6 +517,35 @@ Replacement statuses:
 | `RolledBack` | The original was restored and the replacement removed. |
 | `Purged` | The quarantined original was deleted by approval or retention. Rollback is no longer available. |
 
+## Remote Workers
+
+Optional remote transcoding sidecars. Optimisarr stays the control plane and the sole authority over
+destructive transitions: a worker contributes spare capacity and can never replace, quarantine, move,
+or delete an original.
+
+Pairing is PIN-based. The operator issues a code in Optimisarr and types it into the sidecar along
+with this server's URL. The code lives five minutes, redeems once, and is destroyed after five wrong
+guesses rather than throttled, so a code short enough to retype is safe on its attempt budget rather
+than its length.
+
+`POST /api/workers/pair` is the **only** worker route reachable without the admin token — a pairing
+sidecar holds the PIN and nothing else, so that route authenticates itself. It is inert unless an
+operator has just issued a code, and returns nothing without the correct one. Every other worker
+route stays behind the admin token.
+
+The credential is returned exactly once, in the pairing response. Optimisarr stores only its SHA-256
+fingerprint and cannot reproduce it. Revoking clears the fingerprint, which ends the worker's access
+outright because an absent fingerprint matches nothing; the row is kept for the audit trail.
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `POST` | `/api/workers/pairing-code` | Issue a pairing PIN, replacing any previous one. |
+| `GET` | `/api/workers/pairing-code` | Read the PIN currently on screen. `404` once it is spent, expired, or burned. |
+| `DELETE` | `/api/workers/pairing-code` | Withdraw the active PIN. |
+| `POST` | `/api/workers/pair` | Redeem a PIN and register a sidecar. Open route; the PIN is the credential. Returns the worker credential once. |
+| `GET` | `/api/workers` | List paired workers. Never returns credential fingerprints. |
+| `DELETE` | `/api/workers/{id}` | Revoke a worker. Clears its credential and drains it; keeps the record. |
+
 ## Stats
 
 | Method | Endpoint | Purpose |

--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -3,6 +3,31 @@
 Detailed, dated engineering record: what shipped, the per-phase plan, and current status.
 The forward-looking summary lives in [`../roadmap.md`](../roadmap.md).
 
+**Started on dev (2026-08-24) — worker pairing reaches the API.** The PIN primitives below are now
+wired to endpoints and storage, so a sidecar can genuinely pair. `POST /api/workers/pair` redeems a
+code, negotiates the protocol, writes a `Workers` row (migration `AddWorkers`), and returns the
+credential once; issue/read/withdraw, list, and revoke routes sit alongside it.
+
+Two decisions carry the security weight. First, `/api/workers/pair` is the only worker route outside
+the admin token, because a pairing sidecar holds the PIN and nothing else and cannot obtain a token.
+That widening is bounded deliberately: the route is inert unless an operator has just issued a code,
+it authenticates before doing any other work, and it yields nothing without the correct PIN. The
+generated OpenAPI proves the boundary — every other worker operation documents a `401` and this one
+does not — and both the unit and the real-host end-to-end auth tests assert it in each direction.
+
+Second, the active PIN lives in memory and is never persisted. Writing a short-lived secret to the
+config database would give it a durability it should not have and would carry it into backups;
+losing it on restart is correct, because the operator simply asks for another. The service stores
+the code's post-attempt state, which is what makes the cap real — `PairingCode` is immutable, so
+without that every request would restart from zero failed attempts.
+
+Redemption happens before protocol negotiation, so an incompatible sidecar spends the code rather
+than probing versions repeatedly on one PIN. Enum payloads are integers, matching the rest of this
+API rather than introducing a second convention on one endpoint; whether a third-party sidecar
+contract would be better served by string enums is an open question, not an oversight. Credentials
+are returned exactly once and stored only as fingerprints, so revocation clears the fingerprint and
+keeps the row for the audit trail.
+
 **Started on dev (2026-08-24) — PIN pairing and worker credentials for remote transcoding.**
 The security primitives behind roadmap item 9's pairing bullet, as pure `Optimisarr.Core.Workers`
 logic with no HTTP, persistence, or UI wiring, so no machine can pair yet. The intended flow is the

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -794,6 +794,155 @@
         ],
         "type": "object"
       },
+      "PairRequest": {
+        "properties": {
+          "architecture": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "code": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "freeScratchBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "hardwareDecoders": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "maxConcurrency": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "operatingSystem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "protocolMaximum": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "protocolMinimum": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "videoEncoders": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "vmaf": {
+            "$ref": "#/components/schemas/VmafCapability"
+          }
+        },
+        "required": [
+          "code",
+          "name",
+          "operatingSystem",
+          "architecture",
+          "protocolMinimum",
+          "protocolMaximum",
+          "videoEncoders",
+          "hardwareDecoders",
+          "vmaf",
+          "freeScratchBytes",
+          "maxConcurrency"
+        ],
+        "type": "object"
+      },
+      "PairResponse": {
+        "properties": {
+          "credential": {
+            "type": "string"
+          },
+          "protocolVersion": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "workerId": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          }
+        },
+        "required": [
+          "workerId",
+          "credential",
+          "protocolVersion"
+        ],
+        "type": "object"
+      },
+      "PairingCodeDto": {
+        "properties": {
+          "attemptsRemaining": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "code": {
+            "type": "string"
+          },
+          "expiresUtc": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "expiresUtc",
+          "attemptsRemaining"
+        ],
+        "type": "object"
+      },
       "PlexServersRequest": {
         "properties": {
           "token": {
@@ -1742,6 +1891,103 @@
           "preview",
           "cleanedCount",
           "reclaimedBytes"
+        ],
+        "type": "object"
+      },
+      "VmafCapability": {
+        "type": "integer"
+      },
+      "WorkerDto": {
+        "properties": {
+          "architecture": {
+            "type": "string"
+          },
+          "freeScratchBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "hardwareDecoders": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "lastSeenAt": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "maxConcurrency": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "operatingSystem": {
+            "type": "string"
+          },
+          "pairedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "protocolVersion": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "revokedAt": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "videoEncoders": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "vmaf": {
+            "$ref": "#/components/schemas/VmafCapability"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "operatingSystem",
+          "architecture",
+          "protocolVersion",
+          "videoEncoders",
+          "hardwareDecoders",
+          "vmaf",
+          "freeScratchBytes",
+          "maxConcurrency",
+          "pairedAt",
+          "lastSeenAt",
+          "revokedAt"
         ],
         "type": "object"
       }
@@ -4188,6 +4434,148 @@
           "System"
         ]
       }
+    },
+    "/api/workers": {
+      "get": {
+        "operationId": "ListWorkers",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/WorkerDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Admin token required when OPTIMISARR_ADMIN_TOKEN is set on the server."
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      }
+    },
+    "/api/workers/pair": {
+      "post": {
+        "operationId": "PairWorker",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PairRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      }
+    },
+    "/api/workers/pairing-code": {
+      "delete": {
+        "operationId": "CancelWorkerPairingCode",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Admin token required when OPTIMISARR_ADMIN_TOKEN is set on the server."
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      },
+      "get": {
+        "operationId": "ActiveWorkerPairingCode",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairingCodeDto"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Admin token required when OPTIMISARR_ADMIN_TOKEN is set on the server."
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      },
+      "post": {
+        "operationId": "IssueWorkerPairingCode",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairingCodeDto"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Admin token required when OPTIMISARR_ADMIN_TOKEN is set on the server."
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      }
+    },
+    "/api/workers/{id}": {
+      "delete": {
+        "operationId": "RevokeWorker",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Admin token required when OPTIMISARR_ADMIN_TOKEN is set on the server."
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      }
     }
   },
   "tags": [
@@ -4217,6 +4605,9 @@
     },
     {
       "name": "Realtime"
+    },
+    {
+      "name": "Workers"
     }
   ]
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -486,10 +486,15 @@ the replacement workflow is trustworthy.
      and is destroyed after five wrong guesses rather than throttled, so a typed-length code stays
      safe on its attempt budget rather than its length. Credentials are stored only as SHA-256
      fingerprints and compared in constant time, which makes revocation total — discarding the
-     fingerprint ends the worker's access. Nothing is wired to HTTP, persistence, or the UI yet, so
-     no machine can actually pair. **Still to build:** the pair/revoke endpoints and worker table,
-     the UI panel that displays a live PIN, binding assignments and results to the credential and
-     lease, credential rotation, and the TLS/LAN guidance.
+     fingerprint ends the worker's access. A sidecar can now actually pair: `POST
+     /api/workers/pair` redeems a PIN, negotiates the protocol, records the worker, and returns its
+     credential once, with issue/read/withdraw, list, and revoke routes alongside it and a `Workers`
+     table behind migration `AddWorkers`. That pair route is the single worker endpoint outside the
+     admin token, because a pairing sidecar holds only the PIN — it is inert unless an operator has
+     just issued a code, and yields nothing without the correct one. The active PIN is held in
+     memory and never persisted, so it stays out of the database and its backups. **Still to
+     build:** the UI panel that displays a live PIN, binding assignments and results to the
+     credential and lease, credential rotation, and the TLS/LAN guidance.
    - **Efficient, integrity-checked media delivery.** Support resumable, bounded, checksummed
      streaming when the sidecar cannot see the library. Also offer an explicit shared-storage path
      mapping for SMB/NFS-mounted media so multi-gigabyte sources need not cross the network twice.

--- a/src/Optimisarr.Api/Endpoints/WorkerEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerEndpoints.cs
@@ -1,0 +1,217 @@
+using Microsoft.EntityFrameworkCore;
+using Optimisarr.Api.Workers;
+using Optimisarr.Core.Workers;
+using Optimisarr.Data;
+
+namespace Optimisarr.Api.Endpoints;
+
+/// <summary>What an operator sees about a paired sidecar. Never carries the credential fingerprint.</summary>
+internal sealed record WorkerDto(
+    int Id,
+    string Name,
+    string OperatingSystem,
+    string Architecture,
+    int ProtocolVersion,
+    IReadOnlyList<string> VideoEncoders,
+    IReadOnlyList<string> HardwareDecoders,
+    VmafCapability Vmaf,
+    long FreeScratchBytes,
+    int MaxConcurrency,
+    DateTimeOffset PairedAt,
+    DateTimeOffset? LastSeenAt,
+    DateTimeOffset? RevokedAt);
+
+/// <summary>The PIN an operator reads off the screen and types into a sidecar.</summary>
+internal sealed record PairingCodeDto(string Code, DateTimeOffset ExpiresUtc, int AttemptsRemaining);
+
+/// <summary>What a sidecar sends to redeem a PIN. Everything except the code is self-reported.</summary>
+internal sealed record PairRequest(
+    string? Code,
+    string? Name,
+    string? OperatingSystem,
+    string? Architecture,
+    int ProtocolMinimum,
+    int ProtocolMaximum,
+    IReadOnlyList<string>? VideoEncoders,
+    IReadOnlyList<string>? HardwareDecoders,
+    VmafCapability Vmaf,
+    long FreeScratchBytes,
+    int MaxConcurrency);
+
+/// <summary>The credential, returned exactly once. Optimisarr keeps only its fingerprint.</summary>
+internal sealed record PairResponse(int WorkerId, string Credential, int ProtocolVersion);
+
+internal static class WorkerEndpoints
+{
+    public static void MapWorkerEndpoints(this WebApplication app)
+    {
+        // Issue a PIN for the operator to read out. Replaces any previous one so only the code on
+        // screen is live.
+        app.MapPost("/api/workers/pairing-code", (WorkerPairingService pairing) =>
+        {
+            var code = pairing.Issue(DateTimeOffset.UtcNow);
+            return Results.Ok(new PairingCodeDto(code.Code, code.ExpiresUtc, PairingCode.MaxAttempts));
+        })
+        .WithName("IssueWorkerPairingCode")
+        .Produces<PairingCodeDto>();
+
+        // The PIN currently on screen, so a reloaded UI can resume its countdown. 404 once the code
+        // is spent, burned, or expired — there is then nothing an operator could still type.
+        app.MapGet("/api/workers/pairing-code", (WorkerPairingService pairing) =>
+        {
+            var code = pairing.Active(DateTimeOffset.UtcNow);
+            return code is null
+                ? ApiErrors.NotFound("worker.pairingCode.none", "No pairing code is currently active.")
+                : Results.Ok(new PairingCodeDto(
+                    code.Code, code.ExpiresUtc, PairingCode.MaxAttempts - code.FailedAttempts));
+        })
+        .WithName("ActiveWorkerPairingCode")
+        .Produces<PairingCodeDto>();
+
+        app.MapDelete("/api/workers/pairing-code", (WorkerPairingService pairing) =>
+        {
+            pairing.Cancel();
+            return Results.NoContent();
+        })
+        .WithName("CancelWorkerPairingCode");
+
+        // The one route a sidecar can reach without an admin token; the PIN authenticates it.
+        app.MapPost("/api/workers/pair", async (
+            PairRequest request,
+            WorkerPairingService pairing,
+            OptimisarrDbContext db,
+            CancellationToken cancellationToken) =>
+        {
+            // Authenticate before doing anything else. A wrong or dead code spends an attempt and
+            // learns nothing about the server.
+            var redemption = pairing.Redeem(request.Code ?? string.Empty, DateTimeOffset.UtcNow);
+            if (redemption != PairingRedemption.Accepted)
+            {
+                return Results.Json(
+                    new ApiError($"worker.pairing.{char.ToLowerInvariant(redemption.ToString()[0])}{redemption.ToString()[1..]}",
+                        RedemptionMessage(redemption)),
+                    statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            // The code is spent from here on, including when negotiation fails below. That is
+            // intentional: one PIN buys one pairing attempt, so an incompatible sidecar cannot
+            // probe protocol versions repeatedly on a single code.
+            var negotiation = WorkerProtocol.Negotiate(request.ProtocolMinimum, request.ProtocolMaximum);
+            if (!negotiation.Compatible)
+            {
+                return ApiErrors.Conflict("worker.protocol.incompatible", negotiation.Reason!);
+            }
+
+            var name = string.IsNullOrWhiteSpace(request.Name) ? "Unnamed worker" : request.Name.Trim();
+            var credential = WorkerCredential.Issue();
+
+            var worker = new Worker
+            {
+                Name = name.Length > 160 ? name[..160] : name,
+                OperatingSystem = Trimmed(request.OperatingSystem, 32),
+                Architecture = Trimmed(request.Architecture, 32),
+                ProtocolVersion = negotiation.AgreedVersion,
+                VideoEncoders = Join(request.VideoEncoders),
+                HardwareDecoders = Join(request.HardwareDecoders),
+                Vmaf = request.Vmaf,
+                FreeScratchBytes = Math.Max(0, request.FreeScratchBytes),
+                MaxConcurrency = Math.Max(0, request.MaxConcurrency),
+                CredentialFingerprint = WorkerCredential.Fingerprint(credential),
+                PairedAt = DateTimeOffset.UtcNow
+            };
+
+            db.Workers.Add(worker);
+            await db.SaveChangesAsync(cancellationToken);
+
+            // The only time the credential leaves this process. Optimisarr cannot reproduce it.
+            return Results.Ok(new PairResponse(worker.Id, credential, negotiation.AgreedVersion));
+        })
+        .WithName("PairWorker")
+        .Produces<PairResponse>();
+
+        app.MapGet("/api/workers", async (OptimisarrDbContext db, CancellationToken cancellationToken) =>
+        {
+            var workers = await db.Workers
+                .AsNoTracking()
+                .OrderBy(worker => worker.Id)
+                .ToListAsync(cancellationToken);
+
+            return Results.Ok(workers.Select(ToDto).ToList());
+        })
+        .WithName("ListWorkers")
+        .Produces<IReadOnlyList<WorkerDto>>();
+
+        // Revocation clears the fingerprint rather than deleting the row, so the pairing stays in
+        // the audit trail while the credential stops matching anything at all.
+        app.MapDelete("/api/workers/{id:int}", async (
+            int id,
+            OptimisarrDbContext db,
+            CancellationToken cancellationToken) =>
+        {
+            var worker = await db.Workers.FirstOrDefaultAsync(w => w.Id == id, cancellationToken);
+            if (worker is null)
+            {
+                return ApiErrors.NotFound("worker.notFound", $"No worker with id {id}.", new { id });
+            }
+
+            worker.CredentialFingerprint = null;
+            worker.RevokedAt = DateTimeOffset.UtcNow;
+            worker.MaxConcurrency = 0;
+            await db.SaveChangesAsync(cancellationToken);
+
+            return Results.NoContent();
+        })
+        .WithName("RevokeWorker");
+    }
+
+    private static string RedemptionMessage(PairingRedemption redemption) => redemption switch
+    {
+        PairingRedemption.Expired => "That pairing code has expired. Generate a new one in Optimisarr.",
+        PairingRedemption.AlreadyRedeemed => "That pairing code has already been used.",
+        PairingRedemption.TooManyAttempts =>
+            "That pairing code was entered incorrectly too many times and is no longer valid. Generate a new one.",
+        _ => "That pairing code is not correct."
+    };
+
+    private static WorkerDto ToDto(Worker worker) => new(
+        worker.Id,
+        worker.Name,
+        worker.OperatingSystem,
+        worker.Architecture,
+        worker.ProtocolVersion,
+        Split(worker.VideoEncoders),
+        Split(worker.HardwareDecoders),
+        worker.Vmaf,
+        worker.FreeScratchBytes,
+        worker.MaxConcurrency,
+        worker.PairedAt,
+        worker.LastSeenAt,
+        worker.RevokedAt);
+
+    private static string Trimmed(string? value, int max)
+    {
+        var trimmed = (value ?? string.Empty).Trim();
+        return trimmed.Length > max ? trimmed[..max] : trimmed;
+    }
+
+    private static string Join(IReadOnlyList<string>? values)
+    {
+        if (values is null || values.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var cleaned = values
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Select(v => v.Trim())
+            .Take(64);
+
+        var joined = string.Join(',', cleaned);
+        return joined.Length > 1024 ? joined[..joined.LastIndexOf(',', 1023)] : joined;
+    }
+
+    private static IReadOnlyList<string> Split(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? []
+            : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}

--- a/src/Optimisarr.Api/OpenApi/OptimisarrApiTags.cs
+++ b/src/Optimisarr.Api/OpenApi/OptimisarrApiTags.cs
@@ -9,7 +9,7 @@ namespace Optimisarr.Api.OpenApi;
 internal static class OptimisarrApiTags
 {
     public static readonly string[] AllTags =
-        ["System", "Setup", "Settings", "Libraries", "Inventory", "Queue", "Replacements", "Integrations", "Realtime"];
+        ["System", "Setup", "Settings", "Libraries", "Inventory", "Queue", "Replacements", "Integrations", "Realtime", "Workers"];
 
     public static string TagFor(string path)
     {
@@ -27,6 +27,7 @@ internal static class OptimisarrApiTags
             || p.StartsWith("/api/inventory", StringComparison.OrdinalIgnoreCase)
             || p.StartsWith("/api/preview", StringComparison.OrdinalIgnoreCase)) return "Inventory";
         if (p.StartsWith("/api/jobs", StringComparison.OrdinalIgnoreCase)) return "Queue";
+        if (p.StartsWith("/api/workers", StringComparison.OrdinalIgnoreCase)) return "Workers";
         if (p.StartsWith("/api/replacements", StringComparison.OrdinalIgnoreCase)) return "Replacements";
         if (p.StartsWith("/api/activity-watchers", StringComparison.OrdinalIgnoreCase)
             || p.StartsWith("/api/notification-targets", StringComparison.OrdinalIgnoreCase)

--- a/src/Optimisarr.Api/Program.cs
+++ b/src/Optimisarr.Api/Program.cs
@@ -42,6 +42,7 @@ var ffprobe = MediaToolCommands.ResolveFfprobe(
 builder.Services.AddSingleton(new TranscodeOptions(transcodeFfmpeg));
 builder.Services.AddSingleton(new HardwareCapabilityService(transcodeFfmpeg));
 builder.Services.AddSingleton<LibraryScanner>();
+builder.Services.AddSingleton<Optimisarr.Api.Workers.WorkerPairingService>();
 var mediaProbe = new MediaProbeService(ffprobe);
 builder.Services.AddSingleton(mediaProbe);
 builder.Services.AddSingleton<IMediaProbeService>(mediaProbe);
@@ -226,6 +227,8 @@ app.MapMediaAndQueueEndpoints();
 app.MapStatsEndpoints(configDirectory);
 
 app.MapReplacementEndpoints();
+
+app.MapWorkerEndpoints();
 
 app.MapHub<JobsHub>("/hubs/jobs");
 

--- a/src/Optimisarr.Api/Security/AdminTokenAuth.cs
+++ b/src/Optimisarr.Api/Security/AdminTokenAuth.cs
@@ -13,7 +13,13 @@ public static class AdminTokenAuth
     public static bool IsOpenPath(PathString path) =>
         path.Equals("/api/health", StringComparison.OrdinalIgnoreCase)
         || path.Equals("/api/ready", StringComparison.OrdinalIgnoreCase)
-        || path.Equals("/api/auth/status", StringComparison.OrdinalIgnoreCase);
+        || path.Equals("/api/auth/status", StringComparison.OrdinalIgnoreCase)
+        // A sidecar pairing for the first time holds only the PIN the operator read off this
+        // server — it has no admin token and cannot obtain one, so this route carries its own
+        // authentication instead. The PIN is the credential here: the route is inert unless an
+        // operator has just issued one, it dies after five wrong guesses, and it expires in
+        // minutes. It hands out nothing without the correct code.
+        || path.Equals("/api/workers/pair", StringComparison.OrdinalIgnoreCase);
 
     public static bool IsProtectedPath(PathString path) =>
         path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase)

--- a/src/Optimisarr.Api/Workers/WorkerPairingService.cs
+++ b/src/Optimisarr.Api/Workers/WorkerPairingService.cs
@@ -1,0 +1,81 @@
+using Optimisarr.Core.Workers;
+
+namespace Optimisarr.Api.Workers;
+
+/// <summary>
+/// Holds the one pairing PIN an operator currently has on screen.
+///
+/// Deliberately in memory and never persisted: a PIN is a short-lived secret, so writing it to
+/// the config database would give it a durability it should not have and would leave it in
+/// backups. Losing the active PIN on restart is the correct behaviour — the operator simply asks
+/// for another.
+///
+/// One code is live at a time. Issuing a new PIN replaces any previous one, so an abandoned code
+/// cannot linger alongside the one being shown.
+/// </summary>
+public sealed class WorkerPairingService
+{
+    private readonly Lock _gate = new();
+    private PairingCode? _active;
+
+    /// <summary>Issues a fresh PIN, discarding any previous one.</summary>
+    public PairingCode Issue(DateTimeOffset nowUtc)
+    {
+        lock (_gate)
+        {
+            _active = PairingCode.Issue(nowUtc);
+            return _active;
+        }
+    }
+
+    /// <summary>
+    /// The PIN currently worth showing, or null when there is none the operator could still use.
+    /// A spent, burned, or expired code is reported as absent rather than displayed as live.
+    /// </summary>
+    public PairingCode? Active(DateTimeOffset nowUtc)
+    {
+        lock (_gate)
+        {
+            if (_active is null || _active.Redeemed
+                || _active.FailedAttempts >= PairingCode.MaxAttempts
+                || nowUtc >= _active.ExpiresUtc)
+            {
+                return null;
+            }
+
+            return _active;
+        }
+    }
+
+    /// <summary>Withdraws the active PIN immediately.</summary>
+    public void Cancel()
+    {
+        lock (_gate)
+        {
+            _active = null;
+        }
+    }
+
+    /// <summary>
+    /// Checks a typed PIN and stores the code's resulting state, so failed attempts accumulate
+    /// across requests and actually reach the cap. Without persisting the new state here, every
+    /// request would start from zero attempts and the cap would be meaningless.
+    /// </summary>
+    public PairingRedemption Redeem(string supplied, DateTimeOffset nowUtc)
+    {
+        lock (_gate)
+        {
+            if (_active is null)
+            {
+                // Nothing on screen, so there is nothing to redeem. Reported as an incorrect code
+                // rather than a distinct state: whether a PIN is currently displayed is not
+                // something an unauthenticated caller needs to learn.
+                return PairingRedemption.IncorrectCode;
+            }
+
+            var result = _active.Redeem(supplied, nowUtc);
+            _active = result.Code;
+            return result.Outcome;
+        }
+    }
+}

--- a/src/Optimisarr.Data/Migrations/20260824124359_AddWorkers.Designer.cs
+++ b/src/Optimisarr.Data/Migrations/20260824124359_AddWorkers.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Optimisarr.Data;
 
@@ -10,9 +11,11 @@ using Optimisarr.Data;
 namespace Optimisarr.Data.Migrations
 {
     [DbContext(typeof(OptimisarrDbContext))]
-    partial class OptimisarrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824124359_AddWorkers")]
+    partial class AddWorkers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/src/Optimisarr.Data/Migrations/20260824124359_AddWorkers.cs
+++ b/src/Optimisarr.Data/Migrations/20260824124359_AddWorkers.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Optimisarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Workers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 160, nullable: false),
+                    OperatingSystem = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false),
+                    Architecture = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false),
+                    ProtocolVersion = table.Column<int>(type: "INTEGER", nullable: false),
+                    VideoEncoders = table.Column<string>(type: "TEXT", maxLength: 1024, nullable: false),
+                    HardwareDecoders = table.Column<string>(type: "TEXT", maxLength: 1024, nullable: false),
+                    Vmaf = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false),
+                    FreeScratchBytes = table.Column<long>(type: "INTEGER", nullable: false),
+                    MaxConcurrency = table.Column<int>(type: "INTEGER", nullable: false),
+                    CredentialFingerprint = table.Column<string>(type: "TEXT", maxLength: 64, nullable: true),
+                    PairedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    LastSeenAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    RevokedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Workers", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Workers_CredentialFingerprint",
+                table: "Workers",
+                column: "CredentialFingerprint",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Workers");
+        }
+    }
+}

--- a/src/Optimisarr.Data/OptimisarrDbContext.cs
+++ b/src/Optimisarr.Data/OptimisarrDbContext.cs
@@ -22,6 +22,8 @@ public sealed class OptimisarrDbContext(DbContextOptions<OptimisarrDbContext> op
 
     public DbSet<Exclusion> Exclusions => Set<Exclusion>();
 
+    public DbSet<Worker> Workers => Set<Worker>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<AppSetting>(entity =>
@@ -158,6 +160,22 @@ public sealed class OptimisarrDbContext(DbContextOptions<OptimisarrDbContext> op
             entity.Property(exclusion => exclusion.Reason).HasMaxLength(512);
             entity.Property(exclusion => exclusion.Source).HasConversion<string>().HasMaxLength(32);
             entity.HasIndex(exclusion => exclusion.LibraryId);
+        });
+
+        modelBuilder.Entity<Worker>(entity =>
+        {
+            entity.HasKey(worker => worker.Id);
+            entity.Property(worker => worker.Name).IsRequired().HasMaxLength(160);
+            entity.Property(worker => worker.OperatingSystem).HasMaxLength(32);
+            entity.Property(worker => worker.Architecture).HasMaxLength(32);
+            entity.Property(worker => worker.VideoEncoders).HasMaxLength(1024);
+            entity.Property(worker => worker.HardwareDecoders).HasMaxLength(1024);
+            entity.Property(worker => worker.Vmaf).HasConversion<string>().HasMaxLength(32);
+            // A SHA-256 hex fingerprint is always 64 characters; the credential itself is never stored.
+            entity.Property(worker => worker.CredentialFingerprint).HasMaxLength(64);
+            // Every authenticated worker call arrives with a credential and no id, so the
+            // fingerprint is the lookup key. Unique because two workers must never share one.
+            entity.HasIndex(worker => worker.CredentialFingerprint).IsUnique();
         });
     }
 }

--- a/src/Optimisarr.Data/Worker.cs
+++ b/src/Optimisarr.Data/Worker.cs
@@ -1,0 +1,59 @@
+using Optimisarr.Core.Workers;
+
+namespace Optimisarr.Data;
+
+/// <summary>
+/// A paired remote transcoding sidecar. Optimisarr remains the control plane and the only
+/// authority over destructive transitions; a worker contributes spare CPU/GPU capacity and can
+/// never replace, quarantine, move, or delete an original.
+///
+/// The credential is stored write-only as a fingerprint, exactly like <see cref="ArrConnection"/>'s
+/// API key is never returned. Revoking clears the fingerprint, which ends the worker's access
+/// outright because an absent fingerprint matches nothing.
+/// </summary>
+public sealed class Worker
+{
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The name the sidecar reported at pairing. Operator-facing display text supplied by the
+    /// remote machine, so it is shown escaped and never used as an identifier.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Reported operating system, e.g. <c>windows</c>, <c>macos</c>, <c>linux</c>.</summary>
+    public string OperatingSystem { get; set; } = string.Empty;
+
+    /// <summary>Reported CPU architecture, e.g. <c>x64</c>, <c>arm64</c>.</summary>
+    public string Architecture { get; set; } = string.Empty;
+
+    /// <summary>The protocol version agreed at pairing, from <see cref="WorkerProtocol.Negotiate"/>.</summary>
+    public int ProtocolVersion { get; set; }
+
+    /// <summary>Comma-separated encoders the worker proved, not assumed from its platform.</summary>
+    public string VideoEncoders { get; set; } = string.Empty;
+
+    /// <summary>Comma-separated hardware decoders the worker proved.</summary>
+    public string HardwareDecoders { get; set; } = string.Empty;
+
+    public VmafCapability Vmaf { get; set; } = VmafCapability.None;
+
+    /// <summary>Free scratch space last reported. Zero until the worker reports.</summary>
+    public long FreeScratchBytes { get; set; }
+
+    /// <summary>Jobs the worker will accept at once. Zero means drained — no new assignments.</summary>
+    public int MaxConcurrency { get; set; }
+
+    /// <summary>
+    /// SHA-256 fingerprint of the issued credential. Never the credential itself, and never
+    /// returned to any client. Cleared on revocation.
+    /// </summary>
+    public string? CredentialFingerprint { get; set; }
+
+    public DateTimeOffset PairedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset? LastSeenAt { get; set; }
+
+    /// <summary>Set when an operator revokes the worker. A revoked row is kept for the audit trail.</summary>
+    public DateTimeOffset? RevokedAt { get; set; }
+}

--- a/tests/Optimisarr.Tests/AdminTokenAuthEndpointTests.cs
+++ b/tests/Optimisarr.Tests/AdminTokenAuthEndpointTests.cs
@@ -66,6 +66,13 @@ public sealed class AdminTokenAuthEndpointTests : IClassFixture<AdminTokenAuthEn
     [InlineData("POST", "/api/replacements/1/rollback")]
     [InlineData("POST", "/api/replacements/1/approve")]
     [InlineData("GET", "/api/diagnostics")]       // admin support snapshot
+    // Worker administration stays behind the token; only the pairing exchange itself is open,
+    // and that one carries the PIN as its own credential.
+    [InlineData("POST", "/api/workers/pairing-code")]
+    [InlineData("GET", "/api/workers/pairing-code")]
+    [InlineData("DELETE", "/api/workers/pairing-code")]
+    [InlineData("GET", "/api/workers")]
+    [InlineData("DELETE", "/api/workers/1")]
     public async Task A_protected_endpoint_is_401_without_the_token(string method, string path)
     {
         using var response = await _api.CreateClient()
@@ -84,6 +91,29 @@ public sealed class AdminTokenAuthEndpointTests : IClassFixture<AdminTokenAuthEn
 
         // /api/ready may be 503 in the test host (no /work, /trash), but it must never be 401.
         Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Worker_pairing_is_reachable_without_the_token_but_refuses_a_wrong_pin()
+    {
+        // The route must be open — a pairing sidecar has no admin token and cannot get one — while
+        // still handing out nothing without the correct PIN. With no code issued, every PIN is wrong.
+        using var response = await _api.CreateClient().PostAsJsonAsync("/api/workers/pair", new
+        {
+            code = "12345678",
+            name = "Attacker",
+            operatingSystem = "linux",
+            architecture = "x64",
+            protocolMinimum = 1,
+            protocolMaximum = 1,
+            vmaf = 1, // VmafCapability.Cpu — this API serialises enums as integers
+            freeScratchBytes = 0L,
+            maxConcurrency = 1
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.DoesNotContain("credential", await response.Content.ReadAsStringAsync(),
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/Optimisarr.Tests/AdminTokenAuthTests.cs
+++ b/tests/Optimisarr.Tests/AdminTokenAuthTests.cs
@@ -18,9 +18,23 @@ public sealed class AdminTokenAuthTests
     [InlineData("/api/health")]
     [InlineData("/api/ready")]
     [InlineData("/api/auth/status")]
-    public void Health_readiness_and_auth_status_are_open_paths(string path)
+    // A pairing sidecar has only the PIN, never an admin token, so this route authenticates itself.
+    [InlineData("/api/workers/pair")]
+    public void Health_readiness_auth_status_and_worker_pairing_are_open_paths(string path)
     {
         Assert.True(AdminTokenAuth.IsOpenPath(path));
+    }
+
+    [Theory]
+    // Only the pairing exchange is open. Everything else about workers — issuing a PIN, listing
+    // them, revoking one — stays behind the admin token.
+    [InlineData("/api/workers")]
+    [InlineData("/api/workers/1")]
+    [InlineData("/api/workers/pairing-code")]
+    public void Other_worker_routes_are_not_open(string path)
+    {
+        Assert.False(AdminTokenAuth.IsOpenPath(path));
+        Assert.True(AdminTokenAuth.IsProtectedPath(path));
     }
 
     [Theory]

--- a/tests/Optimisarr.Tests/WorkerPairingServiceTests.cs
+++ b/tests/Optimisarr.Tests/WorkerPairingServiceTests.cs
@@ -1,0 +1,112 @@
+using Optimisarr.Api.Workers;
+using Optimisarr.Core.Workers;
+
+namespace Optimisarr.Tests;
+
+/// <summary>
+/// The service is what makes the attempt cap real. <see cref="PairingCode"/> is immutable, so
+/// without storing the returned state every request would restart from zero failed attempts and
+/// the cap would never be reached — the single most important behaviour to pin down here.
+/// </summary>
+public class WorkerPairingServiceTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 24, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Redeem_refuses_when_no_code_has_been_issued()
+    {
+        var service = new WorkerPairingService();
+
+        Assert.Equal(PairingRedemption.IncorrectCode, service.Redeem("12345678", Now));
+    }
+
+    [Fact]
+    public void Redeem_accepts_the_issued_code()
+    {
+        var service = new WorkerPairingService();
+        var code = service.Issue(Now);
+
+        Assert.Equal(PairingRedemption.Accepted, service.Redeem(code.Code, Now.AddSeconds(10)));
+    }
+
+    [Fact]
+    public void Failed_attempts_accumulate_across_calls_and_reach_the_cap()
+    {
+        var service = new WorkerPairingService();
+        var code = service.Issue(Now);
+
+        for (var i = 0; i < PairingCode.MaxAttempts; i++)
+        {
+            Assert.Equal(PairingRedemption.IncorrectCode, service.Redeem("00000000", Now.AddSeconds(1)));
+        }
+
+        // The genuine code must now fail too. If state were not stored, this would return Accepted.
+        Assert.Equal(PairingRedemption.TooManyAttempts, service.Redeem(code.Code, Now.AddSeconds(2)));
+    }
+
+    [Fact]
+    public void A_code_cannot_be_redeemed_twice()
+    {
+        var service = new WorkerPairingService();
+        var code = service.Issue(Now);
+
+        Assert.Equal(PairingRedemption.Accepted, service.Redeem(code.Code, Now.AddSeconds(1)));
+        Assert.Equal(PairingRedemption.AlreadyRedeemed, service.Redeem(code.Code, Now.AddSeconds(2)));
+    }
+
+    [Fact]
+    public void Issuing_a_new_code_invalidates_the_previous_one()
+    {
+        var service = new WorkerPairingService();
+        var first = service.Issue(Now);
+        service.Issue(Now.AddSeconds(5));
+
+        Assert.Equal(PairingRedemption.IncorrectCode, service.Redeem(first.Code, Now.AddSeconds(6)));
+    }
+
+    [Fact]
+    public void Active_hides_a_code_that_is_spent_expired_or_burned()
+    {
+        var service = new WorkerPairingService();
+
+        var code = service.Issue(Now);
+        Assert.NotNull(service.Active(Now.AddSeconds(1)));
+
+        Assert.Null(service.Active(code.ExpiresUtc));
+
+        service.Issue(Now);
+        service.Redeem(service.Active(Now)!.Code, Now.AddSeconds(1));
+        Assert.Null(service.Active(Now.AddSeconds(2)));
+
+        service.Issue(Now);
+        for (var i = 0; i < PairingCode.MaxAttempts; i++)
+        {
+            service.Redeem("00000000", Now.AddSeconds(1));
+        }
+
+        Assert.Null(service.Active(Now.AddSeconds(2)));
+    }
+
+    [Fact]
+    public void Cancel_withdraws_the_active_code()
+    {
+        var service = new WorkerPairingService();
+        var code = service.Issue(Now);
+
+        service.Cancel();
+
+        Assert.Null(service.Active(Now.AddSeconds(1)));
+        Assert.Equal(PairingRedemption.IncorrectCode, service.Redeem(code.Code, Now.AddSeconds(1)));
+    }
+
+    [Fact]
+    public void Active_reports_the_remaining_attempts_shrinking()
+    {
+        var service = new WorkerPairingService();
+        service.Issue(Now);
+
+        service.Redeem("00000000", Now.AddSeconds(1));
+
+        Assert.Equal(1, service.Active(Now.AddSeconds(2))!.FailedAttempts);
+    }
+}


### PR DESCRIPTION
## Outcome

Third slice of roadmap item 9. A sidecar can now **actually pair**. `POST /api/workers/pair` redeems
a PIN, negotiates the protocol, writes a `Workers` row, and returns the credential once, with
issue/read/withdraw, list, and revoke routes alongside.

The flow is the one you described: Optimisarr shows a PIN → operator types it into the sidecar with
this server's URL → sidecar gets a credential.

## The security decision I most want reviewed

**`/api/workers/pair` is the only worker route outside the admin token.** It has to be — a pairing
sidecar holds the PIN and nothing else, and cannot obtain a token. This is a genuine widening of the
unauthenticated surface, so it is bounded deliberately:

- The route is **inert unless an operator has just issued a code**. No active PIN → every request is
  refused.
- It **authenticates before doing anything else**, so a wrong code does no work and learns nothing.
- It **yields nothing** without the correct PIN, and the PIN dies after five wrong guesses.
- The generated OpenAPI **proves the boundary**: every other worker operation documents a `401` and
  this one does not. That falls out of `AdminTokenAuth.IsOpenPath` rather than being asserted twice.
- Both a unit test and the **real-host end-to-end auth test** assert it in each direction — the five
  admin worker routes 401 without a token, and `pair` stays reachable but refuses a wrong PIN
  without leaking a credential.

## The PIN is never persisted

It lives in memory only. Writing a short-lived secret to the config database would give it a
durability it should not have and would carry it into backups. Losing the active PIN on restart is
*correct* — the operator asks for another.

The service stores the code's **post-attempt state**, which is what makes the cap real:
`PairingCode` is immutable, so without storing the result every request would restart from zero
failed attempts and the cap would be decorative.
`Failed_attempts_accumulate_across_calls_and_reach_the_cap` pins exactly that, asserting the genuine
code is refused once the budget is spent.

## Smaller judgment calls

- **Redemption precedes negotiation**, so an incompatible sidecar spends its code rather than
  probing protocol versions repeatedly on one PIN. Cost: after upgrading, the operator issues a new
  code. That seemed the right trade.
- **Revocation clears the fingerprint and drains the worker rather than deleting the row**, keeping
  the pairing in the audit trail while the credential matches nothing.
- **Enum payloads are integers**, matching every other enum in this API rather than introducing a
  second convention on one endpoint. Flagging it as an open question rather than a silent choice:
  a third-party sidecar contract might be better served by string enums, since integers are brittle
  across versions. Changing it globally is a breaking change and belongs in its own PR.

## Safety

**No work is dispatched to a sidecar yet.** Nothing here can reach a media file, and no destructive
transition is touched. Optimisarr remains the sole authority over replace, quarantine, move, and
delete.

## Included scope

- `Worker` entity, `Workers` DbSet, migration `AddWorkers` (additive `CreateTable`, reversible).
- `WorkerPairingService` — in-memory active PIN.
- `WorkerEndpoints` — six routes.
- `AdminTokenAuth.IsOpenPath` + `OptimisarrApiTags` (`Workers` tag).
- Tests: 8 service tests, 4 auth cases, 1 real-host pairing test.
- `docs/openapi.json` regenerated, `docs/api.md` **Remote Workers** section, roadmap + history,
  `CHANGELOG.md`.

## On the changelog

This one **does** get a changelog entry, unlike #81 and #82. Those were pure logic with nothing an
operator could observe; this adds real API surface someone could use. The entry says plainly that no
work is sent to a sidecar yet and that there is no UI, so nobody expects a working feature.

## Excluded scope

- **The UI panel** showing a live PIN with its countdown.
- **Binding assignments and results** to the credential and lease.
- **Credential rotation, TLS/LAN guidance**, heartbeats, leases, and the result path.

## Verification

- `dotnet build` — **zero warnings**. `dotnet test` — **1558 passed, 0 failed**.
- `scripts/check_openapi.py` — document up to date. `scripts/check_docs.py` — passes.
- Frontend untouched. Migration is an additive `CreateTable` with a `DropTable` down.
