### PR TITLE
Let a worker claim a job, and keep the local queue out of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
   can pair or check in, so a normal single-container install is unchanged and never has to think
   about it. Turning it back off stops check-ins immediately but keeps what is already paired, so
   nothing is lost and turning it on again restores it.
+- **Remote workers can now claim jobs.** A paired sidecar asks for work, and Optimisarr hands it one
+  job at a time, only where the worker has proved it has the encoder, VMAF support, scratch space
+  and spare concurrency the job needs. A claimed job leaves the queue so this machine will not also
+  run it, and comes straight back if the worker gives it up or goes silent. Nothing is transcoded
+  remotely yet — a worker can take a job, but the path for returning a finished file does not exist,
+  so this only has an effect once that lands.
 - **Paired sidecars now report in, and the Workers list shows whether each one is reachable.** A
   worker checks in every 30 seconds using the credential it was given at pairing, and is shown as
   offline after two minutes of silence rather than on a single missed check-in, so a brief network

--- a/docs/api.md
+++ b/docs/api.md
@@ -566,6 +566,18 @@ out of step with the threshold.
 | `POST` | `/api/workers/heartbeat` | A paired sidecar checks in and reports free scratch space and current concurrency. Open route; authenticated by the worker credential as `Authorization: Bearer`, not the admin token. `401` when the credential is absent, unknown, or revoked. |
 | `GET` | `/api/workers` | List paired workers with an `online` flag the server computes from its own liveness rule. Never returns credential fingerprints. |
 | `DELETE` | `/api/workers/{id}` | Revoke a worker. Clears its credential and drains it; keeps the record. |
+| `POST` | `/api/workers/claim` | Ask for work. Returns one assignment, or `204` when nothing matches the worker's proved capabilities — the ordinary answer, not an error. Worker credential. |
+| `POST` | `/api/workers/leases/{leaseId}/renew` | Extend a claim. `403` if the lease belongs to another worker, `409` once it has lapsed. |
+| `POST` | `/api/workers/leases/{leaseId}/release` | Give a job back. It returns to the queue immediately. |
+
+A claimed job leaves the `Queued` status for `Leased`, which is how the local queue stops seeing it:
+the dispatcher selects on `Queued`, so the exclusion is structural rather than a check a future
+query could forget. Releasing a claim, or a lease lapsing, returns the job to `Queued`.
+
+Lapsed leases are reclaimed whenever a worker asks for work, so a job whose holder went silent
+returns to the queue without a background sweeper needing to be running. A lease outlives the point
+at which its holder would be declared offline, so a job is never handed to a second worker while the
+first still counts as reachable.
 
 ## Stats
 

--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -29,6 +29,33 @@ test asserts the field is a JSON string rather than a number, so the ordinal for
 unnoticed. Breaking for the worker contract, but its only consumer today is a curl command in
 testing; the cost of this change rises steeply once a tray app ships.
 
+**Started on dev (2026-08-24) — leases become real, and a worker can claim a job.** The decision
+that carries the safety is representing a claim as a job *status* rather than a flag or a join. A
+claimed job moves from `Queued` to `Leased`, and the local dispatcher selects on `Queued`, so it
+simply stops seeing the job — no query has to remember to check for a lease, and none can be added
+later that forgets. The same reasoning as revocation being enforced by the credential lookup: make
+the exclusion structural and it cannot be omitted at a call site.
+
+Two holders is a database error rather than a possible outcome. A unique index over `JobId` filtered
+to `State = 'Held'` means a race loses at the constraint; the claim path catches that and moves to
+the next candidate instead of treating it as a failure. Lapsed leases are reclaimed at the top of
+the claim path rather than by a background sweeper, so the queue heals on the next thing that would
+have used it — a control plane that was down for an hour recovers on the first claim rather than
+waiting for a timer.
+
+Two SQLite constraints shaped the implementation, both already known here: `DateTimeOffset` cannot
+be compared or ordered in SQL, so lease expiry filtering and the queue ordering both run in memory,
+the latter over a light projection so only the shortlisted jobs are loaded with their media file.
+
+Pairing now also stamps `LastSeenAt`. Without it a freshly paired worker read as offline until its
+first heartbeat and was refused work for that window, which is wrong: pairing is itself proof we
+just heard from the machine.
+
+Adding this test class broke two unrelated setup and calibration tests, because the tokened host
+fixture is shared across the collection and these tests create libraries and jobs the others count.
+They now clean up after themselves. Worth recording as the second time shared-fixture state has
+bitten: the first was the process-wide config directory race.
+
 **Started on dev (2026-08-24) — the macOS sidecar gets a second implementation of the protocol.**
 `sidecars/macos` is a Swift package rather than an `.xcodeproj`, so the build is reviewable in a
 diff instead of a few thousand lines of generated XML, and the protocol client sits in its own

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -80,6 +80,62 @@
         ],
         "type": "object"
       },
+      "AssignmentDto": {
+        "properties": {
+          "expiresUtc": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "jobId": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "leaseId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "renewWithinSeconds": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "sourceBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "sourcePath": {
+            "type": "string"
+          },
+          "videoEncoder": {
+            "type": "string"
+          },
+          "vmaf": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "leaseId",
+          "jobId",
+          "sourcePath",
+          "sourceBytes",
+          "videoEncoder",
+          "vmaf",
+          "expiresUtc",
+          "renewWithinSeconds"
+        ],
+        "type": "object"
+      },
       "BulkReplacementFailure": {
         "properties": {
           "jobId": {
@@ -462,6 +518,23 @@
         "required": [
           "baseUrl",
           "secret"
+        ],
+        "type": "object"
+      },
+      "LeaseRenewedDto": {
+        "properties": {
+          "expiresUtc": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "leaseId": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "leaseId",
+          "expiresUtc"
         ],
         "type": "object"
       },
@@ -4533,6 +4606,36 @@
         ]
       }
     },
+    "/api/workers/claim": {
+      "post": {
+        "operationId": "ClaimWork",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignmentDto"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      }
+    },
     "/api/workers/heartbeat": {
       "post": {
         "operationId": "WorkerHeartbeat",
@@ -4552,6 +4655,78 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HeartbeatResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      }
+    },
+    "/api/workers/leases/{leaseId}/release": {
+      "post": {
+        "operationId": "ReleaseLease",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "leaseId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      }
+    },
+    "/api/workers/leases/{leaseId}/renew": {
+      "post": {
+        "operationId": "RenewLease",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "leaseId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeaseRenewedDto"
                 }
               }
             },

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -530,8 +530,15 @@ the replacement workflow is trustworthy.
      restarting after downtime cannot wake up believing a dead worker still holds a job. Renewing
      or completing a lapsed lease is refused, which is what makes a late result from a vanished
      worker unusable; release is idempotent so a worker retrying after a dropped response is not
-     punished; and no worker can touch a lease it does not hold. **Still to build:** persisting
-     leases, dispatching work against them, drain controls, and recovery after restart.
+     punished; and no worker can touch a lease it does not hold. Leases are now persisted and work is
+     dispatched against them: `POST /api/workers/claim` offers one job at a time, only where the
+     worker's proved capabilities satisfy it, and a claimed job moves from `Queued` to `Leased` so
+     the local dispatcher — which selects on `Queued` — stops seeing it. That exclusion is
+     structural rather than a check a future query could forget. A unique filtered index over held
+     leases means two holders is a database error rather than a possible outcome. Lapsed leases are
+     reclaimed whenever a worker asks for work, so recovery needs no background sweeper.
+     **Still to build:** drain controls, and returning a finished candidate — until that exists a
+     worker can take a job but not complete one.
    - **Preserve the verification boundary.** The sidecar returns the candidate, VMAF measurements,
      tool/model versions, preparation details, hashes, and captured process evidence as one result
      bound to the assignment. The main app independently re-probes the returned file and repeats the

--- a/src/Optimisarr.Api/Endpoints/WorkerEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerEndpoints.cs
@@ -79,7 +79,7 @@ internal static class WorkerEndpoints
             SettingsStore settings,
             CancellationToken cancellationToken) =>
         {
-            if (await RefusedWhenDisabledAsync(settings, cancellationToken) is { } refused)
+            if (await WorkerGate.RefusedAsync(settings, cancellationToken) is { } refused)
             {
                 return refused;
             }
@@ -119,7 +119,7 @@ internal static class WorkerEndpoints
             OptimisarrDbContext db,
             CancellationToken cancellationToken) =>
         {
-            if (await RefusedWhenDisabledAsync(settings, cancellationToken) is { } refused)
+            if (await WorkerGate.RefusedAsync(settings, cancellationToken) is { } refused)
             {
                 return refused;
             }
@@ -167,7 +167,11 @@ internal static class WorkerEndpoints
                 FreeScratchBytes = Math.Max(0, request.FreeScratchBytes),
                 MaxConcurrency = Math.Max(0, request.MaxConcurrency),
                 CredentialFingerprint = WorkerCredential.Fingerprint(credential),
-                PairedAt = DateTimeOffset.UtcNow
+                PairedAt = DateTimeOffset.UtcNow,
+                // Pairing is itself a check-in — we just heard from the machine. Without this a
+                // freshly paired worker would read as offline until its first heartbeat, and be
+                // refused work for no reason during that window.
+                LastSeenAt = DateTimeOffset.UtcNow
             };
 
             db.Workers.Add(worker);
@@ -195,7 +199,7 @@ internal static class WorkerEndpoints
         {
             // Refused before the credential is even looked at: turning the feature off must stop
             // check-ins outright, not merely stop new pairings.
-            if (await RefusedWhenDisabledAsync(settings, cancellationToken) is { } refused)
+            if (await WorkerGate.RefusedAsync(settings, cancellationToken) is { } refused)
             {
                 return refused;
             }
@@ -263,28 +267,6 @@ internal static class WorkerEndpoints
             return Results.NoContent();
         })
         .WithName("RevokeWorker");
-    }
-
-    /// <summary>
-    /// Remote workers are opt-in. Everything that pairs a machine or accepts a check-in is refused
-    /// while the feature is off, so the switch is a real boundary rather than a UI preference. The
-    /// list and revoke routes stay open: after switching off, an operator must still be able to see
-    /// what is paired and remove it.
-    /// </summary>
-    private static async Task<IResult?> RefusedWhenDisabledAsync(
-        SettingsStore settings,
-        CancellationToken cancellationToken)
-    {
-        var queue = await settings.GetQueueSettingsAsync(cancellationToken);
-        if (queue.RemoteWorkersEnabled)
-        {
-            return null;
-        }
-
-        return Results.Json(
-            new ApiError("workers.disabled",
-                "Remote workers are turned off. Enable them in Settings to pair a sidecar."),
-            statusCode: StatusCodes.Status403Forbidden);
     }
 
     private static string RedemptionMessage(PairingRedemption redemption) => redemption switch

--- a/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
@@ -1,0 +1,326 @@
+using Microsoft.EntityFrameworkCore;
+using Optimisarr.Api.Library;
+using Optimisarr.Api.Workers;
+using Optimisarr.Core.Workers;
+using Optimisarr.Data;
+
+namespace Optimisarr.Api.Endpoints;
+
+/// <summary>
+/// One job handed to one worker, with the deadline by which it must renew or lose it.
+/// The encode policy is resolved here rather than by the worker: the control plane owns the rules.
+/// </summary>
+internal sealed record AssignmentDto(
+    Guid LeaseId,
+    int JobId,
+    string SourcePath,
+    long SourceBytes,
+    string VideoEncoder,
+    string Vmaf,
+    DateTimeOffset ExpiresUtc,
+    int RenewWithinSeconds);
+
+internal sealed record LeaseRenewedDto(Guid LeaseId, DateTimeOffset ExpiresUtc);
+
+internal static class WorkerLeaseEndpoints
+{
+    public static void MapWorkerLeaseEndpoints(this WebApplication app)
+    {
+        // A worker asking for something to do. 204 when there is nothing it can run, which is the
+        // ordinary answer most of the time and not an error.
+        app.MapPost("/api/workers/claim", async (
+            HttpRequest http,
+            SettingsStore settings,
+            OptimisarrDbContext db,
+            CancellationToken cancellationToken) =>
+        {
+            if (await WorkerGate.RefusedAsync(settings, cancellationToken) is { } refused)
+            {
+                return refused;
+            }
+
+            var worker = await WorkerAuth.ResolveAsync(http, db, cancellationToken);
+            if (worker is null)
+            {
+                return WorkerGate.Unauthenticated();
+            }
+
+            var now = DateTimeOffset.UtcNow;
+
+            // Reclaim before offering. A job whose holder went away must come back to the queue,
+            // and doing it here means no separate sweeper has to be running for work to recover.
+            await ReclaimExpiredAsync(db, now, cancellationToken);
+
+            // A worker that has stopped checking in is not given new work: it may be mid-shutdown,
+            // and a job handed over now would only sit until the lease lapsed.
+            if (!WorkerLiveness.IsOnline(worker.LastSeenAt, now) || worker.RevokedAt is not null)
+            {
+                return Results.NoContent();
+            }
+
+            var held = await db.JobLeases
+                .CountAsync(lease => lease.WorkerId == worker.Id && lease.State == LeaseState.Held, cancellationToken);
+            if (held >= worker.MaxConcurrency)
+            {
+                return Results.NoContent();
+            }
+
+            var capabilities = ToCapabilities(worker);
+
+            // Ordered the same way the local dispatcher orders its own work, so a remote worker
+            // takes the job that would have run next rather than cherry-picking the easy ones.
+            //
+            // Ordering happens in memory because SQLite cannot ORDER BY a DateTimeOffset — the same
+            // constraint the dispatcher and the job date filters already work around. A light
+            // projection is ordered first so only the few jobs actually under consideration are
+            // loaded with their media file, rather than pulling a whole queue's worth of rows.
+            var queuedOrder = await db.Jobs
+                .AsNoTracking()
+                .Where(job => job.Status == JobStatus.Queued && job.Type == JobType.Normal)
+                .Select(job => new { job.Id, job.Priority, job.EnqueuedAt })
+                .ToListAsync(cancellationToken);
+
+            var shortlist = queuedOrder
+                .OrderBy(job => job.Priority)
+                .ThenBy(job => job.EnqueuedAt)
+                .Take(25)
+                .Select(job => job.Id)
+                .ToList();
+
+            if (shortlist.Count == 0)
+            {
+                return Results.NoContent();
+            }
+
+            var loaded = await db.Jobs
+                .Include(job => job.MediaFile)
+                .Where(job => shortlist.Contains(job.Id))
+                .ToListAsync(cancellationToken);
+
+            var candidates = shortlist
+                .Select(id => loaded.FirstOrDefault(job => job.Id == id))
+                .Where(job => job is not null)
+                .Select(job => job!)
+                .ToList();
+
+            foreach (var job in candidates)
+            {
+                if (job.MediaFile is null)
+                {
+                    continue;
+                }
+
+                var requirements = new JobRequirements(
+                    VideoEncoder: job.VideoEncoder ?? string.Empty,
+                    HardwareDecoder: null,
+                    Vmaf: VmafCapability.Cpu,
+                    // Scratch for the candidate plus headroom; a worker that cannot hold the output
+                    // has no business starting the encode.
+                    ScratchBytes: job.MediaFile.SizeBytes + (job.MediaFile.SizeBytes / 2));
+
+                if (!WorkerCapabilityMatcher.Match(capabilities, requirements).Accepted)
+                {
+                    continue;
+                }
+
+                var lease = WorkerLease.Acquire(Guid.NewGuid(), job.Id, worker.Id, now);
+
+                db.JobLeases.Add(new JobLease
+                {
+                    Id = lease.Id,
+                    JobId = lease.JobId,
+                    WorkerId = lease.WorkerId,
+                    AcquiredAt = lease.AcquiredUtc,
+                    ExpiresAt = lease.ExpiresUtc,
+                    State = lease.State,
+                });
+
+                // The exclusion that matters: off the queue, so this machine will not also run it.
+                job.Status = JobStatus.Leased;
+
+                try
+                {
+                    await db.SaveChangesAsync(cancellationToken);
+                }
+                catch (DbUpdateException)
+                {
+                    // Another worker claimed it in the gap. The unique index on held leases is what
+                    // makes that a database error rather than two holders, so move on and try the
+                    // next candidate rather than treating it as a failure.
+                    db.ChangeTracker.Clear();
+                    continue;
+                }
+
+                return Results.Ok(new AssignmentDto(
+                    lease.Id,
+                    job.Id,
+                    job.MediaFile.Path,
+                    job.MediaFile.SizeBytes,
+                    job.VideoEncoder ?? string.Empty,
+                    VmafCapability.Cpu.ToString(),
+                    lease.ExpiresUtc,
+                    (int)WorkerLiveness.HeartbeatInterval.TotalSeconds));
+            }
+
+            return Results.NoContent();
+        })
+        .WithName("ClaimWork")
+        .Produces<AssignmentDto>()
+        .Produces<ApiError>(StatusCodes.Status401Unauthorized);
+
+        app.MapPost("/api/workers/leases/{leaseId:guid}/renew", async (
+            Guid leaseId,
+            HttpRequest http,
+            SettingsStore settings,
+            OptimisarrDbContext db,
+            CancellationToken cancellationToken) =>
+            await MutateLeaseAsync(leaseId, http, settings, db, cancellationToken,
+                (lease, workerId, now) => lease.Renew(workerId, now),
+                (job, outcome) =>
+                {
+                    // A renewal changes nothing about the job; it still belongs to the worker.
+                },
+                lease => Results.Ok(new LeaseRenewedDto(lease.Id, lease.ExpiresUtc))))
+        .WithName("RenewLease")
+        .Produces<LeaseRenewedDto>()
+        .Produces<ApiError>(StatusCodes.Status401Unauthorized);
+
+        app.MapPost("/api/workers/leases/{leaseId:guid}/release", async (
+            Guid leaseId,
+            HttpRequest http,
+            SettingsStore settings,
+            OptimisarrDbContext db,
+            CancellationToken cancellationToken) =>
+            await MutateLeaseAsync(leaseId, http, settings, db, cancellationToken,
+                (lease, workerId, now) => lease.Release(workerId, now),
+                (job, outcome) =>
+                {
+                    // Giving a job up must never strand it, so it goes straight back on the queue
+                    // for this machine or another worker to pick up.
+                    job.Status = JobStatus.Queued;
+                },
+                _ => Results.NoContent()))
+        .WithName("ReleaseLease")
+        // Declared like the other worker routes: this is outside admin-token protection, so the
+        // document transformer will not add the 401 that an unknown or revoked credential returns.
+        .Produces<ApiError>(StatusCodes.Status401Unauthorized);
+    }
+
+    /// <summary>
+    /// The shared shape of renew and release: authenticate, load, run the domain state machine, and
+    /// persist only if it accepted. Keeping one path means neither operation can skip the ownership
+    /// check or forget to re-derive expiry.
+    /// </summary>
+    private static async Task<IResult> MutateLeaseAsync(
+        Guid leaseId,
+        HttpRequest http,
+        SettingsStore settings,
+        OptimisarrDbContext db,
+        CancellationToken cancellationToken,
+        Func<WorkerLease, int, DateTimeOffset, LeaseResult> operation,
+        Action<Job, LeaseOutcome> applyToJob,
+        Func<WorkerLease, IResult> success)
+    {
+        if (await WorkerGate.RefusedAsync(settings, cancellationToken) is { } refused)
+        {
+            return refused;
+        }
+
+        var worker = await WorkerAuth.ResolveAsync(http, db, cancellationToken);
+        if (worker is null)
+        {
+            return WorkerGate.Unauthenticated();
+        }
+
+        var stored = await db.JobLeases
+            .Include(lease => lease.Job)
+            .FirstOrDefaultAsync(lease => lease.Id == leaseId, cancellationToken);
+
+        if (stored is null)
+        {
+            return ApiErrors.NotFound("worker.lease.notFound", $"No lease with id {leaseId}.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var result = operation(stored.ToDomain(), worker.Id, now);
+
+        switch (result.Outcome)
+        {
+            case LeaseOutcome.NotHolder:
+                // Deliberately 403 rather than 404: the lease exists, this worker simply does not
+                // hold it. Pretending it is missing would make a genuine bug harder to diagnose.
+                return Results.Json(
+                    new ApiError("worker.lease.notHolder", "That lease belongs to another worker."),
+                    statusCode: StatusCodes.Status403Forbidden);
+
+            case LeaseOutcome.Expired:
+                return ApiErrors.Conflict("worker.lease.expired",
+                    "That lease has expired and the job may have been reassigned.");
+
+            case LeaseOutcome.NotHeld:
+                return ApiErrors.Conflict("worker.lease.notHeld", "That lease is no longer held.");
+        }
+
+        stored.Apply(result.Lease);
+        if (stored.Job is not null)
+        {
+            applyToJob(stored.Job, result.Outcome);
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+        return success(result.Lease);
+    }
+
+    /// <summary>
+    /// Returns jobs whose holders went silent. Run whenever a worker asks for work, so recovery
+    /// needs no background sweeper — the queue heals on the next thing that would have used it.
+    /// </summary>
+    private static async Task ReclaimExpiredAsync(
+        OptimisarrDbContext db,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        // The state filter runs in the database; the expiry comparison does not. SQLite cannot
+        // order or compare a DateTimeOffset, which is the same reason the job date filters evaluate
+        // in memory. Held leases are few, so pulling them and filtering here is cheap.
+        var held = await db.JobLeases
+            .Include(lease => lease.Job)
+            .Where(lease => lease.State == LeaseState.Held)
+            .ToListAsync(cancellationToken);
+
+        var lapsed = held.Where(lease => lease.ExpiresAt <= now).ToList();
+
+        if (lapsed.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var lease in lapsed)
+        {
+            lease.State = LeaseState.Expired;
+
+            // Only a job still sitting in Leased is ours to hand back. One that moved on — because
+            // an operator cancelled it, say — must not be dragged back onto the queue.
+            if (lease.Job is { Status: JobStatus.Leased } job)
+            {
+                job.Status = JobStatus.Queued;
+            }
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    private static WorkerCapabilities ToCapabilities(Worker worker) => new(
+        worker.OperatingSystem,
+        worker.Architecture,
+        Split(worker.VideoEncoders),
+        Split(worker.HardwareDecoders),
+        worker.Vmaf,
+        worker.FreeScratchBytes,
+        worker.MaxConcurrency);
+
+    private static IReadOnlyList<string> Split(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? []
+            : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}

--- a/src/Optimisarr.Api/Program.cs
+++ b/src/Optimisarr.Api/Program.cs
@@ -230,6 +230,8 @@ app.MapReplacementEndpoints();
 
 app.MapWorkerEndpoints();
 
+app.MapWorkerLeaseEndpoints();
+
 app.MapHub<JobsHub>("/hubs/jobs");
 
 app.MapFallbackToFile("index.html", staticFileOptions);

--- a/src/Optimisarr.Api/Security/AdminTokenAuth.cs
+++ b/src/Optimisarr.Api/Security/AdminTokenAuth.cs
@@ -23,7 +23,12 @@ public static class AdminTokenAuth
         // Likewise for a paired sidecar checking in. It authenticates with its own 32-byte
         // credential, which is a stronger secret than the admin token and authorises only the
         // worker routes; a revoked worker fails here because its stored fingerprint is gone.
-        || path.Equals("/api/workers/heartbeat", StringComparison.OrdinalIgnoreCase);
+        || path.Equals("/api/workers/heartbeat", StringComparison.OrdinalIgnoreCase)
+        // Claiming work and managing a claim are likewise worker-credential routes. The lease ones
+        // carry an id, so they are matched by segment rather than exact equality — and deliberately
+        // scoped to /leases so this cannot widen to the whole /api/workers surface by accident.
+        || path.Equals("/api/workers/claim", StringComparison.OrdinalIgnoreCase)
+        || path.StartsWithSegments("/api/workers/leases", StringComparison.OrdinalIgnoreCase);
 
     public static bool IsProtectedPath(PathString path) =>
         path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase)

--- a/src/Optimisarr.Api/Workers/WorkerGate.cs
+++ b/src/Optimisarr.Api/Workers/WorkerGate.cs
@@ -1,0 +1,36 @@
+using Optimisarr.Api.Endpoints;
+using Optimisarr.Api.Library;
+
+namespace Optimisarr.Api.Workers;
+
+/// <summary>
+/// The two checks every worker-facing route shares: is the feature on, and is the caller a worker.
+///
+/// Shared rather than repeated so a new route cannot accidentally ship without the opt-in gate —
+/// the switch is only a real boundary if nothing can be added that forgets it.
+/// </summary>
+internal static class WorkerGate
+{
+    /// <summary>Non-null when the request must be refused because remote workers are switched off.</summary>
+    public static async Task<IResult?> RefusedAsync(
+        SettingsStore settings,
+        CancellationToken cancellationToken)
+    {
+        var queue = await settings.GetQueueSettingsAsync(cancellationToken);
+        if (queue.RemoteWorkersEnabled)
+        {
+            return null;
+        }
+
+        return Results.Json(
+            new ApiError("workers.disabled",
+                "Remote workers are turned off. Enable them in Settings to pair a sidecar."),
+            statusCode: StatusCodes.Status403Forbidden);
+    }
+
+    /// <summary>Covers absent, malformed, unknown, and revoked credentials alike.</summary>
+    public static IResult Unauthenticated() =>
+        Results.Json(
+            new ApiError("worker.credential.invalid", "Unknown or revoked worker credential."),
+            statusCode: StatusCodes.Status401Unauthorized);
+}

--- a/src/Optimisarr.Data/Job.cs
+++ b/src/Optimisarr.Data/Job.cs
@@ -17,7 +17,16 @@ public enum JobStatus
     ReadyToReplace = 4,
     Completed = 5,
     Failed = 6,
-    Cancelled = 7
+    Cancelled = 7,
+
+    /// <summary>
+    /// Claimed by a remote worker and being transcoded off this machine.
+    ///
+    /// A distinct status rather than a flag or a join, so the local dispatcher — which selects on
+    /// <see cref="Queued"/> — cannot pick the job up as well. The exclusion is then structural: a
+    /// future query cannot forget to check for a lease, because a leased job simply is not queued.
+    /// </summary>
+    Leased = 8
 }
 
 /// <summary>

--- a/src/Optimisarr.Data/JobLease.cs
+++ b/src/Optimisarr.Data/JobLease.cs
@@ -1,0 +1,43 @@
+using Optimisarr.Core.Workers;
+
+namespace Optimisarr.Data;
+
+/// <summary>
+/// A remote worker's exclusive claim on one job.
+///
+/// The persisted half of <see cref="WorkerLease"/>. Expiry is stored so it survives a restart, but
+/// it is always re-derived through the domain type when read: a lease past its expiry is expired
+/// the moment it is looked at, whether or not anything has swept it.
+///
+/// The claim is enforced by the job's own status rather than by this row. A leased job leaves
+/// <see cref="JobStatus.Queued"/>, so the local dispatcher stops seeing it — the exclusion cannot
+/// be forgotten by a query that neglects to join here.
+/// </summary>
+public sealed class JobLease
+{
+    public Guid Id { get; set; }
+
+    public int JobId { get; set; }
+
+    public Job? Job { get; set; }
+
+    public int WorkerId { get; set; }
+
+    public Worker? Worker { get; set; }
+
+    public DateTimeOffset AcquiredAt { get; set; }
+
+    public DateTimeOffset ExpiresAt { get; set; }
+
+    public LeaseState State { get; set; } = LeaseState.Held;
+
+    /// <summary>Rebuilds the domain lease so every decision runs through one state machine.</summary>
+    public WorkerLease ToDomain() =>
+        new(Id, JobId, WorkerId, AcquiredAt, ExpiresAt, State);
+
+    public void Apply(WorkerLease lease)
+    {
+        ExpiresAt = lease.ExpiresUtc;
+        State = lease.State;
+    }
+}

--- a/src/Optimisarr.Data/Migrations/20260824184344_AddJobLeases.Designer.cs
+++ b/src/Optimisarr.Data/Migrations/20260824184344_AddJobLeases.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Optimisarr.Data;
 
@@ -10,9 +11,11 @@ using Optimisarr.Data;
 namespace Optimisarr.Data.Migrations
 {
     [DbContext(typeof(OptimisarrDbContext))]
-    partial class OptimisarrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824184344_AddJobLeases")]
+    partial class AddJobLeases
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/src/Optimisarr.Data/Migrations/20260824184344_AddJobLeases.cs
+++ b/src/Optimisarr.Data/Migrations/20260824184344_AddJobLeases.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Optimisarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddJobLeases : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "JobLeases",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    JobId = table.Column<int>(type: "INTEGER", nullable: false),
+                    WorkerId = table.Column<int>(type: "INTEGER", nullable: false),
+                    AcquiredAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    State = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_JobLeases", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_JobLeases_Jobs_JobId",
+                        column: x => x.JobId,
+                        principalTable: "Jobs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_JobLeases_Workers_WorkerId",
+                        column: x => x.WorkerId,
+                        principalTable: "Workers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JobLeases_JobId",
+                table: "JobLeases",
+                column: "JobId",
+                unique: true,
+                filter: "\"State\" = 'Held'");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JobLeases_WorkerId",
+                table: "JobLeases",
+                column: "WorkerId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "JobLeases");
+        }
+    }
+}

--- a/src/Optimisarr.Data/OptimisarrDbContext.cs
+++ b/src/Optimisarr.Data/OptimisarrDbContext.cs
@@ -24,6 +24,8 @@ public sealed class OptimisarrDbContext(DbContextOptions<OptimisarrDbContext> op
 
     public DbSet<Worker> Workers => Set<Worker>();
 
+    public DbSet<JobLease> JobLeases => Set<JobLease>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<AppSetting>(entity =>
@@ -176,6 +178,33 @@ public sealed class OptimisarrDbContext(DbContextOptions<OptimisarrDbContext> op
             // Every authenticated worker call arrives with a credential and no id, so the
             // fingerprint is the lookup key. Unique because two workers must never share one.
             entity.HasIndex(worker => worker.CredentialFingerprint).IsUnique();
+        });
+
+        modelBuilder.Entity<JobLease>(entity =>
+        {
+            entity.HasKey(lease => lease.Id);
+            entity.Property(lease => lease.State).HasConversion<string>().HasMaxLength(32);
+
+            // Removing a job removes its leases; a lease without a job claims nothing.
+            entity.HasOne(lease => lease.Job)
+                .WithMany()
+                .HasForeignKey(lease => lease.JobId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // A worker row is kept after revocation for the audit trail, so its leases are kept too
+            // rather than cascading away the record of what it once held.
+            entity.HasOne(lease => lease.Worker)
+                .WithMany()
+                .HasForeignKey(lease => lease.WorkerId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            // Two workers must never hold the same job. Enforced in the schema rather than trusted
+            // to the claim path, so a race or a future call site cannot produce a second holder.
+            entity.HasIndex(lease => lease.JobId)
+                .IsUnique()
+                .HasFilter("\"State\" = 'Held'");
+
+            entity.HasIndex(lease => lease.WorkerId);
         });
     }
 }

--- a/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
+++ b/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
@@ -1,0 +1,294 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Optimisarr.Data;
+
+namespace Optimisarr.Tests;
+
+/// <summary>
+/// Claiming work is the first point a remote machine affects the local queue, so the property that
+/// matters most is not that claiming works — it is that a claimed job stops being runnable here.
+/// Two encoders on one original is the failure this whole mechanism exists to prevent.
+/// </summary>
+[Collection(TokenedApiCollection.Name)]
+public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
+{
+    private readonly AdminTokenAuthEndpointTests.TokenedApi _api;
+    private readonly List<int> _createdLibraries = [];
+
+    public WorkerLeaseEndpointTests(AdminTokenAuthEndpointTests.TokenedApi api) => _api = api;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// Removes the libraries these tests create. The host fixture is shared across the collection,
+    /// so rows left behind here change what other tests in it see — adding this class initially
+    /// broke two unrelated setup and calibration tests that count jobs. Deleting the library
+    /// cascades to its media files and their jobs.
+    /// </summary>
+    public async Task DisposeAsync()
+    {
+        if (_createdLibraries.Count == 0) return;
+
+        using var scope = _api.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
+
+        // Leases restrict deletion of their worker but cascade from the job, so clear them first.
+        var jobIds = await db.Jobs
+            .Where(job => job.LibraryId != null && _createdLibraries.Contains(job.LibraryId.Value))
+            .Select(job => job.Id)
+            .ToListAsync();
+        db.JobLeases.RemoveRange(db.JobLeases.Where(lease => jobIds.Contains(lease.JobId)));
+        await db.SaveChangesAsync();
+
+        db.Libraries.RemoveRange(db.Libraries.Where(library => _createdLibraries.Contains(library.Id)));
+        await db.SaveChangesAsync();
+    }
+
+    private HttpClient Admin()
+    {
+        var client = _api.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", AdminTokenAuthEndpointTests.TokenedApi.Token);
+        return client;
+    }
+
+    private async Task EnableRemoteWorkers()
+    {
+        var admin = Admin();
+        var current = await (await admin.GetAsync("/api/settings")).Content.ReadFromJsonAsync<JsonElement>();
+        using var doc = JsonDocument.Parse(current.GetRawText());
+        var payload = new Dictionary<string, object?>();
+        foreach (var property in doc.RootElement.EnumerateObject())
+        {
+            payload[property.Name] = JsonSerializer.Deserialize<object?>(property.Value.GetRawText());
+        }
+        payload["remoteWorkersEnabled"] = true;
+        (await admin.PutAsJsonAsync("/api/settings", payload)).EnsureSuccessStatusCode();
+    }
+
+    /// <summary>Pairs a worker that can actually satisfy a job, and returns its credential.</summary>
+    private async Task<HttpClient> PairCapableWorker(string name, int concurrency = 1)
+    {
+        var admin = Admin();
+        var issued = await admin.PostAsync("/api/workers/pairing-code", null);
+        issued.EnsureSuccessStatusCode();
+        var pin = (await issued.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("code").GetString()!;
+
+        var paired = await _api.CreateClient().PostAsJsonAsync("/api/workers/pair", new
+        {
+            code = pin,
+            name,
+            operatingSystem = "linux",
+            architecture = "x64",
+            protocolMinimum = 1,
+            protocolMaximum = 1,
+            videoEncoders = new[] { "libx265" },
+            hardwareDecoders = Array.Empty<string>(),
+            vmaf = "Cpu",
+            freeScratchBytes = 500L * 1024 * 1024 * 1024,
+            maxConcurrency = concurrency,
+        });
+        paired.EnsureSuccessStatusCode();
+        var credential = (await paired.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("credential").GetString()!;
+
+        var worker = _api.CreateClient();
+        worker.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential);
+        return worker;
+    }
+
+    /// <summary>Puts one queued job in front of the workers and returns its id.</summary>
+    private async Task<int> QueueAJob()
+    {
+        using var scope = _api.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
+
+        var library = new Library { Name = "Leases", Path = Path.Combine(_api.LibraryDirectory, Guid.NewGuid().ToString("N")) };
+        db.Libraries.Add(library);
+        await db.SaveChangesAsync();
+        _createdLibraries.Add(library.Id);
+
+        var file = new MediaFile
+        {
+            LibraryId = library.Id,
+            Path = Path.Combine(library.Path, "film.mkv"),
+            RelativePath = "film.mkv",
+            SizeBytes = 8L * 1024 * 1024 * 1024,
+        };
+        db.MediaFiles.Add(file);
+        await db.SaveChangesAsync();
+
+        var job = new Job
+        {
+            MediaFileId = file.Id,
+            LibraryId = library.Id,
+            Status = JobStatus.Queued,
+            Type = JobType.Normal,
+            VideoEncoder = "libx265",
+        };
+        db.Jobs.Add(job);
+        await db.SaveChangesAsync();
+        return job.Id;
+    }
+
+    private async Task<JobStatus> StatusOf(int jobId)
+    {
+        using var scope = _api.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
+        return (await db.Jobs.FindAsync(jobId))!.Status;
+    }
+
+    [Fact]
+    public async Task A_claimed_job_stops_being_queued_so_this_machine_cannot_run_it_too()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Claimer");
+        var jobId = await QueueAJob();
+
+        using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.OK, claim.StatusCode);
+        var assignment = await claim.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(jobId, assignment.GetProperty("jobId").GetInt32());
+        // The whole point: the local dispatcher selects on Queued, so leaving that status is what
+        // stops two encoders working the same original.
+        Assert.Equal(JobStatus.Leased, await StatusOf(jobId));
+    }
+
+    [Fact]
+    public async Task A_second_worker_is_not_offered_a_job_someone_already_holds()
+    {
+        await EnableRemoteWorkers();
+        var first = await PairCapableWorker("First");
+        var second = await PairCapableWorker("Second");
+        await QueueAJob();
+
+        using var firstClaim = await first.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.OK, firstClaim.StatusCode);
+
+        using var secondClaim = await second.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.NoContent, secondClaim.StatusCode);
+    }
+
+    [Fact]
+    public async Task Releasing_a_claim_puts_the_job_back_in_the_queue()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Releaser");
+        var jobId = await QueueAJob();
+
+        var assignment = await (await worker.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+
+        using var released = await worker.PostAsJsonAsync($"/api/workers/leases/{leaseId}/release", new { });
+        Assert.Equal(HttpStatusCode.NoContent, released.StatusCode);
+
+        // Back on the queue, runnable here or by another worker. Giving a job up must never strand
+        // it.
+        Assert.Equal(JobStatus.Queued, await StatusOf(jobId));
+    }
+
+    [Fact]
+    public async Task A_worker_cannot_touch_a_lease_it_does_not_hold()
+    {
+        await EnableRemoteWorkers();
+        var holder = await PairCapableWorker("Holder");
+        var intruder = await PairCapableWorker("Intruder");
+        await QueueAJob();
+
+        var assignment = await (await holder.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+
+        using var stolenRenew = await intruder.PostAsJsonAsync($"/api/workers/leases/{leaseId}/renew", new { });
+        using var stolenRelease = await intruder.PostAsJsonAsync($"/api/workers/leases/{leaseId}/release", new { });
+
+        Assert.Equal(HttpStatusCode.Forbidden, stolenRenew.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, stolenRelease.StatusCode);
+    }
+
+    [Fact]
+    public async Task Renewing_extends_the_claim()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Renewer");
+        await QueueAJob();
+
+        var assignment = await (await worker.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+        var firstExpiry = assignment.GetProperty("expiresUtc").GetDateTimeOffset();
+
+        await Task.Delay(1100);
+        using var renewed = await worker.PostAsJsonAsync($"/api/workers/leases/{leaseId}/renew", new { });
+        Assert.Equal(HttpStatusCode.OK, renewed.StatusCode);
+
+        var extended = (await renewed.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("expiresUtc").GetDateTimeOffset();
+        Assert.True(extended > firstExpiry, $"expiry did not move: {firstExpiry} -> {extended}");
+    }
+
+    [Fact]
+    public async Task A_worker_advertising_nothing_is_never_offered_work()
+    {
+        await EnableRemoteWorkers();
+        await QueueAJob();
+
+        // The pairing-only sidecar reports no encoders and zero concurrency. The matcher fails
+        // closed, so it must be offered nothing rather than handed a job it cannot run.
+        var admin = Admin();
+        var pin = (await (await admin.PostAsync("/api/workers/pairing-code", null))
+            .Content.ReadFromJsonAsync<JsonElement>()).GetProperty("code").GetString()!;
+        var paired = await _api.CreateClient().PostAsJsonAsync("/api/workers/pair", new
+        {
+            code = pin,
+            name = "Incapable",
+            operatingSystem = "macos",
+            architecture = "arm64",
+            protocolMinimum = 1,
+            protocolMaximum = 1,
+            vmaf = "None",
+            freeScratchBytes = 0L,
+            maxConcurrency = 0,
+        });
+        paired.EnsureSuccessStatusCode();
+        var credential = (await paired.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("credential").GetString()!;
+
+        var incapable = _api.CreateClient();
+        incapable.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential);
+
+        using var claim = await incapable.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.NoContent, claim.StatusCode);
+    }
+
+    [Fact]
+    public async Task Claiming_is_refused_while_remote_workers_are_switched_off()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Switched off");
+
+        var admin = Admin();
+        var current = await (await admin.GetAsync("/api/settings")).Content.ReadFromJsonAsync<JsonElement>();
+        using (var doc = JsonDocument.Parse(current.GetRawText()))
+        {
+            var payload = new Dictionary<string, object?>();
+            foreach (var property in doc.RootElement.EnumerateObject())
+            {
+                payload[property.Name] = JsonSerializer.Deserialize<object?>(property.Value.GetRawText());
+            }
+            payload["remoteWorkersEnabled"] = false;
+            (await admin.PutAsJsonAsync("/api/settings", payload)).EnsureSuccessStatusCode();
+        }
+
+        using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.Forbidden, claim.StatusCode);
+
+        await EnableRemoteWorkers();
+    }
+}


### PR DESCRIPTION
## Outcome

Seventh slice of roadmap item 9. `POST /api/workers/claim` offers one job at a time, with
`renew` and `release` alongside. This is the first point a remote machine affects the local queue.

## The decision that carries the safety

**A claim is a job status, not a flag or a join.** A claimed job moves `Queued` → `Leased`, and the
local dispatcher selects on `Queued` — so it simply stops seeing the job.

That makes the exclusion **structural**. No query has to remember to check for a lease, and none can
be added later that forgets. Same reasoning as revocation being enforced by the credential lookup
rather than a separate `is it revoked?` check that a future call site could omit.

The alternative — a `LeasedBy` column, or joining leases into the dispatcher query — would have
worked today and been one forgotten `WHERE` away from two encoders on one original.

## Two holders is a database error, not a race

```
CREATE UNIQUE INDEX IX_JobLeases_JobId ON JobLeases (JobId) WHERE "State" = 'Held';
```

A concurrent claim loses at the constraint. The claim path catches `DbUpdateException` and moves to
the next candidate rather than treating it as a failure — the losing worker just gets a different
job.

## Recovery without a sweeper

Lapsed leases are reclaimed at the top of the claim path, not by a background timer. A control plane
that was down for an hour recovers on the first claim rather than waiting for a tick. Reclaim only
touches jobs still sitting in `Leased`, so one an operator cancelled meanwhile is not dragged back
onto the queue.

## Also fixed here

**Pairing now stamps `LastSeenAt`.** Without it a freshly paired worker read as *offline* until its
first heartbeat and was refused work for that window — wrong, since pairing is itself proof we just
heard from the machine.

## Two SQLite constraints, both already known in this repo

`DateTimeOffset` cannot be compared or ordered in SQL. Lease expiry filtering and the queue ordering
therefore run in memory — the latter over a light `{Id, Priority, EnqueuedAt}` projection, so only
the shortlisted jobs are loaded with their media file rather than pulling a whole queue's worth of
rows with includes.

## A test-infrastructure problem this exposed

Adding this test class **broke two unrelated setup and calibration tests**. The tokened host fixture
is shared across the collection, and these tests create libraries and jobs that the others count.
They now clean up after themselves in `DisposeAsync`.

That is the second time shared-fixture state has bitten — the first was the process-wide config
directory race in #88. Worth knowing if more endpoint tests get added.

## Safety

**Nothing can be returned yet.** A worker can take a job but not complete one, because the result
path does not exist. The blast radius of that is bounded by the lease: an unfinished claim lapses
and the job returns to the queue. Optimisarr remains the only thing that replaces, quarantines,
moves, or deletes a file.

## Verification

- `dotnet test` — **1599 passed, 0 failed**, stable over three consecutive runs.
- `dotnet build` — zero warnings. `npm run check` — 0 errors, 0 warnings.
- OpenAPI regenerated. While reviewing it I noticed `release` was the one worker route without a
  documented `401` and fixed it; all ten worker operations now declare it.
- `check_docs.py` caught that I had written `{id}` where the spec says `{leaseId}`.

## Still to build

Drain controls, media delivery, and the result path — where a returned candidate must be re-probed
and re-gated locally before it can go anywhere near a replacement.