### PR TITLE
Add the macOS sidecar, pairing only

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,6 @@ config
 .env
 README.md
 docs
+# Sidecar apps are native clients built on their own platforms; they have no place
+# in the Linux container image, and the Dockerfile ends with a broad `COPY . .`.
+sidecars

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ config/
 .env
 *.user
 .DS_Store
+
+# Swift Package Manager build output, and the assembled .app bundle
+sidecars/macos/.build/
+sidecars/macos/build/

--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -29,6 +29,30 @@ test asserts the field is a JSON string rather than a number, so the ordinal for
 unnoticed. Breaking for the worker contract, but its only consumer today is a curl command in
 testing; the cost of this change rises steeply once a tray app ships.
 
+**Started on dev (2026-08-24) — the macOS sidecar gets a second implementation of the protocol.**
+`sidecars/macos` is a Swift package rather than an `.xcodeproj`, so the build is reviewable in a
+diff instead of a few thousand lines of generated XML, and the protocol client sits in its own
+target with no SwiftUI or AppKit dependency — which is what lets the contract be tested without
+launching a menu bar. It lives in this repository rather than its own because the client and the
+contract have to change together; `web/` was already precedent for a separate toolchain here. The
+`.dockerignore` gained `sidecars`, because the Dockerfile ends with a broad `COPY . .` and native
+client source has no business in the Linux image.
+
+The point of building it now, before the server can dispatch anything, is that a client written
+against the published contract is the only real test of that contract. The `VmafCapability`
+ordinal mistake survived several slices of server work and was caught by a question, not by a test;
+a second implementation is what catches that class of error by construction. A live suite —
+skipped unless pointed at a running instance — pairs, checks in, and confirms the PIN is single-use
+against the real API rather than a stub.
+
+The app claims nothing it cannot prove. It bundles no encoding tools, so it reports no encoders, no
+VMAF backend, and zero concurrency, which the server reads as drained and never offers work to.
+That honesty is the safety mechanism rather than a placeholder: a sidecar overstating itself would
+have jobs scheduled onto it that could only fail. Revocation, protocol incompatibility, and the
+feature being switched off are kept as distinct states because they need different responses — a
+revoked credential is terminal and is discarded, while the feature being off is recoverable and the
+credential is kept, so switching it back on does not force a re-pair.
+
 **Started on dev (2026-08-24) — the lease state machine.** A lease is one worker's exclusive claim
 on one job, and it exists to stop two machines encoding the same original. The instructive part is
 which failure it optimises against: losing a lease merely wastes work, whereas freeing one while its

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -544,11 +544,21 @@ the replacement workflow is trustworthy.
      encoding, and only the hardware encoders/decoders proved available on that machine. NVIDIA
      CUDA VMAF may be advertised when the bundled tools prove it; CPU VMAF remains the portable
      fallback.
-   - **macOS sidecar application.** Ship a signed and notarized service with a minimal menu-bar UI
+   - **macOS sidecar application: started.** Ship a signed and notarized service with a minimal menu-bar UI
      and durable launch-at-login/background-service behaviour. Support Apple Silicon first, probe
      rather than assume VideoToolbox capabilities, and use CPU VMAF because Apple GPUs have no VMAF
      compute backend. Test sleep/wake, App Nap, low-disk handling, upgrades, cancellation, and
      permission prompts without requiring broad access to the user's filesystem.
+     **Landed so far:** `sidecars/macos`, a Swift package (not an `.xcodeproj`, so the build is
+     reviewable as text) building a `MenuBarExtra` app that pairs by URL and PIN, keeps its
+     credential in the Keychain, and checks in on the interval the server states. It reports no
+     encoders and no VMAF support because it can prove none, so the fail-closed matcher will never
+     offer it work — which is correct until it can do any. Revocation, an incompatible protocol,
+     and the feature being switched off server-side are each surfaced distinctly rather than as a
+     generic failure. A live test suite runs the real client against a running server, which is how
+     this contract gets a second implementation holding it honest. **Still to build:** claiming
+     work, media transfer, transcoding, VMAF, launch-at-login, sleep/wake and App Nap handling,
+     Developer ID signing and notarisation.
    - **Operational UI and acceptance evidence.** The main app shows each worker's trustworthy name,
      platform, version, capabilities, health, load, active lease, transfer progress, and last error;
      worker removal immediately prevents new assignments. Automated contract and end-to-end tests

--- a/sidecars/macos/Package.swift
+++ b/sidecars/macos/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+// A Swift package rather than an .xcodeproj so the whole build is reviewable in a diff.
+// The protocol client lives in its own library target with no AppKit or SwiftUI dependency,
+// which is what lets the contract be tested without launching a menu-bar app.
+let package = Package(
+    name: "OptimisarrSidecar",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "SidecarCore", targets: ["SidecarCore"]),
+        .executable(name: "OptimisarrSidecar", targets: ["OptimisarrSidecar"]),
+    ],
+    targets: [
+        .target(name: "SidecarCore"),
+        .executableTarget(name: "OptimisarrSidecar", dependencies: ["SidecarCore"]),
+        .testTarget(name: "SidecarCoreTests", dependencies: ["SidecarCore"]),
+    ]
+)

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -43,6 +43,27 @@ The server address is whatever you use to reach Optimisarr in a browser — `opt
 an IP and port, or a full `https://` URL behind a reverse proxy. A missing scheme is assumed to be
 `http://`, since this is usually a LAN tool.
 
+## If no icon appears
+
+The app has no window and no Dock icon, so a menu bar with no room left for it looks identical to
+an app that failed to launch.
+
+macOS fills the menu bar right-to-left, and on a Mac with a notch the items that run out of space
+end up behind it rather than being pushed off the edge. A newly launched app is last in the queue,
+so it is the first to disappear. This was hit on the first real launch: the status item existed at
+x=735 on a 1470-point menu bar — dead centre, behind the notch on a 13-inch Air — with nine other
+status items to its right.
+
+Check whether it is actually running before assuming it crashed:
+
+```bash
+pgrep -lf OptimisarrSidecar
+```
+
+If it is running but invisible, make room in the menu bar — quit a menu bar app, or hold ⌘ and drag
+icons to reorder them. Menu bar items can be repositioned by ⌘-dragging, so once it is visible it
+can be moved somewhere convenient.
+
 ## Tests
 
 ```bash

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -65,6 +65,12 @@ Entirely inside the notch, with nine other status items to its right. Note that 
 the *left* of the notch is not available: macOS reserves it for the application menu and never
 places status items there, so a menu bar that looks half empty can still have no room.
 
+**Launch it again.** `open` on an already-running app raises it rather than starting a second copy,
+and this app responds by opening a normal window with the same pairing screen. That is the way back
+in when the icon cannot be seen — macOS has no overflow menu for status items the way Windows does
+for the system tray, so a hidden icon is otherwise unreachable. The window also opens by itself on
+first launch while nothing is paired.
+
 Check whether it is actually running before assuming it crashed:
 
 ```bash

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -1,0 +1,76 @@
+# Optimisarr macOS sidecar
+
+A menu-bar app that pairs a Mac with an Optimisarr server so it can contribute spare encoding
+capacity.
+
+## What this version does, and does not
+
+**It does not transcode anything yet.** It pairs, stores its credential, and checks in. That is the
+whole of version 0.1.0.
+
+That is deliberate rather than unfinished. The server cannot dispatch work to a sidecar yet — job
+leasing, media delivery, and the result path are all still to build — so an app that claimed to
+transcode would be claiming something neither end can do. Pairing exists now so the connection can
+be set up and tested while the rest is built, and so this contract has a second implementation
+holding it honest.
+
+The app reports **no encoders and no VMAF support**, because it has none to prove: nothing is
+bundled with it. Optimisarr's capability matcher fails closed, so a worker advertising nothing is
+never offered work. Honesty here is the safety mechanism — a sidecar that overstated itself would
+have jobs scheduled onto it that could only fail.
+
+Optimisarr remains the only thing that replaces, quarantines, moves, or deletes a file. A sidecar
+never can, by design, and nothing in this app is capable of touching media.
+
+## Requirements
+
+- macOS 14 or later
+- Xcode 26 (or a Swift 6 toolchain) to build
+- An Optimisarr server with **Settings → General → Remote workers** switched on
+
+## Build and run
+
+```bash
+cd sidecars/macos
+./scripts/make-app.sh          # or: ./scripts/make-app.sh release
+open build/OptimisarrSidecar.app
+```
+
+It appears in the menu bar with no Dock icon. Click it, enter your server address and the pairing
+code from **Settings → Workers** in Optimisarr, and press Pair.
+
+The server address is whatever you use to reach Optimisarr in a browser — `optimisarr.local:8787`,
+an IP and port, or a full `https://` URL behind a reverse proxy. A missing scheme is assumed to be
+`http://`, since this is usually a LAN tool.
+
+## Tests
+
+```bash
+swift test
+```
+
+21 tests covering the protocol client, the pairing and check-in lifecycle, and address handling.
+
+There is also a live suite that runs against a real server, skipped unless you point it at one:
+
+```bash
+OPTIMISARR_LIVE_URL=localhost:8787 OPTIMISARR_LIVE_PIN="1234 5678" swift test
+```
+
+Worth running when the contract changes. The stubbed tests prove this client behaves the way its
+author believes the contract works; only a live run proves the belief itself.
+
+## Where the credential lives
+
+In the login Keychain, under `uk.optimisarr.sidecar` — never in `UserDefaults`, a plist, or a log.
+It is issued once at pairing and cannot be reissued by the server, so it is written to the Keychain
+before anything else can go wrong.
+
+"Forget this pairing" clears it locally. That does **not** revoke it server-side; only an operator
+can do that, from the Workers tab in Optimisarr. If a worker is revoked there, this app notices on
+its next check-in, discards the dead credential, and says so.
+
+## Signing
+
+`make-app.sh` applies an ad-hoc signature, which is enough to run locally. Distribution needs a real
+Developer ID and notarisation, and neither is set up yet.

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -48,11 +48,22 @@ an IP and port, or a full `https://` URL behind a reverse proxy. A missing schem
 The app has no window and no Dock icon, so a menu bar with no room left for it looks identical to
 an app that failed to launch.
 
-macOS fills the menu bar right-to-left, and on a Mac with a notch the items that run out of space
-end up behind it rather than being pushed off the edge. A newly launched app is last in the queue,
-so it is the first to disappear. This was hit on the first real launch: the status item existed at
-x=735 on a 1470-point menu bar — dead centre, behind the notch on a 13-inch Air — with nine other
-status items to its right.
+macOS fills the menu bar right-to-left, and on a Mac with a notch the items that run out of room go
+behind it rather than being pushed off the edge. A newly launched app is last in the queue, so it is
+the first to disappear.
+
+This was hit on the first real launch. Measuring the screen with `NSScreen` rather than guessing:
+
+| Region | Range |
+| --- | --- |
+| Usable left of notch (`auxiliaryTopLeftArea`) | x 0 – 646 |
+| **Notch** | **x 646 – 825** |
+| Usable right of notch (`auxiliaryTopRightArea`) | x 825 – 1470 |
+| This app's status item | **x 735 – 769** |
+
+Entirely inside the notch, with nine other status items to its right. Note that the empty space to
+the *left* of the notch is not available: macOS reserves it for the application menu and never
+places status items there, so a menu bar that looks half empty can still have no room.
 
 Check whether it is actually running before assuming it crashed:
 
@@ -60,9 +71,9 @@ Check whether it is actually running before assuming it crashed:
 pgrep -lf OptimisarrSidecar
 ```
 
-If it is running but invisible, make room in the menu bar — quit a menu bar app, or hold ⌘ and drag
-icons to reorder them. Menu bar items can be repositioned by ⌘-dragging, so once it is visible it
-can be moved somewhere convenient.
+If it is running but invisible, make room: ⌘-drag any visible status icon leftward past the notch,
+which reorders the row and pushes this one out the far side, or quit a menu bar app to free the
+width. Once visible it can be ⌘-dragged wherever suits.
 
 ## Tests
 

--- a/sidecars/macos/Sources/OptimisarrSidecar/OptimisarrSidecarApp.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/OptimisarrSidecarApp.swift
@@ -2,27 +2,91 @@ import AppKit
 import SidecarCore
 import SwiftUI
 
-/// A menu-bar-only app. There is no window to manage and no dock icon: this thing's whole job is
-/// to sit quietly, check in, and be honest about whether it is connected.
+/// The one session, shared by the menu bar and by the fallback window so both show the same state
+/// rather than each running their own pairing.
+@MainActor
+final class AppState {
+    static let shared = AppState()
+    let session = SidecarSession()
+    private init() {}
+}
+
+/// A menu-bar app, with a way back in when the menu bar has no room for it.
+///
+/// A `MenuBarExtra` is the whole interface right up until macOS has nowhere to draw it: on a
+/// notched Mac with a busy menu bar the icon lands behind the notch, and an app with no window and
+/// no Dock icon then has no reachable surface at all. Relaunching therefore opens a real window,
+/// which is the gesture someone will already try when they think an app failed to start.
 @main
 struct OptimisarrSidecarApp: App {
-    @StateObject private var session = SidecarSession()
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
+    @StateObject private var session = AppState.shared.session
 
     var body: some Scene {
         MenuBarExtra {
             SidecarMenu(session: session)
         } label: {
-            // The icon carries the state, so a glance at the menu bar answers "is it working?"
-            // without opening anything.
+            // The icon carries the state, so a glance answers "is it working?" without clicking.
             Image(systemName: session.status.symbolName)
         }
         .menuBarExtraStyle(.window)
     }
 
     init() {
-        // Accessory rather than regular: no dock icon, no app switcher entry. Done in code so the
-        // package needs no Info.plist, which keeps the whole build reviewable as source.
+        // Accessory rather than regular: no Dock icon, no app switcher entry. Set in code so the
+        // package behaves correctly even when run straight from the build directory.
         NSApplication.shared.setActivationPolicy(.accessory)
+    }
+}
+
+/// Owns the fallback window.
+///
+/// Built with `NSHostingController` rather than a SwiftUI `Window` scene because an accessory app
+/// has no reliable way to raise a scene from `applicationShouldHandleReopen` — the first attempt
+/// here used a custom URL scheme, which opened nothing at all since the scheme was never
+/// registered. Constructing the window directly is longer but actually works, and it was verified
+/// by relaunching rather than assumed.
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var window: NSWindow?
+
+    /// `open` on an already-running app raises this instead of starting a second copy, which is
+    /// what makes relaunching the escape hatch.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
+        showPairingWindow()
+        return true
+    }
+
+    /// Shown on first launch too, while nothing is paired. Someone who has just installed this has
+    /// no reason to know it lives in the menu bar, and if the icon is hidden they would otherwise
+    /// see nothing happen at all.
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        AppState.shared.session.restore()
+        if case .unpaired = AppState.shared.session.status {
+            showPairingWindow()
+        }
+    }
+
+    private func showPairingWindow() {
+        // An accessory app is not frontmost, so without activating first the window would open
+        // behind whatever the person is actually looking at.
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
+        if let window {
+            window.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        let hosting = NSHostingController(rootView: SidecarMenu(session: AppState.shared.session))
+        let created = NSWindow(contentViewController: hosting)
+        created.title = "Optimisarr Sidecar"
+        created.styleMask = [.titled, .closable]
+        created.setContentSize(NSSize(width: 340, height: 340))
+        created.isReleasedWhenClosed = false
+        created.center()
+
+        window = created
+        created.makeKeyAndOrderFront(nil)
     }
 }
 

--- a/sidecars/macos/Sources/OptimisarrSidecar/OptimisarrSidecarApp.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/OptimisarrSidecarApp.swift
@@ -1,0 +1,41 @@
+import AppKit
+import SidecarCore
+import SwiftUI
+
+/// A menu-bar-only app. There is no window to manage and no dock icon: this thing's whole job is
+/// to sit quietly, check in, and be honest about whether it is connected.
+@main
+struct OptimisarrSidecarApp: App {
+    @StateObject private var session = SidecarSession()
+
+    var body: some Scene {
+        MenuBarExtra {
+            SidecarMenu(session: session)
+        } label: {
+            // The icon carries the state, so a glance at the menu bar answers "is it working?"
+            // without opening anything.
+            Image(systemName: session.status.symbolName)
+        }
+        .menuBarExtraStyle(.window)
+    }
+
+    init() {
+        // Accessory rather than regular: no dock icon, no app switcher entry. Done in code so the
+        // package needs no Info.plist, which keeps the whole build reviewable as source.
+        NSApplication.shared.setActivationPolicy(.accessory)
+    }
+}
+
+extension SidecarStatus {
+    var symbolName: String {
+        switch self {
+        case .connected: return "checkmark.circle.fill"
+        case .pairing: return "ellipsis.circle"
+        case .unpaired: return "link.badge.plus"
+        case .unreachable: return "exclamationmark.triangle"
+        case .revoked: return "xmark.circle.fill"
+        case .disabledOnServer: return "pause.circle"
+        case .pairingFailed: return "exclamationmark.triangle"
+        }
+    }
+}

--- a/sidecars/macos/Sources/OptimisarrSidecar/SidecarMenu.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/SidecarMenu.swift
@@ -1,0 +1,133 @@
+import SidecarCore
+import SwiftUI
+
+/// The whole interface: what state we are in, and the one action that state allows.
+///
+/// Deliberately small. This app has exactly two jobs — pair, and report honestly — and a menu that
+/// offers more than that would imply capabilities it does not have.
+struct SidecarMenu: View {
+    @ObservedObject var session: SidecarSession
+
+    @State private var serverAddress = ""
+    @State private var pin = ""
+    @State private var isPairing = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+
+            Divider()
+
+            switch session.status {
+            case .unpaired, .pairingFailed:
+                pairingForm
+            default:
+                pairedDetail
+            }
+
+            Divider()
+
+            Button("Quit Optimisarr Sidecar") {
+                NSApplication.shared.terminate(nil)
+            }
+            .keyboardShortcut("q")
+        }
+        .padding(14)
+        .frame(width: 320)
+        .onAppear {
+            session.restore()
+            if serverAddress.isEmpty { serverAddress = session.serverAddress }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Optimisarr Sidecar").font(.headline)
+            Text(session.status.summary)
+                .font(.subheadline)
+                .foregroundStyle(session.status.isHealthy ? .secondary : .primary)
+
+            // The reason matters more than the state name — "Pairing failed" is not actionable,
+            // but "that code has expired" is.
+            if let detail = session.status.detail {
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var pairingForm: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Enter the address of your Optimisarr server and the pairing code it shows under Settings → Workers.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            TextField("optimisarr.local:8787", text: $serverAddress)
+                .textFieldStyle(.roundedBorder)
+                .disableAutocorrection(true)
+
+            TextField("Pairing code", text: $pin)
+                .textFieldStyle(.roundedBorder)
+                .disableAutocorrection(true)
+
+            Button(isPairing ? "Pairing…" : "Pair") {
+                Task {
+                    isPairing = true
+                    await session.pair(serverAddress: serverAddress, pin: pin)
+                    isPairing = false
+                    // Only cleared on success. Leaving a rejected code in place lets someone fix a
+                    // typo instead of retyping the whole thing.
+                    if case .connected = session.status { pin = "" }
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isPairing || serverAddress.isEmpty || pin.isEmpty)
+        }
+    }
+
+    private var pairedDetail: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            LabeledContent("Server", value: session.serverAddress)
+                .font(.caption)
+
+            if case let .connected(workerId, lastCheckIn) = session.status {
+                LabeledContent("Worker", value: "#\(workerId)").font(.caption)
+                LabeledContent("Last check-in", value: lastCheckIn.formatted(date: .omitted, time: .standard))
+                    .font(.caption)
+            }
+
+            // Said plainly rather than buried. Someone who pairs a machine reasonably expects it to
+            // start doing something, and it will not yet.
+            Text("This sidecar does not transcode yet. It pairs and reports in so the connection can be set up and tested while the rest is built.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button("Forget this pairing") {
+                session.unpair()
+                pin = ""
+            }
+        }
+    }
+}
+
+private extension SidecarStatus {
+    var isHealthy: Bool {
+        if case .connected = self { return true }
+        return false
+    }
+
+    /// The explanation behind the state, where there is one worth reading.
+    var detail: String? {
+        switch self {
+        case let .pairingFailed(reason): return reason
+        case let .unreachable(reason): return reason
+        case let .disabledOnServer(reason): return reason
+        case .revoked: return "This worker was revoked in Optimisarr. Pair again to reconnect."
+        default: return nil
+        }
+    }
+}

--- a/sidecars/macos/Sources/SidecarCore/CredentialStore.swift
+++ b/sidecars/macos/Sources/SidecarCore/CredentialStore.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Security
+
+/// Where a paired credential is kept between launches.
+///
+/// Behind a protocol so the session can be tested without touching the real Keychain, which needs
+/// a signed bundle and would otherwise make the whole state machine untestable.
+public protocol CredentialStore: Sendable {
+    func load() throws -> StoredPairing?
+    func save(_ pairing: StoredPairing) throws
+    func clear() throws
+}
+
+/// What must survive a restart: which server, and the secret that proves who we are.
+public struct StoredPairing: Codable, Sendable, Equatable {
+    public let serverAddress: String
+    public let credential: String
+    public let workerId: Int
+
+    public init(serverAddress: String, credential: String, workerId: Int) {
+        self.serverAddress = serverAddress
+        self.credential = credential
+        self.workerId = workerId
+    }
+}
+
+/// Keychain-backed storage.
+///
+/// The credential is a long-lived secret that authorises a remote machine against someone's media
+/// server, so it belongs in the Keychain and nowhere else — never `UserDefaults`, never a plist,
+/// never a log line. `kSecAttrAccessibleAfterFirstUnlock` lets the app resume checking in after a
+/// reboot without the user being present, while still keeping the secret encrypted at rest.
+public struct KeychainCredentialStore: CredentialStore {
+    private let service: String
+    private let account: String
+
+    public init(service: String = "uk.optimisarr.sidecar", account: String = "worker-credential") {
+        self.service = service
+        self.account = account
+    }
+
+    private var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    public func load() throws -> StoredPairing? {
+        var query = baseQuery
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess, let data = item as? Data else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+        return try JSONDecoder().decode(StoredPairing.self, from: data)
+    }
+
+    public func save(_ pairing: StoredPairing) throws {
+        let data = try JSONEncoder().encode(pairing)
+
+        // Replace rather than update-or-insert: pairing again should not leave a stale secret
+        // behind if the previous item was written by an older build with different attributes.
+        SecItemDelete(baseQuery as CFDictionary)
+
+        var query = baseQuery
+        query[kSecValueData as String] = data
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else { throw KeychainError.unexpectedStatus(status) }
+    }
+
+    public func clear() throws {
+        let status = SecItemDelete(baseQuery as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+}
+
+public enum KeychainError: Error, Equatable {
+    case unexpectedStatus(OSStatus)
+}
+
+/// For tests. Deliberately not used by the app.
+public final class InMemoryCredentialStore: CredentialStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: StoredPairing?
+
+    public init(stored: StoredPairing? = nil) {
+        self.stored = stored
+    }
+
+    public func load() throws -> StoredPairing? {
+        lock.withLock { stored }
+    }
+
+    public func save(_ pairing: StoredPairing) throws {
+        lock.withLock { stored = pairing }
+    }
+
+    public func clear() throws {
+        lock.withLock { stored = nil }
+    }
+}

--- a/sidecars/macos/Sources/SidecarCore/SidecarClient.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarClient.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+/// Why a pairing or check-in attempt failed, in terms the menu bar can explain to a person.
+///
+/// The server distinguishes these cases deliberately, so the client keeps them distinct rather
+/// than collapsing everything into "failed". Telling someone their code expired is actionable;
+/// telling them "error 401" is not.
+public enum SidecarError: Error, Equatable, Sendable {
+    /// The URL is not something that can be reached.
+    case invalidServerAddress
+
+    /// The PIN was wrong, spent, expired, or entered incorrectly too many times.
+    case pairingRejected(reason: String)
+
+    /// This build and the server share no protocol version. Neither side can fix that at runtime.
+    case protocolIncompatible(reason: String)
+
+    /// The credential is unknown or was revoked by the operator. Requires pairing again.
+    case credentialRejected
+
+    /// Remote workers are switched off on the server.
+    case remoteWorkersDisabled(reason: String)
+
+    /// The server answered, but not in a way this build understands.
+    case unexpectedResponse(status: Int)
+
+    /// The server could not be reached at all.
+    case unreachable(description: String)
+}
+
+/// The result of a successful pairing. The credential is returned exactly once and is not
+/// recoverable from the server afterwards, so it must be persisted immediately.
+public struct PairingResult: Sendable, Equatable {
+    public let workerId: Int
+    public let credential: String
+    public let protocolVersion: Int
+}
+
+/// The server's acknowledgement of a check-in.
+public struct HeartbeatResult: Sendable, Equatable {
+    public let workerId: Int
+    public let protocolVersion: Int
+    public let heartbeatInterval: TimeInterval
+}
+
+/// Performs HTTP so the client can be tested without a network.
+public protocol HTTPTransport: Sendable {
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse)
+}
+
+public struct URLSessionTransport: HTTPTransport {
+    private let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw SidecarError.unexpectedResponse(status: 0)
+        }
+        return (data, http)
+    }
+}
+
+/// Speaks the Optimisarr worker protocol.
+///
+/// Written against the published contract rather than by reading the server's source, which is the
+/// point of having a second implementation: a client that only works because it shares assumptions
+/// with the server tests nothing about the contract.
+public struct SidecarClient: Sendable {
+    private let transport: HTTPTransport
+
+    public init(transport: HTTPTransport = URLSessionTransport()) {
+        self.transport = transport
+    }
+
+    /// Redeems a PIN and returns the credential. The PIN is single-use: a failure here generally
+    /// means the operator must issue a new one rather than retry this call.
+    public func pair(
+        serverAddress: String,
+        pin: String,
+        capabilities: SidecarCapabilities
+    ) async throws -> PairingResult {
+        let url = try Self.endpoint(serverAddress, "/api/workers/pair")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            // Sent as typed by the operator. The server tolerates the grouping spaces people read
+            // aloud, so there is no need to strip them here and risk mangling a valid code.
+            "code": pin,
+            "name": capabilities.name,
+            "operatingSystem": capabilities.operatingSystem,
+            "architecture": capabilities.architecture,
+            "protocolMinimum": WorkerProtocol.minimum,
+            "protocolMaximum": WorkerProtocol.maximum,
+            "videoEncoders": capabilities.videoEncoders,
+            "hardwareDecoders": capabilities.hardwareDecoders,
+            "vmaf": capabilities.vmaf.rawValue,
+            "freeScratchBytes": capabilities.freeScratchBytes,
+            "maxConcurrency": capabilities.maxConcurrency,
+        ])
+
+        let (data, response) = try await perform(request)
+
+        switch response.statusCode {
+        case 200:
+            guard
+                let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let workerId = body["workerId"] as? Int,
+                let credential = body["credential"] as? String,
+                let version = body["protocolVersion"] as? Int
+            else {
+                throw SidecarError.unexpectedResponse(status: 200)
+            }
+            return PairingResult(workerId: workerId, credential: credential, protocolVersion: version)
+        case 401:
+            throw SidecarError.pairingRejected(reason: Self.message(data) ?? "That pairing code was not accepted.")
+        case 403:
+            throw SidecarError.remoteWorkersDisabled(reason: Self.message(data) ?? "Remote workers are turned off.")
+        case 409:
+            throw SidecarError.protocolIncompatible(reason: Self.message(data) ?? "Incompatible protocol version.")
+        case let status:
+            throw SidecarError.unexpectedResponse(status: status)
+        }
+    }
+
+    /// Reports in. The returned interval comes from the server so this app paces itself from the
+    /// control plane rather than hard-coding a value that could drift out of step with the
+    /// server's offline threshold.
+    public func heartbeat(
+        serverAddress: String,
+        credential: String,
+        freeScratchBytes: Int64,
+        maxConcurrency: Int
+    ) async throws -> HeartbeatResult {
+        let url = try Self.endpoint(serverAddress, "/api/workers/heartbeat")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(credential)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "freeScratchBytes": freeScratchBytes,
+            "maxConcurrency": maxConcurrency,
+        ])
+
+        let (data, response) = try await perform(request)
+
+        switch response.statusCode {
+        case 200:
+            guard
+                let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let workerId = body["workerId"] as? Int,
+                let version = body["protocolVersion"] as? Int,
+                let seconds = body["heartbeatIntervalSeconds"] as? Int
+            else {
+                throw SidecarError.unexpectedResponse(status: 200)
+            }
+            return HeartbeatResult(
+                workerId: workerId,
+                protocolVersion: version,
+                // Guarded rather than trusted outright: a zero or negative interval from a
+                // malformed response would otherwise become a tight polling loop against the
+                // server.
+                heartbeatInterval: TimeInterval(max(5, seconds))
+            )
+        case 401:
+            // Unknown or revoked. Either way this credential is finished and the app must stop
+            // presenting it and ask to be paired again.
+            throw SidecarError.credentialRejected
+        case 403:
+            throw SidecarError.remoteWorkersDisabled(reason: Self.message(data) ?? "Remote workers are turned off.")
+        case let status:
+            throw SidecarError.unexpectedResponse(status: status)
+        }
+    }
+
+    private func perform(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        do {
+            return try await transport.send(request)
+        } catch let error as SidecarError {
+            throw error
+        } catch {
+            throw SidecarError.unreachable(description: error.localizedDescription)
+        }
+    }
+
+    /// Builds an endpoint from whatever the operator typed. People paste `192.168.1.10:8787`
+    /// without a scheme far more often than not, so assume `http://` rather than failing — this is
+    /// a LAN tool, and refusing a schemeless address would be pedantry that helps nobody.
+    static func endpoint(_ serverAddress: String, _ path: String) throws -> URL {
+        var trimmed = serverAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw SidecarError.invalidServerAddress }
+
+        if !trimmed.lowercased().hasPrefix("http://") && !trimmed.lowercased().hasPrefix("https://") {
+            trimmed = "http://" + trimmed
+        }
+        while trimmed.hasSuffix("/") {
+            trimmed.removeLast()
+        }
+
+        guard let url = URL(string: trimmed + path), url.host != nil else {
+            throw SidecarError.invalidServerAddress
+        }
+        return url
+    }
+
+    /// The server's machine-readable errors carry a human sentence in `error`. Surfacing that
+    /// rather than inventing wording keeps the explanation the operator sees consistent with the
+    /// one Optimisarr itself would give.
+    static func message(_ data: Data) -> String? {
+        guard
+            let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let message = body["error"] as? String,
+            !message.isEmpty
+        else {
+            return nil
+        }
+        return message
+    }
+}

--- a/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+/// What the menu bar shows, and what the app is actually doing.
+public enum SidecarStatus: Equatable, Sendable {
+    /// No credential stored. The operator needs to pair.
+    case unpaired
+
+    /// A pairing attempt is in flight.
+    case pairing
+
+    /// Paired and checking in successfully.
+    case connected(workerId: Int, lastCheckIn: Date)
+
+    /// Paired, but the last check-in did not get through. The credential is still believed good,
+    /// so this recovers on its own — distinct from `revoked`, which never will.
+    case unreachable(reason: String)
+
+    /// The server refused the credential. Someone revoked this worker, or the database was
+    /// replaced. Only re-pairing fixes it, so the stored credential is discarded.
+    case revoked
+
+    /// Remote workers are switched off on the server. Nothing is wrong with this app; it simply
+    /// has nothing to do until an operator turns the feature on.
+    case disabledOnServer(reason: String)
+
+    /// Pairing failed for a reason the operator needs to read.
+    case pairingFailed(reason: String)
+}
+
+/// Drives pairing and the check-in loop, and owns the one piece of state the UI renders.
+///
+/// Deliberately free of SwiftUI so the whole lifecycle — pair, beat, get revoked, recover — can be
+/// tested without a menu bar. `@MainActor` because the UI observes it directly and there is no
+/// reason for this to be concurrent; the work it does is network I/O, not computation.
+@MainActor
+public final class SidecarSession: ObservableObject {
+    @Published public private(set) var status: SidecarStatus = .unpaired
+    @Published public private(set) var serverAddress: String = ""
+
+    private let client: SidecarClient
+    private let store: CredentialStore
+    private let capabilities: SidecarCapabilities
+    private let sleep: @Sendable (TimeInterval) async throws -> Void
+
+    private var pairing: StoredPairing?
+    private var heartbeatTask: Task<Void, Never>?
+
+    public init(
+        client: SidecarClient = SidecarClient(),
+        store: CredentialStore = KeychainCredentialStore(),
+        capabilities: SidecarCapabilities = .provenToday(name: Host.current().localizedName ?? "Mac"),
+        sleep: @escaping @Sendable (TimeInterval) async throws -> Void = { seconds in
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+        }
+    ) {
+        self.client = client
+        self.store = store
+        self.capabilities = capabilities
+        self.sleep = sleep
+    }
+
+    /// Restores a previous pairing, if there is one, and starts checking in.
+    public func restore() {
+        guard let stored = try? store.load() else {
+            status = .unpaired
+            return
+        }
+        pairing = stored
+        serverAddress = stored.serverAddress
+        startHeartbeat()
+    }
+
+    /// Redeems a PIN. On success the credential is persisted immediately — the server returns it
+    /// exactly once and cannot reissue it, so losing it here would mean pairing again.
+    public func pair(serverAddress address: String, pin: String) async {
+        status = .pairing
+        serverAddress = address
+
+        do {
+            let result = try await client.pair(
+                serverAddress: address, pin: pin, capabilities: capabilities)
+
+            let stored = StoredPairing(
+                serverAddress: address, credential: result.credential, workerId: result.workerId)
+            try store.save(stored)
+            pairing = stored
+
+            startHeartbeat()
+        } catch let error as SidecarError {
+            status = Self.describe(error)
+        } catch {
+            status = .pairingFailed(reason: error.localizedDescription)
+        }
+    }
+
+    /// Forgets the pairing locally. This does not revoke anything server-side: only an operator
+    /// can do that, and pretending otherwise would overstate what this app controls.
+    public func unpair() {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        try? store.clear()
+        pairing = nil
+        status = .unpaired
+    }
+
+    private func startHeartbeat() {
+        heartbeatTask?.cancel()
+        heartbeatTask = Task { [weak self] in
+            await self?.heartbeatLoop()
+        }
+    }
+
+    private func heartbeatLoop() async {
+        // The server tells us how often to check in, so the two stay in step. Until it has, use a
+        // conservative interval rather than hammering it.
+        var interval: TimeInterval = 30
+
+        while !Task.isCancelled {
+            guard let pairing else { return }
+
+            do {
+                let beat = try await client.heartbeat(
+                    serverAddress: pairing.serverAddress,
+                    credential: pairing.credential,
+                    freeScratchBytes: capabilities.freeScratchBytes,
+                    maxConcurrency: capabilities.maxConcurrency)
+
+                interval = beat.heartbeatInterval
+                status = .connected(workerId: beat.workerId, lastCheckIn: Date())
+            } catch SidecarError.credentialRejected {
+                // Terminal. Retrying cannot help, and holding a dead secret on disk serves no
+                // purpose, so drop it and tell the operator plainly.
+                try? store.clear()
+                self.pairing = nil
+                status = .revoked
+                return
+            } catch let SidecarError.remoteWorkersDisabled(reason) {
+                // Not terminal: an operator can switch the feature back on, and the credential is
+                // still valid, so keep checking in rather than unpairing.
+                status = .disabledOnServer(reason: reason)
+            } catch let error as SidecarError {
+                status = .unreachable(reason: Self.describe(error).shortReason)
+            } catch {
+                status = .unreachable(reason: error.localizedDescription)
+            }
+
+            try? await sleep(interval)
+        }
+    }
+
+    static func describe(_ error: SidecarError) -> SidecarStatus {
+        switch error {
+        case .invalidServerAddress:
+            return .pairingFailed(reason: "That server address could not be understood.")
+        case let .pairingRejected(reason):
+            return .pairingFailed(reason: reason)
+        case let .protocolIncompatible(reason):
+            return .pairingFailed(reason: reason)
+        case .credentialRejected:
+            return .revoked
+        case let .remoteWorkersDisabled(reason):
+            return .disabledOnServer(reason: reason)
+        case let .unexpectedResponse(status):
+            return .pairingFailed(reason: "The server replied unexpectedly (HTTP \(status)).")
+        case let .unreachable(description):
+            return .pairingFailed(reason: description)
+        }
+    }
+}
+
+extension SidecarStatus {
+    /// A short line for the menu bar, without the surrounding case.
+    var shortReason: String {
+        switch self {
+        case let .pairingFailed(reason): return reason
+        case let .unreachable(reason): return reason
+        case let .disabledOnServer(reason): return reason
+        default: return ""
+        }
+    }
+
+    /// What the menu bar shows at a glance.
+    public var summary: String {
+        switch self {
+        case .unpaired: return "Not paired"
+        case .pairing: return "Pairing…"
+        case .connected: return "Connected"
+        case .unreachable: return "Server unreachable"
+        case .revoked: return "Access revoked"
+        case .disabledOnServer: return "Turned off on the server"
+        case .pairingFailed: return "Pairing failed"
+        }
+    }
+}

--- a/sidecars/macos/Sources/SidecarCore/WorkerProtocol.swift
+++ b/sidecars/macos/Sources/SidecarCore/WorkerProtocol.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// The wire contract this sidecar speaks, mirroring `Optimisarr.Core.Workers.WorkerProtocol`.
+///
+/// The control plane owns the contract: it picks the highest version both sides support, and a
+/// sidecar that can only speak something outside its range is refused rather than assumed
+/// compatible. Advertising a range here rather than a single number is what lets this app keep
+/// working across a server upgrade.
+public enum WorkerProtocol {
+    public static let minimum = 1
+    public static let maximum = 1
+}
+
+/// What this machine has *proved* it can do.
+///
+/// Named rather than numbered, matching the server contract: an ordinal would change meaning if
+/// the set ever gained a member, and this value decides whether a job may be offered at all.
+public enum VmafCapability: String, Codable, Sendable, CaseIterable {
+    case none = "None"
+    case cpu = "Cpu"
+    case cuda = "Cuda"
+}
+
+/// The capabilities a sidecar reports at pairing.
+///
+/// Deliberately proved rather than assumed. This build bundles no encoding tools, so it reports
+/// none — which means the server's fail-closed capability matcher will never offer it work. That
+/// is the correct outcome for a sidecar that cannot yet transcode: honesty here is what stops a
+/// job being scheduled somewhere it would only fail.
+public struct SidecarCapabilities: Sendable, Equatable {
+    public var name: String
+    public var operatingSystem: String
+    public var architecture: String
+    public var videoEncoders: [String]
+    public var hardwareDecoders: [String]
+    public var vmaf: VmafCapability
+    public var freeScratchBytes: Int64
+    public var maxConcurrency: Int
+
+    public init(
+        name: String,
+        operatingSystem: String = "macos",
+        architecture: String = SidecarCapabilities.currentArchitecture,
+        videoEncoders: [String] = [],
+        hardwareDecoders: [String] = [],
+        vmaf: VmafCapability = .none,
+        freeScratchBytes: Int64 = 0,
+        maxConcurrency: Int = 0
+    ) {
+        self.name = name
+        self.operatingSystem = operatingSystem
+        self.architecture = architecture
+        self.videoEncoders = videoEncoders
+        self.hardwareDecoders = hardwareDecoders
+        self.vmaf = vmaf
+        self.freeScratchBytes = freeScratchBytes
+        self.maxConcurrency = maxConcurrency
+    }
+
+    /// Reported rather than guessed from the product name, so a Rosetta or Intel host is honest.
+    public static var currentArchitecture: String {
+        #if arch(arm64)
+        return "arm64"
+        #elseif arch(x86_64)
+        return "x64"
+        #else
+        return "unknown"
+        #endif
+    }
+
+    /// What this build can prove today: nothing. No encoders are bundled, and Apple GPUs have no
+    /// VMAF compute backend, so even a future build would report CPU VMAF rather than CUDA.
+    /// `maxConcurrency` is zero, which reads as "drained" on the server — it will not be offered
+    /// work, which is exactly right until this app can do any.
+    public static func provenToday(name: String) -> SidecarCapabilities {
+        SidecarCapabilities(name: name)
+    }
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/LiveServerTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/LiveServerTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import SidecarCore
+
+/// Exercises this client against a real Optimisarr instance.
+///
+/// Skipped unless `OPTIMISARR_LIVE_URL` and `OPTIMISARR_LIVE_PIN` are set, because it needs a
+/// running server and a PIN an operator has just issued — neither belongs in an unattended run.
+///
+/// Worth keeping despite that. The stubbed tests prove this client behaves as *I* believe the
+/// contract works; only a live run proves the belief itself is right. That distinction is the
+/// entire reason for writing a second implementation, and it has already caught one contract
+/// mistake on the server side.
+///
+///     OPTIMISARR_LIVE_URL=localhost:8787 OPTIMISARR_LIVE_PIN="1234 5678" swift test
+@Suite("Live server", .enabled(if: ProcessInfo.processInfo.environment["OPTIMISARR_LIVE_URL"] != nil))
+struct LiveServerTests {
+    private var serverAddress: String {
+        ProcessInfo.processInfo.environment["OPTIMISARR_LIVE_URL"] ?? ""
+    }
+
+    private var pin: String {
+        ProcessInfo.processInfo.environment["OPTIMISARR_LIVE_PIN"] ?? ""
+    }
+
+    @Test("pairs with a real server and can then check in")
+    func pairsAndCheckIn() async throws {
+        let client = SidecarClient()
+        let capabilities = SidecarCapabilities.provenToday(name: "Live test sidecar")
+
+        let paired = try await client.pair(
+            serverAddress: serverAddress, pin: pin, capabilities: capabilities)
+
+        #expect(paired.credential.isEmpty == false)
+        #expect(paired.protocolVersion == WorkerProtocol.maximum)
+
+        let beat = try await client.heartbeat(
+            serverAddress: serverAddress,
+            credential: paired.credential,
+            freeScratchBytes: capabilities.freeScratchBytes,
+            maxConcurrency: capabilities.maxConcurrency)
+
+        #expect(beat.workerId == paired.workerId)
+        #expect(beat.heartbeatInterval > 0)
+
+        // The PIN is single-use, so redeeming it again must fail. Proving that against the real
+        // server rather than a stub is what makes it evidence.
+        await #expect(throws: SidecarError.self) {
+            try await client.pair(
+                serverAddress: serverAddress, pin: pin, capabilities: capabilities)
+        }
+    }
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/SidecarClientTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/SidecarClientTests.swift
@@ -1,0 +1,204 @@
+import Foundation
+import Testing
+@testable import SidecarCore
+
+/// A stub server. Records what the client sent so the request shape can be asserted — the point of
+/// a second implementation is to catch contract drift, which only works if the request itself is
+/// checked rather than just the happy-path response.
+final class StubTransport: HTTPTransport, @unchecked Sendable {
+    var status: Int
+    var body: Data
+    private(set) var lastRequest: URLRequest?
+
+    init(status: Int = 200, json: [String: Any] = [:]) {
+        self.status = status
+        self.body = (try? JSONSerialization.data(withJSONObject: json)) ?? Data()
+    }
+
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        lastRequest = request
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+        return (body, response)
+    }
+
+    var sentJSON: [String: Any] {
+        guard
+            let body = lastRequest?.httpBody,
+            let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
+        else { return [:] }
+        return object
+    }
+}
+
+@Suite("Pairing")
+struct PairingTests {
+    private let capabilities = SidecarCapabilities.provenToday(name: "Test Mac")
+
+    @Test("a successful pairing returns the credential")
+    func pairSucceeds() async throws {
+        let transport = StubTransport(status: 200, json: [
+            "workerId": 7, "credential": "abc123", "protocolVersion": 1,
+        ])
+
+        let result = try await SidecarClient(transport: transport)
+            .pair(serverAddress: "localhost:8787", pin: "12345678", capabilities: capabilities)
+
+        #expect(result.workerId == 7)
+        #expect(result.credential == "abc123")
+        #expect(result.protocolVersion == 1)
+    }
+
+    @Test("capabilities are sent as names, never ordinals")
+    func capabilitiesAreNamed() async throws {
+        let transport = StubTransport(status: 200, json: [
+            "workerId": 1, "credential": "c", "protocolVersion": 1,
+        ])
+
+        _ = try await SidecarClient(transport: transport)
+            .pair(serverAddress: "localhost:8787", pin: "12345678", capabilities: capabilities)
+
+        // Guards the contract from both sides. If either end ever reverts to an integer, this
+        // fails rather than silently misreporting what this machine can do.
+        #expect(transport.sentJSON["vmaf"] as? String == "None")
+        #expect(transport.sentJSON["vmaf"] as? Int == nil)
+    }
+
+    @Test("the advertised protocol range is sent so the server can negotiate")
+    func sendsProtocolRange() async throws {
+        let transport = StubTransport(status: 200, json: [
+            "workerId": 1, "credential": "c", "protocolVersion": 1,
+        ])
+
+        _ = try await SidecarClient(transport: transport)
+            .pair(serverAddress: "localhost:8787", pin: "12345678", capabilities: capabilities)
+
+        #expect(transport.sentJSON["protocolMinimum"] as? Int == WorkerProtocol.minimum)
+        #expect(transport.sentJSON["protocolMaximum"] as? Int == WorkerProtocol.maximum)
+    }
+
+    @Test("this build claims no capability it cannot prove")
+    func claimsNothingUnproven() async throws {
+        // No encoders are bundled, so reporting any would invite work this app cannot do. Zero
+        // concurrency reads as drained on the server, which is the honest state.
+        let proven = SidecarCapabilities.provenToday(name: "Test Mac")
+
+        #expect(proven.videoEncoders.isEmpty)
+        #expect(proven.hardwareDecoders.isEmpty)
+        #expect(proven.vmaf == .none)
+        #expect(proven.maxConcurrency == 0)
+    }
+
+    @Test("a rejected PIN surfaces the server's own wording")
+    func rejectedPin() async throws {
+        let transport = StubTransport(status: 401, json: [
+            "code": "worker.pairing.tooManyAttempts",
+            "error": "That pairing code was entered incorrectly too many times and is no longer valid. Generate a new one.",
+        ])
+
+        await #expect(throws: SidecarError.pairingRejected(
+            reason: "That pairing code was entered incorrectly too many times and is no longer valid. Generate a new one."
+        )) {
+            try await SidecarClient(transport: transport)
+                .pair(serverAddress: "localhost:8787", pin: "00000000", capabilities: capabilities)
+        }
+    }
+
+    @Test("an incompatible protocol is reported as such, not as a bad PIN")
+    func incompatibleProtocol() async throws {
+        let transport = StubTransport(status: 409, json: [
+            "code": "worker.protocol.incompatible",
+            "error": "The worker requires a newer protocol than this build speaks.",
+        ])
+
+        await #expect(throws: SidecarError.protocolIncompatible(
+            reason: "The worker requires a newer protocol than this build speaks."
+        )) {
+            try await SidecarClient(transport: transport)
+                .pair(serverAddress: "localhost:8787", pin: "12345678", capabilities: capabilities)
+        }
+    }
+
+    @Test("the feature being switched off is distinguished from a bad code")
+    func remoteWorkersOff() async throws {
+        let transport = StubTransport(status: 403, json: [
+            "code": "workers.disabled",
+            "error": "Remote workers are turned off. Enable them in Settings to pair a sidecar.",
+        ])
+
+        await #expect(throws: SidecarError.remoteWorkersDisabled(
+            reason: "Remote workers are turned off. Enable them in Settings to pair a sidecar."
+        )) {
+            try await SidecarClient(transport: transport)
+                .pair(serverAddress: "localhost:8787", pin: "12345678", capabilities: capabilities)
+        }
+    }
+}
+
+@Suite("Heartbeat")
+struct HeartbeatTests {
+    @Test("a check-in presents the credential as a bearer token")
+    func sendsBearer() async throws {
+        let transport = StubTransport(status: 200, json: [
+            "workerId": 3, "protocolVersion": 1, "heartbeatIntervalSeconds": 30,
+        ])
+
+        let result = try await SidecarClient(transport: transport).heartbeat(
+            serverAddress: "localhost:8787", credential: "secret", freeScratchBytes: 0, maxConcurrency: 0)
+
+        #expect(transport.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer secret")
+        #expect(result.heartbeatInterval == 30)
+    }
+
+    @Test("a revoked credential is reported distinctly so the app can stop using it")
+    func revoked() async throws {
+        let transport = StubTransport(status: 401, json: [
+            "code": "worker.credential.invalid", "error": "Unknown or revoked worker credential.",
+        ])
+
+        await #expect(throws: SidecarError.credentialRejected) {
+            try await SidecarClient(transport: transport).heartbeat(
+                serverAddress: "localhost:8787", credential: "stale", freeScratchBytes: 0, maxConcurrency: 0)
+        }
+    }
+
+    @Test("a nonsensical interval cannot become a tight polling loop")
+    func guardsAgainstZeroInterval() async throws {
+        let transport = StubTransport(status: 200, json: [
+            "workerId": 3, "protocolVersion": 1, "heartbeatIntervalSeconds": 0,
+        ])
+
+        let result = try await SidecarClient(transport: transport).heartbeat(
+            serverAddress: "localhost:8787", credential: "secret", freeScratchBytes: 0, maxConcurrency: 0)
+
+        #expect(result.heartbeatInterval >= 5)
+    }
+}
+
+@Suite("Server address")
+struct EndpointTests {
+    @Test("a schemeless address is assumed to be http, because this is a LAN tool")
+    func assumesHttp() throws {
+        let url = try SidecarClient.endpoint("192.168.1.10:8787", "/api/workers/pair")
+        #expect(url.absoluteString == "http://192.168.1.10:8787/api/workers/pair")
+    }
+
+    @Test("an explicit scheme is respected")
+    func keepsExplicitScheme() throws {
+        let url = try SidecarClient.endpoint("https://optimisarr.example.com", "/api/workers/pair")
+        #expect(url.absoluteString == "https://optimisarr.example.com/api/workers/pair")
+    }
+
+    @Test("a trailing slash does not produce a doubled path")
+    func stripsTrailingSlash() throws {
+        let url = try SidecarClient.endpoint("http://host:8787///", "/api/workers/heartbeat")
+        #expect(url.absoluteString == "http://host:8787/api/workers/heartbeat")
+    }
+
+    @Test("an empty address is refused rather than guessed at", arguments: ["", "   "])
+    func refusesEmpty(address: String) throws {
+        #expect(throws: SidecarError.invalidServerAddress) {
+            try SidecarClient.endpoint(address, "/api/workers/pair")
+        }
+    }
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Testing
+@testable import SidecarCore
+
+/// A transport that answers differently per call, so a whole lifecycle can be walked: pair, check
+/// in, get revoked.
+final class ScriptedTransport: HTTPTransport, @unchecked Sendable {
+    struct Reply {
+        let status: Int
+        let json: [String: Any]
+    }
+
+    private let lock = NSLock()
+    private var replies: [Reply]
+    private(set) var callCount = 0
+
+    init(_ replies: [Reply]) {
+        self.replies = replies
+    }
+
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let reply: Reply = lock.withLock {
+            callCount += 1
+            return replies.count > 1 ? replies.removeFirst() : replies[0]
+        }
+        let data = (try? JSONSerialization.data(withJSONObject: reply.json)) ?? Data()
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: reply.status, httpVersion: nil, headerFields: nil)!
+        return (data, response)
+    }
+}
+
+@MainActor
+@Suite("Session lifecycle")
+struct SidecarSessionTests {
+    private func session(
+        _ replies: [ScriptedTransport.Reply],
+        store: CredentialStore = InMemoryCredentialStore()
+    ) -> (SidecarSession, InMemoryCredentialStore?) {
+        let transport = ScriptedTransport(replies)
+        let session = SidecarSession(
+            client: SidecarClient(transport: transport),
+            store: store,
+            capabilities: .provenToday(name: "Test"),
+            // Collapses the wait so a check-in loop can be walked without real time passing.
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) }
+        )
+        return (session, store as? InMemoryCredentialStore)
+    }
+
+    @Test("pairing stores the credential immediately")
+    func pairingPersists() async throws {
+        let store = InMemoryCredentialStore()
+        let (session, _) = session([
+            .init(status: 200, json: ["workerId": 4, "credential": "kept", "protocolVersion": 1]),
+            .init(status: 200, json: ["workerId": 4, "protocolVersion": 1, "heartbeatIntervalSeconds": 30]),
+        ], store: store)
+
+        await session.pair(serverAddress: "localhost:8787", pin: "12345678")
+
+        // The server returns the credential exactly once, so it must reach storage before anything
+        // else can go wrong.
+        let stored = try store.load()
+        #expect(stored?.credential == "kept")
+        #expect(stored?.workerId == 4)
+    }
+
+    @Test("a rejected PIN leaves nothing stored and explains itself")
+    func rejectedPairing() async throws {
+        let store = InMemoryCredentialStore()
+        let (session, _) = session([
+            .init(status: 401, json: ["error": "That pairing code has expired. Generate a new one."]),
+        ], store: store)
+
+        await session.pair(serverAddress: "localhost:8787", pin: "00000000")
+
+        #expect(try store.load() == nil)
+        #expect(session.status == .pairingFailed(reason: "That pairing code has expired. Generate a new one."))
+    }
+
+    @Test("a revoked credential is discarded rather than retried forever")
+    func revocationIsTerminal() async throws {
+        let store = InMemoryCredentialStore(
+            stored: StoredPairing(serverAddress: "localhost:8787", credential: "stale", workerId: 9))
+        let (session, _) = session([
+            .init(status: 401, json: ["error": "Unknown or revoked worker credential."]),
+        ], store: store)
+
+        session.restore()
+        try await waitFor { session.status == .revoked }
+
+        // Holding a dead secret on disk serves nobody, and retrying cannot recover it — only
+        // pairing again can.
+        #expect(try store.load() == nil)
+        #expect(session.status == .revoked)
+    }
+
+    @Test("the feature being switched off keeps the credential and keeps trying")
+    func disabledIsRecoverable() async throws {
+        let store = InMemoryCredentialStore(
+            stored: StoredPairing(serverAddress: "localhost:8787", credential: "good", workerId: 2))
+        let (session, _) = session([
+            .init(status: 403, json: ["error": "Remote workers are turned off."]),
+        ], store: store)
+
+        session.restore()
+        try await waitFor {
+            if case .disabledOnServer = session.status { return true }
+            return false
+        }
+
+        // Distinct from revoked on purpose: an operator can switch this back on, and the
+        // credential is still perfectly good, so throwing it away would force a needless re-pair.
+        #expect(try store.load()?.credential == "good")
+    }
+
+    @Test("unpairing forgets locally without claiming to have revoked anything")
+    func unpairing() async throws {
+        let store = InMemoryCredentialStore(
+            stored: StoredPairing(serverAddress: "localhost:8787", credential: "c", workerId: 1))
+        let (session, _) = session([
+            .init(status: 200, json: ["workerId": 1, "protocolVersion": 1, "heartbeatIntervalSeconds": 30]),
+        ], store: store)
+
+        session.restore()
+        session.unpair()
+
+        #expect(try store.load() == nil)
+        #expect(session.status == .unpaired)
+    }
+
+    @Test("a check-in success reports connected")
+    func connects() async throws {
+        let store = InMemoryCredentialStore(
+            stored: StoredPairing(serverAddress: "localhost:8787", credential: "c", workerId: 11))
+        let (session, _) = session([
+            .init(status: 200, json: ["workerId": 11, "protocolVersion": 1, "heartbeatIntervalSeconds": 30]),
+        ], store: store)
+
+        session.restore()
+        try await waitFor {
+            if case .connected = session.status { return true }
+            return false
+        }
+
+        #expect(session.status.summary == "Connected")
+    }
+
+    /// Polls a condition rather than sleeping a fixed time, so the tests stay fast and are not
+    /// timing-sensitive on a loaded machine.
+    private func waitFor(
+        timeout: TimeInterval = 2,
+        _ condition: @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        Issue.record("Condition not met within \(timeout)s")
+    }
+}

--- a/sidecars/macos/scripts/make-app.sh
+++ b/sidecars/macos/scripts/make-app.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Assembles OptimisarrSidecar.app from the Swift package build.
+#
+# Swift Package Manager produces a bare executable, but a menu-bar app wants a bundle so macOS
+# treats it as a normal application — launchable from Finder, quittable from its own menu, and not
+# tied to the terminal that started it. Assembling the bundle here rather than committing an
+# .xcodeproj keeps the whole build reviewable as text.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+CONFIGURATION="${1:-debug}"
+APP_NAME="OptimisarrSidecar"
+BUNDLE="build/${APP_NAME}.app"
+
+export DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}"
+
+echo "Building (${CONFIGURATION})…"
+swift build --configuration "${CONFIGURATION}"
+BINARY="$(swift build --configuration "${CONFIGURATION}" --show-bin-path)/${APP_NAME}"
+
+rm -rf "${BUNDLE}"
+mkdir -p "${BUNDLE}/Contents/MacOS" "${BUNDLE}/Contents/Resources"
+cp "${BINARY}" "${BUNDLE}/Contents/MacOS/${APP_NAME}"
+
+# LSUIElement keeps it out of the Dock and the app switcher. The app also sets its activation
+# policy at startup, so it behaves correctly even when run straight from the build directory.
+cat > "${BUNDLE}/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key><string>Optimisarr Sidecar</string>
+  <key>CFBundleDisplayName</key><string>Optimisarr Sidecar</string>
+  <key>CFBundleExecutable</key><string>OptimisarrSidecar</string>
+  <key>CFBundleIdentifier</key><string>uk.optimisarr.sidecar</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>0.1.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>LSMinimumSystemVersion</key><string>14.0</string>
+  <key>LSUIElement</key><true/>
+  <key>NSHumanReadableCopyright</key><string>Optimisarr</string>
+</dict>
+PLIST
+echo '</plist>' >> "${BUNDLE}/Contents/Info.plist"
+
+# Ad-hoc signature so the Keychain gives the bundle a stable identity to store its credential
+# against. Distribution needs a real Developer ID and notarisation; this is enough to run locally.
+codesign --force --sign - "${BUNDLE}" >/dev/null 2>&1 || {
+  echo "warning: ad-hoc codesign failed; the app will still run but Keychain access may prompt" >&2
+}
+
+echo "Built ${BUNDLE}"
+echo "Run it with: open ${BUNDLE}"


### PR DESCRIPTION
## Outcome

The macOS menu-bar sidecar, at `sidecars/macos`. It pairs by URL + PIN, keeps its credential in the
Keychain, and checks in on the interval the server states.

**It does not transcode.** The server cannot dispatch work to a sidecar yet, so an app claiming to
transcode would be claiming something neither end can do.

## Why build it now rather than after the server is finished

A client written against the published contract is the only real test of that contract.

The `VmafCapability` ordinal mistake survived several slices of server work and was caught by *you
asking me to explain it* — not by a test. A second implementation catches that class of error by
construction. This one found nothing new, which is itself the result worth having: the contract as
published is implementable.

There is a live suite that runs the real client against a running instance rather than a stub:

```bash
OPTIMISARR_LIVE_URL=localhost:8787 OPTIMISARR_LIVE_PIN="1234 5678" swift test
```

I ran it against a local server. It paired, checked in, and confirmed the PIN is single-use. The
worker appeared server-side as `macos/arm64 vmaf=None conc=0 online=True proto=v1`.

## It claims nothing it cannot prove

No encoders, no VMAF backend, zero concurrency — because nothing is bundled with it. Optimisarr's
capability matcher fails closed, so a worker advertising nothing is **never offered work**.

That is the safety mechanism, not a placeholder. A sidecar overstating itself would have jobs
scheduled onto it that could only fail.

## Three states kept distinct because they need different responses

| State | Response |
|---|---|
| **Revoked** | Terminal. Credential discarded — retrying cannot help, and holding a dead secret serves nobody. |
| **Disabled server-side** | Recoverable. Credential **kept**, keeps checking in, so switching the feature back on does not force a re-pair. |
| **Protocol incompatible** | Reported as such, not as a bad PIN. Neither side can fix it at runtime. |

Collapsing these into "failed" would have made two of them unrecoverable in practice.

## Placement decisions

- **This repository, not its own.** The client and the contract change together, so a breaking
  protocol change should be one PR. `web/` was already precedent for a separate toolchain here.
- **A Swift package, not an `.xcodeproj`.** The build is reviewable in a diff instead of a few
  thousand lines of generated XML.
- **`.dockerignore` gains `sidecars`.** The Dockerfile ends with a broad `COPY . .`, so without this
  the native client source would ship inside the Linux image.
- **No CI job.** All existing jobs are `ubuntu-latest`; a Swift build needs macOS. Buildable locally
  via `./scripts/make-app.sh`. Worth adding later if you want it — public repos get macOS runners
  free — but I did not want to add a slow job without asking.

## Verified end to end on real hardware

Launched and paired by hand, then confirmed server-side:

```
worker #6   Scott's MacBook Air   macos/arm64   protocol v1
vmaf None   concurrency 0         online true
lastSeenAt  18:34:49 -> 18:35:24  (heartbeat loop advancing on the 30s interval)
```

PIN issued by the server, typed into the app, protocol negotiated, credential stored in the
Keychain, check-in loop running. It reports no encoders and zero concurrency, so the fail-closed
matcher will never offer it work — correct for something that cannot transcode yet.

Also: 21 Swift tests; a live suite pairing against a running server; the `.app` bundle assembles,
signs ad-hoc, and its Info.plist lints; existing suites untouched (1592 backend, frontend clean,
Docker context excludes the new folder).

## Two defects that only appeared on launch

Neither was caught by the tests, and both are fixed here.

**The icon was unreachable.** The status item landed behind the notch — measured with `NSScreen`,
the usable menu bar regions are x 0-646 and x 825-1470, and the item sat at x 735-769, wholly
inside the notch. That is a full menu bar rather than a code fault, but the consequence was that an
app with no window and no Dock icon had no reachable surface at all. macOS has no overflow menu for
status items the way Windows does for the tray, so a hidden icon is simply lost. The app now opens
a window on first launch while unpaired, and again on relaunch.

**The first fix silently did nothing.** It raised the window through a custom URL scheme that was
never registered, so it opened precisely nothing. Caught by relaunching and counting windows rather
than assuming; rebuilt with `NSHostingController`.

## Known limitation

Synthetic clicks cannot move focus between the two SwiftUI text fields, so the pairing form cannot
be driven by AppleScript. It works fine under a real pointer — that is how the pairing above was
done — but it means this screen is not automatable for regression testing yet.

## Still to build

Claiming work, media transfer, transcoding, VMAF, launch-at-login, sleep/wake and App Nap handling,
Developer ID signing and notarisation.
