### PR TITLE
Send worker capabilities as names, not ordinals

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -537,6 +537,13 @@ The credential is returned exactly once, in the pairing response. Optimisarr sto
 fingerprint and cannot reproduce it. Revoking clears the fingerprint, which ends the worker's access
 outright because an absent fingerprint matches nothing; the row is kept for the audit trail.
 
+Capabilities are named, not numbered. `vmaf` is `None`, `Cpu`, or `Cuda` (case-insensitive on the
+way in; omitting it means the worker claims no VMAF support). An unrecognised name is rejected with
+`worker.vmaf.invalid` rather than silently treated as `None`, so a typo cannot quietly downgrade a
+capable worker. Names are used because this contract is implemented by separately-versioned
+sidecars: an ordinal would change meaning if the set ever gained a member, and that value decides
+whether a job may be offered to a worker at all.
+
 A worker checks in every 30 seconds and is treated as offline after 2 minutes of silence. Those are
 different numbers on purpose: declaring a worker offline on one missed beat would make the status
 flap on a single dropped packet. The control plane stamps the last-seen time from its own clock, so

--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -3,6 +3,32 @@
 Detailed, dated engineering record: what shipped, the per-phase plan, and current status.
 The forward-looking summary lives in [`../roadmap.md`](../roadmap.md).
 
+**Corrected on dev (2026-08-24) — worker capabilities cross the wire as names, not ordinals.** The
+pairing slice exposed `VmafCapability` directly on its DTOs, making it the only enum in the whole
+generated OpenAPI document rendered as `{"type": "integer"}`. That was justified at the time as
+matching the API's convention. It did not: `SaveArrConnectionRequest.Type` and
+`SaveNotificationTargetRequest.Type` are `string?` on the wire and parsed into enums by a
+`Parsed*` record, `JobDto` carries `job.Status.ToString()`, and the calibration report serialises
+through `JsonStringEnumConverter`. Enums already reached the wire as strings everywhere; the worker
+DTOs were the exception, not the rule.
+
+The reason it matters more here than it would elsewhere is that this contract is implemented by
+separately-versioned third-party sidecars. Optimisarr's own web client ships from this repository at
+the same version as the server and cannot disagree about what `2` means; a native tray app can lag
+or lead by months. Inserting a member into `VmafCapability` would silently change what an existing
+paired worker is believed to support — and that value gates whether a job may be offered to it, so a
+quietly wrong capability would arrive through a side door the protocol negotiation was built to
+close.
+
+`PairRequest.Vmaf` is now `string?`, parsed at the boundary with an error naming the valid values,
+following the same shape as the jobs endpoint's `job.status.invalid`. A missing value means the
+worker claims no VMAF support — a real answer — while anything unrecognised is refused, so a typo
+cannot quietly downgrade a capable worker to `None`. `WorkerDto.Vmaf` is the name, which also let
+the web client drop an ordinal-indexed label lookup in favour of the value itself. An end-to-end
+test asserts the field is a JSON string rather than a number, so the ordinal form cannot return
+unnoticed. Breaking for the worker contract, but its only consumer today is a curl command in
+testing; the cost of this change rises steeply once a tray app ships.
+
 **Started on dev (2026-08-24) — the lease state machine.** A lease is one worker's exclusive claim
 on one job, and it exists to stop two machines encoding the same original. The instructive part is
 which failure it optimises against: losing a lease merely wastes work, whereas freeing one while its
@@ -70,9 +96,10 @@ the code's post-attempt state, which is what makes the cap real — `PairingCode
 without that every request would restart from zero failed attempts.
 
 Redemption happens before protocol negotiation, so an incompatible sidecar spends the code rather
-than probing versions repeatedly on one PIN. Enum payloads are integers, matching the rest of this
-API rather than introducing a second convention on one endpoint; whether a third-party sidecar
-contract would be better served by string enums is an open question, not an oversight. Credentials
+than probing versions repeatedly on one PIN. Enum payloads were initially integers on the claim that
+this matched the rest of the API — **that was wrong, and is corrected below in the 2026-08-24 entry
+on capability names**; the rest of the API converts enums to strings at the wire boundary and the
+worker DTOs were the only exception. Credentials
 are returned exactly once and stored only as fingerprints, so revocation clears the fingerprint and
 keeps the row for the audit trail.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -935,7 +935,10 @@
             ]
           },
           "vmaf": {
-            "$ref": "#/components/schemas/VmafCapability"
+            "type": [
+              "null",
+              "string"
+            ]
           }
         },
         "required": [
@@ -1958,9 +1961,6 @@
         ],
         "type": "object"
       },
-      "VmafCapability": {
-        "type": "integer"
-      },
       "WorkerDto": {
         "properties": {
           "architecture": {
@@ -2038,7 +2038,7 @@
             "type": "array"
           },
           "vmaf": {
-            "$ref": "#/components/schemas/VmafCapability"
+            "type": "string"
           }
         },
         "required": [

--- a/src/Optimisarr.Api/Endpoints/WorkerEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerEndpoints.cs
@@ -14,7 +14,7 @@ internal sealed record WorkerDto(
     int ProtocolVersion,
     IReadOnlyList<string> VideoEncoders,
     IReadOnlyList<string> HardwareDecoders,
-    VmafCapability Vmaf,
+    string Vmaf,
     long FreeScratchBytes,
     int MaxConcurrency,
     DateTimeOffset PairedAt,
@@ -25,7 +25,14 @@ internal sealed record WorkerDto(
 /// <summary>The PIN an operator reads off the screen and types into a sidecar.</summary>
 internal sealed record PairingCodeDto(string Code, DateTimeOffset ExpiresUtc, int AttemptsRemaining);
 
-/// <summary>What a sidecar sends to redeem a PIN. Everything except the code is self-reported.</summary>
+/// <summary>
+/// What a sidecar sends to redeem a PIN. Everything except the code is self-reported.
+///
+/// <paramref name="Vmaf"/> is a name rather than a number. This contract is implemented by
+/// separately-versioned third-party sidecars, so an enum's meaning must never depend on its
+/// ordinal: inserting a member would otherwise silently change what an existing worker is believed
+/// to support, and that value gates whether a job may be offered to it.
+/// </summary>
 internal sealed record PairRequest(
     string? Code,
     string? Name,
@@ -35,7 +42,7 @@ internal sealed record PairRequest(
     int ProtocolMaximum,
     IReadOnlyList<string>? VideoEncoders,
     IReadOnlyList<string>? HardwareDecoders,
-    VmafCapability Vmaf,
+    string? Vmaf,
     long FreeScratchBytes,
     int MaxConcurrency);
 
@@ -122,6 +129,14 @@ internal static class WorkerEndpoints
                 return ApiErrors.Conflict("worker.protocol.incompatible", negotiation.Reason!);
             }
 
+            if (!TryParseVmaf(request.Vmaf, out var vmaf))
+            {
+                return ApiErrors.BadRequest("worker.vmaf.invalid",
+                    $"Unknown VMAF capability '{request.Vmaf}'. Valid values: " +
+                    $"{string.Join(", ", Enum.GetNames<VmafCapability>())}.",
+                    new { value = request.Vmaf });
+            }
+
             var name = string.IsNullOrWhiteSpace(request.Name) ? "Unnamed worker" : request.Name.Trim();
             var credential = WorkerCredential.Issue();
 
@@ -133,7 +148,7 @@ internal static class WorkerEndpoints
                 ProtocolVersion = negotiation.AgreedVersion,
                 VideoEncoders = Join(request.VideoEncoders),
                 HardwareDecoders = Join(request.HardwareDecoders),
-                Vmaf = request.Vmaf,
+                Vmaf = vmaf,
                 FreeScratchBytes = Math.Max(0, request.FreeScratchBytes),
                 MaxConcurrency = Math.Max(0, request.MaxConcurrency),
                 CredentialFingerprint = WorkerCredential.Fingerprint(credential),
@@ -244,7 +259,7 @@ internal static class WorkerEndpoints
         worker.ProtocolVersion,
         Split(worker.VideoEncoders),
         Split(worker.HardwareDecoders),
-        worker.Vmaf,
+        worker.Vmaf.ToString(),
         worker.FreeScratchBytes,
         worker.MaxConcurrency,
         worker.PairedAt,
@@ -253,6 +268,23 @@ internal static class WorkerEndpoints
         // Revoked workers are never "online" whatever their last heartbeat said, so the UI cannot
         // show a green light next to a worker that can no longer authenticate.
         worker.RevokedAt is null && WorkerLiveness.IsOnline(worker.LastSeenAt, nowUtc));
+
+    /// <summary>
+    /// Accepts a capability name, case-insensitively. An absent value means the worker claims no
+    /// VMAF support, which is a real answer rather than a missing one; anything unrecognised is
+    /// refused so a typo cannot quietly downgrade to None.
+    /// </summary>
+    private static bool TryParseVmaf(string? value, out VmafCapability parsed)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            parsed = VmafCapability.None;
+            return true;
+        }
+
+        return Enum.TryParse(value.Trim(), ignoreCase: true, out parsed)
+            && Enum.IsDefined(parsed);
+    }
 
     private static string Trimmed(string? value, int max)
     {

--- a/tests/Optimisarr.Tests/AdminTokenAuthEndpointTests.cs
+++ b/tests/Optimisarr.Tests/AdminTokenAuthEndpointTests.cs
@@ -106,7 +106,7 @@ public sealed class AdminTokenAuthEndpointTests : IClassFixture<AdminTokenAuthEn
             architecture = "x64",
             protocolMinimum = 1,
             protocolMaximum = 1,
-            vmaf = 1, // VmafCapability.Cpu — this API serialises enums as integers
+            vmaf = "Cpu", // a name, not an ordinal — see WorkerEndpoints.PairRequest
             freeScratchBytes = 0L,
             maxConcurrency = 1
         });

--- a/tests/Optimisarr.Tests/WorkerHeartbeatEndpointTests.cs
+++ b/tests/Optimisarr.Tests/WorkerHeartbeatEndpointTests.cs
@@ -37,7 +37,7 @@ public sealed class WorkerHeartbeatEndpointTests
         protocolMaximum = 1,
         videoEncoders = new[] { "libx265" },
         hardwareDecoders = Array.Empty<string>(),
-        vmaf = 1,
+        vmaf = "Cpu",
         freeScratchBytes = 50L * 1024 * 1024 * 1024,
         maxConcurrency = 2,
     };
@@ -92,6 +92,58 @@ public sealed class WorkerHeartbeatEndpointTests
         var rowsAgain = await listedAgain.Content.ReadFromJsonAsync<JsonElement>();
         var revokedRow = rowsAgain.EnumerateArray().Single(w => w.GetProperty("id").GetInt32() == workerId);
         Assert.False(revokedRow.GetProperty("online").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Capabilities_cross_the_wire_as_names_not_numbers()
+    {
+        // The worker contract is consumed by separately-versioned third-party sidecars, so an
+        // enum's meaning must not depend on its ordinal. Renumbering VmafCapability would
+        // otherwise silently change what a paired worker is believed to support, and that value
+        // gates whether a job may be offered to it.
+        var admin = Admin();
+
+        using var issued = await admin.PostAsync("/api/workers/pairing-code", null);
+        var code = (await issued.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("code").GetString()!;
+
+        using var paired = await _api.CreateClient()
+            .PostAsJsonAsync("/api/workers/pair", PairBody(code, "Named capability worker"));
+        paired.EnsureSuccessStatusCode();
+        var workerId = (await paired.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("workerId").GetInt32();
+
+        using var listed = await admin.GetAsync("/api/workers");
+        var row = (await listed.Content.ReadFromJsonAsync<JsonElement>())
+            .EnumerateArray().Single(w => w.GetProperty("id").GetInt32() == workerId);
+
+        var vmaf = row.GetProperty("vmaf");
+        Assert.Equal(JsonValueKind.String, vmaf.ValueKind);
+        Assert.Equal("Cpu", vmaf.GetString());
+    }
+
+    [Fact]
+    public async Task Pairing_rejects_an_unknown_capability_name_and_says_what_is_valid()
+    {
+        var admin = Admin();
+        using var issued = await admin.PostAsync("/api/workers/pairing-code", null);
+        var code = (await issued.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("code").GetString()!;
+
+        using var response = await _api.CreateClient().PostAsJsonAsync("/api/workers/pair", new
+        {
+            code,
+            name = "Bad capability",
+            operatingSystem = "linux",
+            architecture = "x64",
+            protocolMinimum = 1,
+            protocolMaximum = 1,
+            vmaf = "gpu",
+            freeScratchBytes = 1L,
+            maxConcurrency = 1,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        // Naming the valid values matters: this contract is hand-implemented by sidecar authors.
+        Assert.Contains("Cuda", body, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -691,8 +691,11 @@ export type NotificationTestResult = {
 
 export type ArrConnectionType = 'Sonarr' | 'Radarr'
 
-/** VMAF backends a sidecar can prove. Ordered: CUDA also implies CPU. */
-export type VmafCapability = 0 | 1 | 2
+/**
+ * VMAF backends a sidecar can prove. Ordered: CUDA also implies CPU. Sent and received as a name,
+ * never an ordinal, so the worker contract cannot shift meaning if the enum is ever renumbered.
+ */
+export type VmafCapability = 'None' | 'Cpu' | 'Cuda'
 
 export type Worker = {
   id: number

--- a/web/src/lib/components/WorkersPanel.svelte
+++ b/web/src/lib/components/WorkersPanel.svelte
@@ -95,8 +95,6 @@
     }
   }
 
-  const vmafLabels = ['None', 'CPU', 'CUDA']
-
   function status(worker: Worker): { label: string; classes: string } {
     if (worker.revokedAt) {
       return {
@@ -219,7 +217,7 @@
                   {worker.operatingSystem}
                   {worker.architecture}
                   <span class="block text-xs text-slate-500 dark:text-slate-400">
-                    {t(i18n.m.workers.vmaf, { mode: vmafLabels[worker.vmaf] ?? '—' })}
+                    {t(i18n.m.workers.vmaf, { mode: worker.vmaf })}
                   </span>
                 </td>
                 <td class="px-4 py-3 text-slate-600 dark:text-slate-300">


### PR DESCRIPTION
## Outcome

Resolves the open enum question, and **corrects a claim I made in #83**.

I justified exposing `VmafCapability` directly on the worker DTOs as "matching every other enum in
this API." That was backwards. The convention is the opposite:

| Where | Wire type |
|---|---|
| `SaveArrConnectionRequest.Type` | `string?`, parsed into `ParsedArrConnection` |
| `SaveNotificationTargetRequest.Type` | `string?`, parsed into `ParsedNotificationTarget` |
| `JobDto.Status`, `.FailureCategory` | `job.Status.ToString()` |
| Calibration report | explicit `JsonStringEnumConverter` |
| **Worker DTOs** | **raw enum → integer** |

Enums already reached the wire as strings everywhere. The worker DTOs were the exception, and the
generated spec proved it: `VmafCapability` was the **only** enum schema in the whole document, and
the only one rendered `{"type": "integer"}`. It is now gone from the schema list entirely.

## Why this contract in particular

Optimisarr's own web client ships from this repository at the same version as the server, so it
cannot disagree about what `2` means. **A native tray sidecar can lag or lead by months.**

If `VmafCapability` ever gains a member — `Vulkan` between `Cpu` and `Cuda`, say — every ordinal
after it shifts. An older sidecar would then advertise a capability it does not have, and that value
**gates whether a job is offered to it**. A silently wrong capability would arrive through exactly
the side door the protocol negotiation was built to close.

## The change

`PairRequest.Vmaf` is now `string?`, parsed at the boundary with an error naming the valid values —
the same shape as the jobs endpoint's `job.status.invalid`:

> `Unknown VMAF capability 'cuda-ish'. Valid values: None, Cpu, Cuda.`

I used the parser pattern rather than a `[JsonConverter]` attribute deliberately. The attribute is
one line but yields a generic 400; for an audience hand-writing sidecar clients against a spec, a
message naming the valid values is worth the extra code.

- **Omitted means `None`** — a worker claiming no VMAF support is a real answer, not a missing one.
- **Unrecognised is refused**, so a typo cannot quietly downgrade a capable worker to `None`.
- `WorkerDto.Vmaf` is the name, which also let the web client **delete** its ordinal-indexed
  `vmafLabels` lookup in favour of the value itself.

## Verified against a running server, not just tests

- `"vmaf":"cpu"` → accepted, reads back as the JSON **string** `"Cpu"` (case normalised).
- `"vmaf":"cuda-ish"` → **400** `worker.vmaf.invalid`, listing `None, Cpu, Cuda`.
- `"vmaf":2` (the old form) → **400**. A clean break, not a silent mis-read.
- `vmaf` omitted → **200**, stored as `None`.

`Capabilities_cross_the_wire_as_names_not_numbers` asserts `JsonValueKind.String`, so the ordinal
form cannot return unnoticed.

## Breaking change

Yes, for the worker contract. Its only consumer today is a curl command in my own testing, and the
whole worker feature is still in `## Unreleased` — so no released behaviour changes and no changelog
churn is needed. The cost of this change rises steeply once a tray app ships against the old shape.

## Also corrected

The `history.md` entry that recorded the wrong reasoning now says so and points at the entry
explaining the fix, rather than being quietly rewritten.

## Verification

- `dotnet build` — **zero warnings**. `dotnet test` — **1589 passed, 0 failed**.
- `npm run check` — 0 errors, 0 warnings. `check_docs.py` and `check_openapi.py` pass.
