### PR TITLE
Add the worker lease state machine

### DIFF
--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -3,6 +3,24 @@
 Detailed, dated engineering record: what shipped, the per-phase plan, and current status.
 The forward-looking summary lives in [`../roadmap.md`](../roadmap.md).
 
+**Started on dev (2026-08-24) — the lease state machine.** A lease is one worker's exclusive claim
+on one job, and it exists to stop two machines encoding the same original. The instructive part is
+which failure it optimises against: losing a lease merely wastes work, whereas freeing one while its
+holder is still running produces two candidates racing for one source. `WorkerLease.Duration` is
+therefore *derived* from `WorkerLiveness.OfflineAfter` rather than chosen independently, so the
+invariant — a job can only be reclaimed after its holder was already declared unreachable — holds
+structurally and not merely by convention. A test asserts the relationship as well, so neither
+constant can be tuned into overlap.
+
+Expiry is computed at read time rather than stored. A sweeper may tidy rows, but correctness must
+not depend on one having run, or a control plane restarting after downtime would wake up still
+believing a long-dead worker holds a job. Renewing or completing a lapsed lease is refused, which is
+precisely what makes the late-result case safe: a worker that vanished, whose job moved on, cannot
+deliver a candidate through a claim it no longer holds. Release is idempotent so a worker retrying
+after a dropped response is not punished for being careful, and ownership is checked before state in
+every operation so a stranger learns nothing about a lease it does not hold. Nothing is persisted or
+dispatched yet, so no job can currently be leased.
+
 **Started on dev (2026-08-24) — worker credentials finally authenticate something.** Pairing issued
 a credential but nothing consumed it: `WorkerCredential.Matches` had no call site, so the secret
 handed to a sidecar was inert. `POST /api/workers/heartbeat` closes that. `WorkerAuth` resolves the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -511,11 +511,22 @@ the replacement workflow is trustworthy.
      Shared sources remain read-only; sidecar scratch stays isolated. The main app verifies source
      identity before dispatch and rejects an output, report, or resumed transfer whose hashes,
      lease, size, or policy no longer match.
-   - **Capability-aware leases and recovery.** Schedule only when OS, architecture, FFmpeg build,
-     encoder, decoder, VMAF mode, free scratch space, and configured concurrency satisfy the job.
-     Persist idempotent leases with expiry and heartbeats, expose drain/disable controls, and make
-     retry after disconnect or restart safe. A lost, duplicated, late, cancelled, or partially
+   - **Capability-aware leases and recovery: started.** Schedule only when OS, architecture, FFmpeg
+     build, encoder, decoder, VMAF mode, free scratch space, and configured concurrency satisfy the
+     job. Persist idempotent leases with expiry and heartbeats, expose drain/disable controls, and
+     make retry after disconnect or restart safe. A lost, duplicated, late, cancelled, or partially
      uploaded result must never become replaceable.
+     **Landed so far:** the lease state machine as pure `Optimisarr.Core.Workers` logic. A lease is
+     one worker's exclusive claim on one job, and its duration is *derived* from the offline
+     threshold rather than set independently, so a job can only ever be reclaimed after its holder
+     has already been declared unreachable — never while it still counts as online, which is the
+     case that would put two encoders on one original. Expiry is computed when the lease is read
+     rather than stored, so correctness never depends on a sweeper having run and a control plane
+     restarting after downtime cannot wake up believing a dead worker still holds a job. Renewing
+     or completing a lapsed lease is refused, which is what makes a late result from a vanished
+     worker unusable; release is idempotent so a worker retrying after a dropped response is not
+     punished; and no worker can touch a lease it does not hold. **Still to build:** persisting
+     leases, dispatching work against them, drain controls, and recovery after restart.
    - **Preserve the verification boundary.** The sidecar returns the candidate, VMAF measurements,
      tool/model versions, preparation details, hashes, and captured process evidence as one result
      bound to the assignment. The main app independently re-probes the returned file and repeats the

--- a/src/Optimisarr.Core/Workers/WorkerLease.cs
+++ b/src/Optimisarr.Core/Workers/WorkerLease.cs
@@ -1,0 +1,119 @@
+namespace Optimisarr.Core.Workers;
+
+/// <summary>Where a lease stands. <see cref="Expired"/> is derived from the clock, never stored.</summary>
+public enum LeaseState
+{
+    Held,
+    Released,
+    Expired,
+    Completed
+}
+
+/// <summary>Why a lease operation was accepted or refused.</summary>
+public enum LeaseOutcome
+{
+    Renewed,
+    Released,
+    Completed,
+
+    /// <summary>Another worker tried to touch a lease it does not hold.</summary>
+    NotHolder,
+
+    /// <summary>The lease lapsed; the job may already belong to someone else.</summary>
+    Expired,
+
+    /// <summary>The lease was already released or completed, so there is nothing to act on.</summary>
+    NotHeld
+}
+
+/// <summary>The lease's new state alongside the outcome. A refused operation returns it unchanged.</summary>
+public sealed record LeaseResult(LeaseOutcome Outcome, WorkerLease Lease);
+
+/// <summary>
+/// One worker's exclusive claim on one job, with an expiry.
+///
+/// This is what stops two machines encoding the same original. The dangerous failure is not losing
+/// a lease — that merely wastes work — but freeing one while its holder is still running, because
+/// two candidates would then race for the same source. <see cref="Duration"/> is therefore longer
+/// than <see cref="WorkerLiveness.OfflineAfter"/>: a job can only be reclaimed after its holder has
+/// already been declared unreachable, never while it still counts as online.
+/// </summary>
+public sealed record WorkerLease(
+    Guid Id,
+    int JobId,
+    int WorkerId,
+    DateTimeOffset AcquiredUtc,
+    DateTimeOffset ExpiresUtc,
+    LeaseState State)
+{
+    /// <summary>
+    /// How long a claim survives without renewal. Comfortably beyond the point a silent worker is
+    /// declared offline, so a reclaim never overlaps a holder still believed to be alive.
+    /// </summary>
+    public static readonly TimeSpan Duration = WorkerLiveness.OfflineAfter + TimeSpan.FromMinutes(3);
+
+    public static WorkerLease Acquire(Guid id, int jobId, int workerId, DateTimeOffset nowUtc) =>
+        new(id, jobId, workerId, nowUtc, nowUtc + Duration, LeaseState.Held);
+
+    /// <summary>
+    /// The lease's effective state at <paramref name="nowUtc"/>. Expiry is computed rather than
+    /// stored, so a lapsed lease is lapsed the moment it is read. Correctness cannot depend on a
+    /// sweeper having run — otherwise a control plane restarting after downtime would wake up
+    /// still believing a long-dead worker holds the job.
+    /// </summary>
+    public LeaseState StateAt(DateTimeOffset nowUtc) =>
+        State == LeaseState.Held && nowUtc >= ExpiresUtc ? LeaseState.Expired : State;
+
+    /// <summary>Extends the claim from the moment of renewal, if the caller still holds it.</summary>
+    public LeaseResult Renew(int byWorkerId, DateTimeOffset nowUtc) =>
+        Guard(byWorkerId, nowUtc)
+            ?? new LeaseResult(LeaseOutcome.Renewed, this with { ExpiresUtc = nowUtc + Duration });
+
+    /// <summary>
+    /// Hands the job back. Idempotent: releasing an already-released lease succeeds rather than
+    /// erroring, so a worker retrying after a dropped response is not punished for being careful.
+    /// </summary>
+    public LeaseResult Release(int byWorkerId, DateTimeOffset nowUtc)
+    {
+        if (byWorkerId != WorkerId)
+        {
+            return new LeaseResult(LeaseOutcome.NotHolder, this);
+        }
+
+        if (StateAt(nowUtc) == LeaseState.Released)
+        {
+            return new LeaseResult(LeaseOutcome.Released, this);
+        }
+
+        return Guard(byWorkerId, nowUtc)
+            ?? new LeaseResult(LeaseOutcome.Released, this with { State = LeaseState.Released });
+    }
+
+    /// <summary>
+    /// Marks the claim finished because a result was delivered. A lapsed lease cannot be completed:
+    /// that is the late-result case, where a worker vanished, the job moved on, and it then returns
+    /// with a candidate that must not be accepted through a claim it no longer holds.
+    /// </summary>
+    public LeaseResult Complete(int byWorkerId, DateTimeOffset nowUtc) =>
+        Guard(byWorkerId, nowUtc)
+            ?? new LeaseResult(LeaseOutcome.Completed, this with { State = LeaseState.Completed });
+
+    /// <summary>
+    /// The checks every operation shares, in the order that matters: ownership first, so a stranger
+    /// learns nothing about a lease's state; then whether the claim is still live.
+    /// </summary>
+    private LeaseResult? Guard(int byWorkerId, DateTimeOffset nowUtc)
+    {
+        if (byWorkerId != WorkerId)
+        {
+            return new LeaseResult(LeaseOutcome.NotHolder, this);
+        }
+
+        return StateAt(nowUtc) switch
+        {
+            LeaseState.Held => null,
+            LeaseState.Expired => new LeaseResult(LeaseOutcome.Expired, this),
+            _ => new LeaseResult(LeaseOutcome.NotHeld, this)
+        };
+    }
+}

--- a/tests/Optimisarr.Tests/WorkerLeaseTests.cs
+++ b/tests/Optimisarr.Tests/WorkerLeaseTests.cs
@@ -1,0 +1,188 @@
+using Optimisarr.Core.Workers;
+
+namespace Optimisarr.Tests;
+
+/// <summary>
+/// A lease is what stops two machines encoding the same job. The dangerous failure is not losing a
+/// lease — that just wastes work — but releasing one while its holder is still running, because
+/// then two workers race to produce a candidate for the same original. These tests pin the
+/// behaviour that prevents it.
+/// </summary>
+public class WorkerLeaseTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 24, 12, 0, 0, TimeSpan.Zero);
+    private static readonly Guid LeaseId = new("11111111-1111-1111-1111-111111111111");
+
+    private static WorkerLease Held() => WorkerLease.Acquire(LeaseId, jobId: 42, workerId: 7, Now);
+
+    [Fact]
+    public void A_lease_can_only_expire_after_its_holder_would_be_declared_offline()
+    {
+        // The invariant the whole design rests on. If a lease could lapse while its holder still
+        // counted as online, the job could be handed to a second worker while the first was still
+        // encoding it. Asserted as a relationship so tuning either constant cannot break it
+        // silently.
+        Assert.True(WorkerLease.Duration > WorkerLiveness.OfflineAfter);
+    }
+
+    [Fact]
+    public void Acquire_holds_the_job_for_the_lease_duration()
+    {
+        var lease = Held();
+
+        Assert.Equal(LeaseState.Held, lease.StateAt(Now));
+        Assert.Equal(Now + WorkerLease.Duration, lease.ExpiresUtc);
+        Assert.Equal(42, lease.JobId);
+        Assert.Equal(7, lease.WorkerId);
+    }
+
+    [Fact]
+    public void A_held_lease_past_its_expiry_reads_as_expired_without_anyone_sweeping_it()
+    {
+        // Correctness must not depend on a background job running. A sweeper may tidy rows up, but
+        // a lapsed lease has to be lapsed the moment it is read, or a crashed control plane would
+        // wake up still believing a dead worker holds the job.
+        var lease = Held();
+
+        Assert.Equal(LeaseState.Held, lease.StateAt(lease.ExpiresUtc - TimeSpan.FromSeconds(1)));
+        Assert.Equal(LeaseState.Expired, lease.StateAt(lease.ExpiresUtc));
+        Assert.Equal(LeaseState.Expired, lease.StateAt(lease.ExpiresUtc + TimeSpan.FromHours(1)));
+    }
+
+    [Fact]
+    public void Renew_extends_the_expiry_from_the_moment_of_renewal()
+    {
+        var lease = Held();
+        var later = Now + TimeSpan.FromMinutes(1);
+
+        var result = lease.Renew(byWorkerId: 7, later);
+
+        Assert.Equal(LeaseOutcome.Renewed, result.Outcome);
+        Assert.Equal(later + WorkerLease.Duration, result.Lease.ExpiresUtc);
+    }
+
+    [Fact]
+    public void Renew_refuses_a_lease_that_has_already_lapsed()
+    {
+        // Resurrecting a lapsed lease is the exact path to two holders: the job may already have
+        // been offered to someone else, so a late renewal must fail rather than reclaim it.
+        var lease = Held();
+
+        var result = lease.Renew(byWorkerId: 7, lease.ExpiresUtc);
+
+        Assert.Equal(LeaseOutcome.Expired, result.Outcome);
+        Assert.Equal(LeaseState.Expired, result.Lease.StateAt(lease.ExpiresUtc));
+    }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Another_worker_cannot_renew_release_or_complete_someone_elses_lease(int intruder)
+    {
+        var lease = Held();
+
+        Assert.Equal(LeaseOutcome.NotHolder, lease.Renew(intruder, Now).Outcome);
+        Assert.Equal(LeaseOutcome.NotHolder, lease.Release(intruder, Now).Outcome);
+        Assert.Equal(LeaseOutcome.NotHolder, lease.Complete(intruder, Now).Outcome);
+    }
+
+    [Fact]
+    public void A_rejected_operation_leaves_the_lease_untouched()
+    {
+        var lease = Held();
+
+        var result = lease.Release(byWorkerId: 8, Now);
+
+        Assert.Equal(LeaseOutcome.NotHolder, result.Outcome);
+        Assert.Equal(LeaseState.Held, result.Lease.StateAt(Now));
+        Assert.Equal(lease.ExpiresUtc, result.Lease.ExpiresUtc);
+    }
+
+    [Fact]
+    public void Release_hands_the_job_back()
+    {
+        var result = Held().Release(byWorkerId: 7, Now);
+
+        Assert.Equal(LeaseOutcome.Released, result.Outcome);
+        Assert.Equal(LeaseState.Released, result.Lease.StateAt(Now));
+    }
+
+    [Fact]
+    public void Release_is_idempotent_so_a_retrying_worker_is_not_punished()
+    {
+        var once = Held().Release(byWorkerId: 7, Now);
+
+        var twice = once.Lease.Release(byWorkerId: 7, Now + TimeSpan.FromSeconds(5));
+
+        Assert.Equal(LeaseOutcome.Released, twice.Outcome);
+        Assert.Equal(LeaseState.Released, twice.Lease.StateAt(Now));
+    }
+
+    [Fact]
+    public void Complete_marks_the_lease_finished()
+    {
+        var result = Held().Complete(byWorkerId: 7, Now + TimeSpan.FromMinutes(1));
+
+        Assert.Equal(LeaseOutcome.Completed, result.Outcome);
+        Assert.Equal(LeaseState.Completed, result.Lease.StateAt(Now + TimeSpan.FromMinutes(2)));
+    }
+
+    [Fact]
+    public void A_completed_lease_never_reverts_to_expired_once_its_window_passes()
+    {
+        // A finished result must not start reading as a lapsed lease simply because time moved on,
+        // or a delivered candidate could look abandoned and be re-dispatched.
+        var completed = Held().Complete(byWorkerId: 7, Now).Lease;
+
+        Assert.Equal(LeaseState.Completed, completed.StateAt(Now + WorkerLease.Duration * 10));
+    }
+
+    [Fact]
+    public void A_lapsed_lease_cannot_be_completed_afterwards()
+    {
+        // The late-result case: the worker went away, the lease lapsed, and it then comes back with
+        // a candidate. That result must not be accepted through this lease, because the job may
+        // already be elsewhere.
+        var lease = Held();
+
+        var result = lease.Complete(byWorkerId: 7, lease.ExpiresUtc + TimeSpan.FromSeconds(1));
+
+        Assert.Equal(LeaseOutcome.Expired, result.Outcome);
+    }
+
+    [Fact]
+    public void A_released_lease_cannot_be_completed()
+    {
+        var released = Held().Release(byWorkerId: 7, Now).Lease;
+
+        Assert.Equal(LeaseOutcome.NotHeld, released.Complete(byWorkerId: 7, Now).Outcome);
+    }
+
+    [Fact]
+    public void A_released_lease_cannot_be_renewed_back_into_life()
+    {
+        var released = Held().Release(byWorkerId: 7, Now).Lease;
+
+        Assert.Equal(LeaseOutcome.NotHeld, released.Renew(byWorkerId: 7, Now).Outcome);
+    }
+
+    [Fact]
+    public void Renewal_at_the_heartbeat_interval_keeps_a_live_worker_comfortably_ahead()
+    {
+        // A worker beating normally should never be at risk of losing its lease. Walk several
+        // intervals and confirm it stays held throughout.
+        var lease = Held();
+        var clock = Now;
+
+        for (var i = 0; i < 20; i++)
+        {
+            clock += WorkerLiveness.HeartbeatInterval;
+            var result = lease.Renew(byWorkerId: 7, clock);
+            Assert.Equal(LeaseOutcome.Renewed, result.Outcome);
+            lease = result.Lease;
+        }
+
+        Assert.Equal(LeaseState.Held, lease.StateAt(clock));
+    }
+}


### PR DESCRIPTION
## Outcome

Sixth slice of roadmap item 9. A lease is one worker's exclusive claim on one job — the thing that
stops two machines encoding the same original.

## The failure it optimises against

Losing a lease only wastes work. **Freeing one while its holder is still running produces two
candidates racing for one source.** That asymmetry drives the whole design.

So `WorkerLease.Duration` is **derived** from `WorkerLiveness.OfflineAfter` rather than picked
independently:

```csharp
public static readonly TimeSpan Duration = WorkerLiveness.OfflineAfter + TimeSpan.FromMinutes(3);
```

A job can therefore only be reclaimed *after* its holder was already declared unreachable, never
while it still counts as online. The invariant holds **structurally**, not by convention — and
`A_lease_can_only_expire_after_its_holder_would_be_declared_offline` asserts the relationship as
well, so neither constant can later be tuned into overlap.

## Expiry is computed, not stored

`StateAt(now)` derives expiry when the lease is read. A sweeper may tidy rows, but correctness must
not depend on one having run — otherwise a control plane restarting after downtime would wake up
still believing a long-dead worker holds a job.

## Three behaviours worth reviewing

- **A lapsed lease cannot be renewed or completed.** This is what makes the late-result case safe:
  a worker that vanished, whose job has since moved on, must not be able to deliver a candidate
  through a claim it no longer holds. Tested both ways.
- **Release is idempotent.** A worker retrying after a dropped response is not punished for being
  careful.
- **Ownership is checked before state, everywhere.** A stranger gets `NotHolder` and learns nothing
  about a lease it does not hold. A rejected operation returns the lease untouched, which is
  asserted rather than assumed.

There is also a walk test that renews at the heartbeat interval twenty times over and confirms a
normally-beating worker never drifts near losing its claim.

## Safety

Nothing is persisted and nothing is dispatched — **no job can currently be leased**. No destructive
path is touched, and Optimisarr remains the sole authority over replace, quarantine, move, and
delete.

## Included scope

- `src/Optimisarr.Core/Workers/WorkerLease.cs` — `LeaseState`, `LeaseOutcome`, and the state machine.
- `tests/Optimisarr.Tests/WorkerLeaseTests.cs` — 17 tests.
- Roadmap bullet marked **started** with what remains; dated history entry.

## Excluded scope

- **Persisting leases, dispatching work against them, drain controls, recovery after restart.** All
  named in the roadmap entry as still to build.
- **No changelog entry** — pure logic, nothing an operator can observe, same call as #81/#82.

## Verification

- `dotnet build` — **zero warnings**. `dotnet test` — **1587 passed, 0 failed** (1570 before).
- Tests written first and confirmed failing to compile before the implementation existed.
- `scripts/check_docs.py` passes. Frontend untouched; no schema change.
