### PR TITLE
Let a worker fetch the file it was given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   can pair or check in, so a normal single-container install is unchanged and never has to think
   about it. Turning it back off stops check-ins immediately but keeps what is already paired, so
   nothing is lost and turning it on again restores it.
+- **A remote worker can now download the file it has been given.** Transfers resume where they left
+  off if the connection drops, and come with a checksum so the worker can confirm it received the
+  file intact. A worker can only ever fetch the exact original it was assigned, and only while it
+  still holds the job.
 - **Remote workers can now claim jobs.** A paired sidecar asks for work, and Optimisarr hands it one
   job at a time, only where the worker has proved it has the encoder, VMAF support, scratch space
   and spare concurrency the job needs. A claimed job leaves the queue so this machine will not also

--- a/docs/api.md
+++ b/docs/api.md
@@ -569,6 +569,13 @@ out of step with the threshold.
 | `POST` | `/api/workers/claim` | Ask for work. Returns one assignment, or `204` when nothing matches the worker's proved capabilities — the ordinary answer, not an error. Worker credential. |
 | `POST` | `/api/workers/leases/{leaseId}/renew` | Extend a claim. `403` if the lease belongs to another worker, `409` once it has lapsed. |
 | `POST` | `/api/workers/leases/{leaseId}/release` | Give a job back. It returns to the queue immediately. |
+| `GET` | `/api/workers/leases/{leaseId}/source` | Stream the source for a held lease. Supports `Range` for resumable transfer, and returns `X-Optimisarr-Source-Sha256` so the worker can verify what it received. |
+
+The source route takes no path, filename, or library parameter, by design. A worker presents a lease
+id and the server resolves the file from it, so a paired sidecar can only ever read the exact
+original the control plane already assigned to it — there is no shape of request that reads anything
+else. The original is opened shared and read-only, and access ends the moment the lease stops being
+held, so releasing a job also ends the worker's reach into the library.
 
 A claimed job leaves the `Queued` status for `Leased`, which is how the local queue stops seeing it:
 the dispatcher selects on `Queued`, so the exclusion is structural rather than a check a future

--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -29,6 +29,27 @@ test asserts the field is a JSON string rather than a number, so the ordinal for
 unnoticed. Breaking for the worker contract, but its only consumer today is a curl command in
 testing; the cost of this change rises steeply once a tray app ships.
 
+**Started on dev (2026-08-24) — the sidecar can work out what it is actually capable of.** Probing
+mirrors the server's `HardwareCapabilityService` rather than inventing a second approach: parse
+`ffmpeg -encoders` for a cheap first pass, then confirm each hardware encoder with a real throwaway
+encode to the null muxer. The distinction matters more on Apple than elsewhere, because every macOS
+ffmpeg build lists VideoToolbox whether or not the machine in front of you can open it — listing
+alone would have the sidecar advertise encoders that fail on first use, and a job scheduled against
+a false capability can only fail. CPU encoders are trusted from the listing, as the server trusts
+them.
+
+VMAF can only ever be CPU here. Apple GPUs have no VMAF compute backend, so a test asserts the
+parser can never return `Cuda` — guarding the honesty of the capability rather than the parsing.
+
+A worker with no encoder reports zero concurrency too. Advertising capacity while advertising no
+encoder would show the server a live worker it can never actually use.
+
+ffmpeg will be bundled in the app rather than found on the system, so the worker's build matches the
+server's. The roadmap already treats FFmpeg build as a scheduling criterion, and the reason becomes
+concrete here: the server re-verifies a returned candidate, which only means something if the same
+encode settings produce comparable output at both ends. Nothing is bundled yet — the probing reports
+nothing without it, which is the correct behaviour rather than a gap to paper over.
+
 **Started on dev (2026-08-24) — a worker can fetch the file it was given.** The design constraint
 that shaped this route is that the worker names nothing. It presents a lease id and the server
 resolves lease → job → media file → path; there is deliberately no path, filename, or library

--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -29,6 +29,31 @@ test asserts the field is a JSON string rather than a number, so the ordinal for
 unnoticed. Breaking for the worker contract, but its only consumer today is a curl command in
 testing; the cost of this change rises steeply once a tray app ships.
 
+**Started on dev (2026-08-24) — a worker can fetch the file it was given.** The design constraint
+that shaped this route is that the worker names nothing. It presents a lease id and the server
+resolves lease → job → media file → path; there is deliberately no path, filename, or library
+parameter anywhere in the signature. Any of them would turn a paired sidecar into an arbitrary file
+reader on the host, and no amount of validation on such a parameter is as safe as not accepting one.
+Access is also bounded in time rather than only in scope: a lease that is no longer held serves
+nothing, so releasing a job ends the worker's reach into the library at the same moment it gives the
+work back.
+
+Delivery is over HTTP rather than a shared mount, chosen deliberately over the cheaper option. A
+shared SMB/NFS path mapping would avoid moving multi-gigabyte files across the network twice per
+job, but it would also mean a sidecar that pairs with a PIN in thirty seconds then requires mount
+configuration before it can do anything. Zero-config pairing that demands NFS is not zero-config.
+The shared-storage path remains worth adding as an optimisation for workers that can already see the
+library; it is not the thing to build first.
+
+The source hash is computed once and stored on the job rather than per request, because re-reading
+gigabytes on every resumed transfer would be its own performance bug. It exists for the slice after
+this one: a returned candidate and its quality evidence have to be bound to the exact bytes that
+were encoded, since a measurement taken against a different version of the file is not evidence
+about this one.
+
+Range support is not a nicety here. A worker on a home network pulling an 8 GB original will
+sometimes lose the connection, and without resumption every drop costs the whole transfer again.
+
 **Started on dev (2026-08-24) — leases become real, and a worker can claim a job.** The decision
 that carries the safety is representing a claim as a job *status* rather than a flag or a join. A
 claimed job moves from `Queued` to `Leased`, and the local dispatcher selects on `Queued`, so it

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4748,6 +4748,37 @@
         ]
       }
     },
+    "/api/workers/leases/{leaseId}/source": {
+      "get": {
+        "operationId": "FetchLeaseSource",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "leaseId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      }
+    },
     "/api/workers/pair": {
       "post": {
         "operationId": "PairWorker",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -510,12 +510,21 @@ the replacement workflow is trustworthy.
      the status — and the Workers tab shows Online, Offline, Drained, or Revoked.
      **Still to build:** binding assignments and results to the credential and lease, credential
      rotation, and the TLS/LAN guidance.
-   - **Efficient, integrity-checked media delivery.** Support resumable, bounded, checksummed
+   - **Efficient, integrity-checked media delivery: started.** Support resumable, bounded, checksummed
      streaming when the sidecar cannot see the library. Also offer an explicit shared-storage path
      mapping for SMB/NFS-mounted media so multi-gigabyte sources need not cross the network twice.
      Shared sources remain read-only; sidecar scratch stays isolated. The main app verifies source
      identity before dispatch and rejects an output, report, or resumed transfer whose hashes,
      lease, size, or policy no longer match.
+     **Landed so far:** `GET /api/workers/leases/{leaseId}/source` streams an assigned original with
+     `Range` support so a dropped transfer resumes, and returns the source SHA-256 so the worker can
+     verify what it received. The route takes no path, filename, or library parameter — a worker
+     presents a lease and the server resolves the file — so a paired sidecar cannot be induced to
+     read anything other than the original already assigned to it. The source is opened shared and
+     read-only, and access ends when the lease stops being held. The hash is computed once and kept
+     on the job, which is what will later bind a returned candidate to the exact bytes encoded.
+     **Still to build:** the shared-storage path mapping for workers that can already see the
+     library, and returning the candidate.
    - **Capability-aware leases and recovery: started.** Schedule only when OS, architecture, FFmpeg
      build, encoder, decoder, VMAF mode, free scratch space, and configured concurrency satisfy the
      job. Persist idempotent leases with expiry and heartbeats, expose drain/disable controls, and

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -14,8 +14,11 @@ transcode would be claiming something neither end can do. Pairing exists now so 
 be set up and tested while the rest is built, and so this contract has a second implementation
 holding it honest.
 
-The app reports **no encoders and no VMAF support**, because it has none to prove: nothing is
-bundled with it. Optimisarr's capability matcher fails closed, so a worker advertising nothing is
+The app reports **no encoders and no VMAF support**, because it has none to prove: no ffmpeg is
+bundled with it yet. The probing that will report them is written and tested — it parses
+`ffmpeg -encoders` and then confirms each VideoToolbox encoder with a real throwaway encode, because
+every Apple build lists VideoToolbox whether or not a given machine can actually open it. With no
+ffmpeg present it reports nothing, which is the honest answer. Optimisarr's capability matcher fails closed, so a worker advertising nothing is
 never offered work. Honesty here is the safety mechanism — a sidecar that overstated itself would
 have jobs scheduled onto it that could only fail.
 

--- a/sidecars/macos/Sources/SidecarCore/CapabilityProber.swift
+++ b/sidecars/macos/Sources/SidecarCore/CapabilityProber.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// Runs a command and returns what it said. Behind a protocol so probing can be tested without a
+/// real ffmpeg — the parsing and the confirmation policy are the parts worth pinning, and neither
+/// needs an 80MB binary present to verify.
+public protocol CommandRunner: Sendable {
+    func run(_ executable: URL, _ arguments: [String]) async -> (exitCode: Int32, output: String)
+}
+
+public struct ProcessCommandRunner: CommandRunner {
+    public init() {}
+
+    public func run(_ executable: URL, _ arguments: [String]) async -> (exitCode: Int32, output: String) {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+        } catch {
+            return (-1, error.localizedDescription)
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (process.terminationStatus, String(decoding: data, as: UTF8.self))
+    }
+}
+
+/// Works out what this Mac can actually do.
+///
+/// Two stages, matching the server's `HardwareCapabilityService`: parse `ffmpeg -encoders` for a
+/// cheap first pass, then confirm each hardware encoder with a real throwaway encode. Every Apple
+/// ffmpeg build lists VideoToolbox whether or not this particular machine can open it, so listing
+/// alone would have the sidecar advertise encoders that fail on first use — and a job scheduled
+/// against a false capability is a job that can only fail.
+public struct CapabilityProber: Sendable {
+    private let runner: CommandRunner
+    private let ffmpeg: URL?
+    private let scratchDirectory: URL
+
+    public init(
+        ffmpeg: URL? = CapabilityProber.bundledFfmpeg(),
+        runner: CommandRunner = ProcessCommandRunner(),
+        scratchDirectory: URL = FileManager.default.temporaryDirectory
+    ) {
+        self.ffmpeg = ffmpeg
+        self.runner = runner
+        self.scratchDirectory = scratchDirectory
+    }
+
+    /// The ffmpeg shipped inside the app bundle.
+    ///
+    /// Bundled rather than found on the system so the worker's build matches the server's. The
+    /// roadmap treats FFmpeg build as a scheduling criterion for good reason: the same encode
+    /// settings must produce comparable output for the server's verification of a returned
+    /// candidate to mean anything.
+    public static func bundledFfmpeg() -> URL? {
+        guard let resource = Bundle.main.resourceURL?.appendingPathComponent("ffmpeg"),
+              FileManager.default.isExecutableFile(atPath: resource.path)
+        else {
+            return nil
+        }
+        return resource
+    }
+
+    /// What this machine has proved. With no ffmpeg there is nothing to prove, so it reports
+    /// nothing and the server's fail-closed matcher simply never offers it work.
+    public func probe(name: String, maxConcurrency: Int = 1) async -> SidecarCapabilities {
+        guard let ffmpeg else {
+            return SidecarCapabilities.provenToday(name: name)
+        }
+
+        let listing = await runner.run(ffmpeg, ["-hide_banner", "-encoders"])
+        guard listing.exitCode == 0 else {
+            return SidecarCapabilities.provenToday(name: name)
+        }
+
+        var proved: [String] = []
+        for encoder in EncoderListParser.parse(listing.output) {
+            if EncoderListParser.needsConfirmation(encoder) {
+                let probe = await runner.run(ffmpeg, EncoderProbeCommand.arguments(for: encoder))
+                guard probe.exitCode == 0 else { continue }
+            }
+            proved.append(encoder)
+        }
+
+        let filters = await runner.run(ffmpeg, ["-hide_banner", "-filters"])
+        let vmaf = filters.exitCode == 0 ? VmafSupportParser.parse(filters.output) : VmafCapability.none
+
+        return SidecarCapabilities(
+            name: name,
+            videoEncoders: proved,
+            hardwareDecoders: [],
+            vmaf: vmaf,
+            freeScratchBytes: freeScratchBytes(),
+            // Nothing to offer means nothing to accept. Reporting concurrency while advertising no
+            // encoder would have the server see a live worker it can never actually use.
+            maxConcurrency: proved.isEmpty ? 0 : maxConcurrency)
+    }
+
+    /// Real free space where the candidate would be written, not a guess. A worker that cannot hold
+    /// the output has no business starting the encode, and the server checks this before offering.
+    private func freeScratchBytes() -> Int64 {
+        let values = try? scratchDirectory.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        return values?.volumeAvailableCapacityForImportantUsage ?? 0
+    }
+}

--- a/sidecars/macos/Sources/SidecarCore/EncoderProbe.swift
+++ b/sidecars/macos/Sources/SidecarCore/EncoderProbe.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Parses `ffmpeg -encoders` output.
+///
+/// Listing is only the cheap first pass. The server's `HardwareCapabilityService` takes the same
+/// two-stage approach — parse, then confirm each hardware encoder with a real test encode — because
+/// ffmpeg lists what it was compiled with, not what this machine can actually open. A VideoToolbox
+/// encoder is present in every build for Apple platforms and can still fail at runtime, which is
+/// exactly why the roadmap says to probe rather than assume.
+public enum EncoderListParser {
+    /// Encoders worth reporting. Deliberately narrow: advertising an encoder the server would never
+    /// ask for only invites work this sidecar has no better claim to than the container.
+    static let interesting: Set<String> = [
+        "libx264", "libx265", "libsvtav1",
+        "h264_videotoolbox", "hevc_videotoolbox",
+    ]
+
+    /// `ffmpeg -encoders` prints a header, a separator line of dashes, then one row per encoder:
+    ///
+    ///     V....D hevc_videotoolbox    VideoToolbox H.265 Encoder
+    ///
+    /// The leading flags column starts with the media type, so video encoders begin with `V`.
+    public static func parse(_ output: String) -> [String] {
+        var found: [String] = []
+
+        for line in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Skip the header block; rows only start after the dashed separator, and every real row
+            // carries a flags column followed by the name.
+            let parts = trimmed.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
+            guard parts.count >= 2 else { continue }
+
+            let flags = String(parts[0])
+            let name = String(parts[1])
+
+            guard flags.hasPrefix("V"), interesting.contains(name), !found.contains(name) else {
+                continue
+            }
+            found.append(name)
+        }
+
+        return found
+    }
+
+    /// True when the encoder runs on the GPU and therefore needs proving rather than trusting.
+    /// CPU encoders are taken from the listing, matching how the server treats them.
+    public static func needsConfirmation(_ encoder: String) -> Bool {
+        encoder.hasSuffix("_videotoolbox")
+    }
+}
+
+/// Builds the throwaway encode that proves an encoder actually opens on this machine.
+///
+/// Mirrors the server's `EncoderProbeCommand`: a few frames of a synthetic source to the null
+/// muxer, at a resolution large enough to clear encoder minimums rather than a thumbnail. A clean
+/// exit means the encoder opened and produced packets.
+public enum EncoderProbeCommand {
+    public static func arguments(for encoder: String) -> [String] {
+        [
+            "-hide_banner", "-v", "error",
+            "-f", "lavfi", "-i", "color=c=black:s=320x240:r=25:d=0.2",
+            "-frames:v", "3",
+            "-c:v", encoder,
+            "-f", "null", "-",
+        ]
+    }
+}
+
+/// Parses `ffmpeg -filters` to decide whether VMAF can be measured.
+///
+/// Apple GPUs have no VMAF compute backend, so the only honest answer here is CPU or nothing —
+/// there is no arrangement of Apple hardware that yields `Cuda`.
+public enum VmafSupportParser {
+    public static func parse(_ filtersOutput: String) -> VmafCapability {
+        filtersOutput.contains("libvmaf") ? .cpu : .none
+    }
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/CapabilityProberTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/CapabilityProberTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import SidecarCore
+
+/// Answers scripted per command, so the two-stage probe can be walked without a real ffmpeg.
+final class ScriptedRunner: CommandRunner, @unchecked Sendable {
+    private let lock = NSLock()
+    private var replies: [String: (Int32, String)]
+    private(set) var probedEncoders: [String] = []
+
+    init(_ replies: [String: (Int32, String)]) { self.replies = replies }
+
+    func run(_ executable: URL, _ arguments: [String]) async -> (exitCode: Int32, output: String) {
+        lock.withLock {
+            if arguments.contains("-encoders") { return replies["encoders"] ?? (1, "") }
+            if arguments.contains("-filters") { return replies["filters"] ?? (1, "") }
+            // A confirmation encode; remember which encoder was proved.
+            if let index = arguments.firstIndex(of: "-c:v"), index + 1 < arguments.count {
+                let encoder = arguments[index + 1]
+                probedEncoders.append(encoder)
+                return replies[encoder] ?? (0, "")
+            }
+            return (1, "")
+        }
+    }
+}
+
+private let listing = """
+ V....D hevc_videotoolbox    VideoToolbox H.265 Encoder
+ V....D libx265              libx265 H.265 / HEVC
+"""
+
+@Suite("Capability probing")
+struct CapabilityProberTests {
+    private func prober(_ runner: ScriptedRunner) -> CapabilityProber {
+        CapabilityProber(ffmpeg: URL(fileURLWithPath: "/fake/ffmpeg"), runner: runner)
+    }
+
+    @Test("claims nothing at all when there is no ffmpeg to ask")
+    func noFfmpeg() async {
+        // The state this app ships in today. Nothing proved means the server's fail-closed matcher
+        // never offers it work, which is correct rather than a limitation to work around.
+        let capabilities = await CapabilityProber(ffmpeg: nil).probe(name: "Bare")
+
+        #expect(capabilities.videoEncoders.isEmpty)
+        #expect(capabilities.vmaf == .none)
+        #expect(capabilities.maxConcurrency == 0)
+    }
+
+    @Test("proves a VideoToolbox encoder with a real encode before advertising it")
+    func confirmsHardware() async {
+        let runner = ScriptedRunner([
+            "encoders": (0, listing),
+            "filters": (0, "libvmaf"),
+            "hevc_videotoolbox": (0, ""),
+        ])
+
+        let capabilities = await prober(runner).probe(name: "Mac", maxConcurrency: 2)
+
+        #expect(capabilities.videoEncoders.contains("hevc_videotoolbox"))
+        #expect(runner.probedEncoders.contains("hevc_videotoolbox"))
+        // CPU encoders are trusted from the listing, exactly as the server treats them.
+        #expect(!runner.probedEncoders.contains("libx265"))
+        #expect(capabilities.videoEncoders.contains("libx265"))
+    }
+
+    @Test("a listed but broken VideoToolbox encoder is not advertised")
+    func rejectsBrokenHardware() async {
+        // The reason listing alone is not enough: every Apple build lists VideoToolbox, and a job
+        // scheduled against a capability that fails on first use can only fail.
+        let runner = ScriptedRunner([
+            "encoders": (0, listing),
+            "filters": (0, "libvmaf"),
+            "hevc_videotoolbox": (1, "Error opening encoder"),
+        ])
+
+        let capabilities = await prober(runner).probe(name: "Mac")
+
+        #expect(!capabilities.videoEncoders.contains("hevc_videotoolbox"))
+        #expect(capabilities.videoEncoders.contains("libx265"))
+    }
+
+    @Test("reports CPU VMAF when the filter is present")
+    func detectsVmaf() async {
+        let runner = ScriptedRunner([
+            "encoders": (0, listing), "filters": (0, "libvmaf"), "hevc_videotoolbox": (0, ""),
+        ])
+
+        #expect(await prober(runner).probe(name: "Mac").vmaf == .cpu)
+    }
+
+    @Test("advertises no concurrency when it has no encoder to offer")
+    func noEncodersMeansNoConcurrency() async {
+        // Otherwise the server sees a live worker with capacity that it can never actually use.
+        let runner = ScriptedRunner(["encoders": (0, " A....D aac  AAC"), "filters": (0, "")])
+
+        let capabilities = await prober(runner).probe(name: "Mac", maxConcurrency: 4)
+
+        #expect(capabilities.videoEncoders.isEmpty)
+        #expect(capabilities.maxConcurrency == 0)
+    }
+
+    @Test("a failed listing is treated as no capability, not as an error to ignore")
+    func failedListing() async {
+        let runner = ScriptedRunner(["encoders": (1, "not found")])
+
+        #expect(await prober(runner).probe(name: "Mac").videoEncoders.isEmpty)
+    }
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/EncoderProbeTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/EncoderProbeTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+@testable import SidecarCore
+
+/// Real `ffmpeg -encoders` output from an Apple Silicon build, trimmed to the rows that matter plus
+/// enough noise to prove the parser is not just matching substrings anywhere in the text.
+private let encoderListing = """
+Encoders:
+ V..... = Video
+ A..... = Audio
+ S..... = Subtitle
+ ------
+ V....D h264_videotoolbox    VideoToolbox H.264 Encoder (codec h264)
+ V....D hevc_videotoolbox    VideoToolbox H.265 Encoder (codec hevc)
+ V....D libx264              libx264 H.264 / AVC / MPEG-4 AVC
+ V....D libx265              libx265 H.265 / HEVC
+ A....D aac                  AAC (Advanced Audio Coding)
+ S..... mov_text             3GPP Timed Text subtitle
+ V....D wrapped_avframe      AVFrame to AVPacket passthrough
+"""
+
+@Suite("Encoder listing")
+struct EncoderListParserTests {
+    @Test("finds the video encoders worth advertising")
+    func findsEncoders() {
+        let found = EncoderListParser.parse(encoderListing)
+
+        #expect(found.contains("hevc_videotoolbox"))
+        #expect(found.contains("h264_videotoolbox"))
+        #expect(found.contains("libx264"))
+        #expect(found.contains("libx265"))
+    }
+
+    @Test("ignores audio and subtitle encoders")
+    func ignoresNonVideo() {
+        let found = EncoderListParser.parse(encoderListing)
+
+        #expect(!found.contains("aac"))
+        #expect(!found.contains("mov_text"))
+    }
+
+    @Test("ignores video encoders that are not worth offering")
+    func ignoresUninteresting() {
+        // Advertising everything ffmpeg can emit would invite work this sidecar has no better claim
+        // to than the container already running it.
+        #expect(!EncoderListParser.parse(encoderListing).contains("wrapped_avframe"))
+    }
+
+    @Test("returns nothing for empty or unparseable output")
+    func handlesJunk() {
+        #expect(EncoderListParser.parse("").isEmpty)
+        #expect(EncoderListParser.parse("ffmpeg: command not found").isEmpty)
+    }
+
+    @Test("hardware encoders must be proved, CPU encoders may be trusted")
+    func confirmationPolicy() {
+        // The distinction that matters: ffmpeg lists what it was compiled with, and every Apple
+        // build lists VideoToolbox whether or not this machine can actually open it.
+        #expect(EncoderListParser.needsConfirmation("hevc_videotoolbox"))
+        #expect(EncoderListParser.needsConfirmation("h264_videotoolbox"))
+        #expect(!EncoderListParser.needsConfirmation("libx265"))
+        #expect(!EncoderListParser.needsConfirmation("libx264"))
+    }
+}
+
+@Suite("Encoder probe command")
+struct EncoderProbeCommandTests {
+    @Test("encodes a few frames of a synthetic source to null")
+    func probeShape() {
+        let args = EncoderProbeCommand.arguments(for: "hevc_videotoolbox")
+
+        #expect(args.contains("lavfi"))
+        #expect(args.contains("-frames:v"))
+        #expect(args.contains("hevc_videotoolbox"))
+        // Null muxer: the probe must prove the encoder opens without leaving a file behind.
+        #expect(args.contains("null"))
+    }
+
+    @Test("uses a resolution that clears encoder minimums")
+    func probeResolution() {
+        // A thumbnail-sized probe is rejected by some encoders, which would report a working
+        // encoder as broken. The server's probe uses the same 320x240 for this reason.
+        let args = EncoderProbeCommand.arguments(for: "hevc_videotoolbox").joined(separator: " ")
+
+        #expect(args.contains("320x240"))
+    }
+}
+
+@Suite("VMAF support")
+struct VmafSupportParserTests {
+    @Test("reports CPU when libvmaf is present")
+    func detectsVmaf() {
+        let filters = " ... T.. libvmaf           VV->V     Calculate the VMAF between two video streams."
+        #expect(VmafSupportParser.parse(filters) == .cpu)
+    }
+
+    @Test("reports none when libvmaf is absent")
+    func absentVmaf() {
+        #expect(VmafSupportParser.parse(" ... T.. scale  V->V  Scale the input video size.") == .none)
+    }
+
+    @Test("never reports CUDA, because Apple GPUs have no VMAF backend")
+    func neverCuda() {
+        // Guards the honesty of the capability rather than the parser. Claiming CUDA here would
+        // have the server schedule work on a measurement path that cannot exist on this hardware.
+        #expect(VmafSupportParser.parse("libvmaf libvmaf_cuda") != .cuda)
+    }
+}

--- a/src/Optimisarr.Api/Endpoints/WorkerSourceEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerSourceEndpoints.cs
@@ -1,0 +1,119 @@
+using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
+using Optimisarr.Api.Library;
+using Optimisarr.Api.Workers;
+using Optimisarr.Core.Workers;
+using Optimisarr.Data;
+
+namespace Optimisarr.Api.Endpoints;
+
+internal static class WorkerSourceEndpoints
+{
+    public static void MapWorkerSourceEndpoints(this WebApplication app)
+    {
+        // Streams the source a worker has been assigned.
+        //
+        // The single most important property here is that the worker names nothing. It presents a
+        // lease id; the server resolves lease -> job -> media file -> path. There is deliberately no
+        // path, filename, or library parameter anywhere in this route, because any of them would
+        // turn a paired sidecar into an arbitrary file reader on the host. A worker can only ever
+        // fetch the exact file the control plane already decided to give it.
+        //
+        // Read-only throughout: the original is opened for shared reading and never written,
+        // moved, or truncated. Optimisarr remains the only thing that touches originals.
+        app.MapGet("/api/workers/leases/{leaseId:guid}/source", async (
+            Guid leaseId,
+            HttpRequest http,
+            HttpResponse response,
+            SettingsStore settings,
+            OptimisarrDbContext db,
+            CancellationToken cancellationToken) =>
+        {
+            if (await WorkerGate.RefusedAsync(settings, cancellationToken) is { } refused)
+            {
+                return refused;
+            }
+
+            var worker = await WorkerAuth.ResolveAsync(http, db, cancellationToken);
+            if (worker is null)
+            {
+                return WorkerGate.Unauthenticated();
+            }
+
+            var lease = await db.JobLeases
+                .Include(l => l.Job)
+                .ThenInclude(job => job!.MediaFile)
+                .FirstOrDefaultAsync(l => l.Id == leaseId, cancellationToken);
+
+            if (lease is null)
+            {
+                return ApiErrors.NotFound("worker.lease.notFound", $"No lease with id {leaseId}.");
+            }
+
+            if (lease.WorkerId != worker.Id)
+            {
+                return Results.Json(
+                    new ApiError("worker.lease.notHolder", "That lease belongs to another worker."),
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            // A lapsed lease grants nothing. Otherwise a worker that lost its claim could keep
+            // pulling media indefinitely, which is exactly the access the lease is meant to bound.
+            if (lease.ToDomain().StateAt(DateTimeOffset.UtcNow) != LeaseState.Held)
+            {
+                return ApiErrors.Conflict("worker.lease.expired",
+                    "That lease is no longer held, so its source is no longer available.");
+            }
+
+            var job = lease.Job;
+            var path = job?.MediaFile?.Path;
+            if (job is null || string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                return ApiErrors.NotFound("worker.source.missing",
+                    "The source for that lease is no longer on disk.");
+            }
+
+            // Hashed once and remembered. Repeating it per request would re-read gigabytes every
+            // time a transfer resumed, and the value is what later proves a returned candidate was
+            // encoded from these exact bytes rather than some other version of the file.
+            if (string.IsNullOrWhiteSpace(job.SourceSha256))
+            {
+                job.SourceSha256 = await ComputeSha256Async(path, cancellationToken);
+                await db.SaveChangesAsync(cancellationToken);
+            }
+
+            // Let the worker verify what it received without a second pass over the network, and
+            // let it compare against what it will later be held to.
+            response.Headers["X-Optimisarr-Source-Sha256"] = job.SourceSha256;
+            response.Headers["X-Optimisarr-Job-Id"] = job.Id.ToString();
+
+            var stream = new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                // Shared so a scan or probe reading the same original is not blocked by a transfer
+                // that may take minutes.
+                FileShare.Read,
+                bufferSize: 128 * 1024,
+                useAsync: true);
+
+            // enableRangeProcessing is what makes a large transfer resumable: a worker whose
+            // connection drops resumes with a Range header instead of pulling the whole file again.
+            return Results.File(
+                stream,
+                contentType: "application/octet-stream",
+                fileDownloadName: Path.GetFileName(path),
+                enableRangeProcessing: true);
+        })
+        .WithName("FetchLeaseSource")
+        .Produces<ApiError>(StatusCodes.Status401Unauthorized);
+    }
+
+    private static async Task<string> ComputeSha256Async(string path, CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(
+            path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1024 * 1024, useAsync: true);
+        var hash = await SHA256.HashDataAsync(stream, cancellationToken);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}

--- a/src/Optimisarr.Api/Program.cs
+++ b/src/Optimisarr.Api/Program.cs
@@ -232,6 +232,8 @@ app.MapWorkerEndpoints();
 
 app.MapWorkerLeaseEndpoints();
 
+app.MapWorkerSourceEndpoints();
+
 app.MapHub<JobsHub>("/hubs/jobs");
 
 app.MapFallbackToFile("index.html", staticFileOptions);

--- a/src/Optimisarr.Data/Job.cs
+++ b/src/Optimisarr.Data/Job.cs
@@ -157,6 +157,16 @@ public sealed class Job
     /// </summary>
     public string? ProcessLog { get; set; }
 
+    /// <summary>
+    /// SHA-256 of the source as it was when a remote worker first fetched it.
+    ///
+    /// Computed once and kept, because hashing a multi-gigabyte file is not something to repeat per
+    /// request. It is what later binds a returned candidate and its quality evidence to the exact
+    /// bytes that were encoded: a result measured against a different source is not evidence about
+    /// this one.
+    /// </summary>
+    public string? SourceSha256 { get; set; }
+
     // --- Verification (Phase 4: populated once the output has been verified) ---
 
     /// <summary>Size of the produced output in bytes, recorded at verification time.</summary>

--- a/src/Optimisarr.Data/Migrations/20260824191153_AddJobSourceHash.Designer.cs
+++ b/src/Optimisarr.Data/Migrations/20260824191153_AddJobSourceHash.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Optimisarr.Data;
 
@@ -10,9 +11,11 @@ using Optimisarr.Data;
 namespace Optimisarr.Data.Migrations
 {
     [DbContext(typeof(OptimisarrDbContext))]
-    partial class OptimisarrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824191153_AddJobSourceHash")]
+    partial class AddJobSourceHash
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/src/Optimisarr.Data/Migrations/20260824191153_AddJobSourceHash.cs
+++ b/src/Optimisarr.Data/Migrations/20260824191153_AddJobSourceHash.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Optimisarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddJobSourceHash : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SourceSha256",
+                table: "Jobs",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SourceSha256",
+                table: "Jobs");
+        }
+    }
+}

--- a/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
+++ b/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
@@ -19,6 +19,10 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
     private readonly AdminTokenAuthEndpointTests.TokenedApi _api;
     private readonly List<int> _createdLibraries = [];
 
+    /// <summary>Small but non-trivial, so hashing and range requests have something to work on.</summary>
+    private static readonly byte[] SourceBytes =
+        Enumerable.Range(0, 4096).Select(i => (byte)(i % 251)).ToArray();
+
     public WorkerLeaseEndpointTests(AdminTokenAuthEndpointTests.TokenedApi api) => _api = api;
 
     public Task InitializeAsync() => Task.CompletedTask;
@@ -112,12 +116,18 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
         await db.SaveChangesAsync();
         _createdLibraries.Add(library.Id);
 
+        Directory.CreateDirectory(library.Path);
+        var sourcePath = Path.Combine(library.Path, "film.mkv");
+        // Real bytes on disk: the source route streams and hashes the actual file, so a row
+        // pointing at nothing would only exercise the missing-file path.
+        await File.WriteAllBytesAsync(sourcePath, SourceBytes);
+
         var file = new MediaFile
         {
             LibraryId = library.Id,
-            Path = Path.Combine(library.Path, "film.mkv"),
+            Path = sourcePath,
             RelativePath = "film.mkv",
-            SizeBytes = 8L * 1024 * 1024 * 1024,
+            SizeBytes = SourceBytes.Length,
         };
         db.MediaFiles.Add(file);
         await db.SaveChangesAsync();
@@ -265,6 +275,93 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
 
         using var claim = await incapable.PostAsJsonAsync("/api/workers/claim", new { });
         Assert.Equal(HttpStatusCode.NoContent, claim.StatusCode);
+    }
+
+
+    [Fact]
+    public async Task The_lease_holder_can_fetch_its_source_with_a_hash_it_can_verify()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Fetcher");
+        await QueueAJob();
+
+        var assignment = await (await worker.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+
+        using var source = await worker.GetAsync($"/api/workers/leases/{leaseId}/source");
+        Assert.Equal(HttpStatusCode.OK, source.StatusCode);
+
+        var received = await source.Content.ReadAsByteArrayAsync();
+        Assert.Equal(SourceBytes, received);
+
+        // The worker must be able to confirm what it received without a second pass, and the value
+        // is what later binds a returned candidate to these exact bytes.
+        var advertised = source.Headers.GetValues("X-Optimisarr-Source-Sha256").Single();
+        var actual = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(received)).ToLowerInvariant();
+        Assert.Equal(actual, advertised);
+    }
+
+    [Fact]
+    public async Task A_worker_cannot_fetch_a_source_for_a_lease_it_does_not_hold()
+    {
+        await EnableRemoteWorkers();
+        var holder = await PairCapableWorker("Source holder");
+        var intruder = await PairCapableWorker("Source intruder");
+        await QueueAJob();
+
+        var assignment = await (await holder.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+
+        using var stolen = await intruder.GetAsync($"/api/workers/leases/{leaseId}/source");
+        Assert.Equal(HttpStatusCode.Forbidden, stolen.StatusCode);
+
+        using var anonymous = await _api.CreateClient().GetAsync($"/api/workers/leases/{leaseId}/source");
+        Assert.Equal(HttpStatusCode.Unauthorized, anonymous.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_released_lease_stops_granting_access_to_the_media()
+    {
+        // The lease is what bounds a worker's reach into the library. Giving the job back must end
+        // that reach, or a worker could keep pulling media it no longer has any claim on.
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Handback");
+        await QueueAJob();
+
+        var assignment = await (await worker.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+
+        (await worker.PostAsJsonAsync($"/api/workers/leases/{leaseId}/release", new { }))
+            .EnsureSuccessStatusCode();
+
+        using var afterRelease = await worker.GetAsync($"/api/workers/leases/{leaseId}/source");
+        Assert.Equal(HttpStatusCode.Conflict, afterRelease.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_dropped_transfer_can_resume_with_a_range_request()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Resumer");
+        await QueueAJob();
+
+        var assignment = await (await worker.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/workers/leases/{leaseId}/source");
+        request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(1000, null);
+
+        using var partial = await worker.SendAsync(request);
+
+        // Without this a worker whose connection drops part-way through a multi-gigabyte source has
+        // to start again from zero.
+        Assert.Equal(HttpStatusCode.PartialContent, partial.StatusCode);
+        var tail = await partial.Content.ReadAsByteArrayAsync();
+        Assert.Equal(SourceBytes.Skip(1000).ToArray(), tail);
     }
 
     [Fact]


### PR DESCRIPTION
## Outcome

`GET /api/workers/leases/{leaseId}/source` streams an assigned original with `Range` support, and
returns `X-Optimisarr-Source-Sha256` so the worker can verify what it received.

First half of media delivery — the read-only half, and therefore the safe one.

## The constraint that shaped the route

**The worker names nothing.** It presents a lease id; the server resolves
`lease → job → media file → path`.

There is deliberately no path, filename, or library parameter anywhere in the signature. Any of them
would turn a paired sidecar into an arbitrary file reader on the host, and **no validation of such a
parameter is as safe as not accepting one.** There is no shape of request that reads a file the
control plane did not already assign.

Access is bounded in **time** as well as scope: a lease that is no longer held serves nothing, so
releasing a job ends the worker's reach into the library at the same moment it gives the work back.
`A_released_lease_stops_granting_access_to_the_media` pins that.

The original is opened `FileShare.Read` and never written, moved, or truncated.

## On choosing HTTP over a shared mount

You picked streaming over the SMB/NFS path mapping, and I think that was the better call than my
recommendation. A shared mount avoids moving gigabytes twice per job — but it also means a sidecar
that pairs with a PIN in thirty seconds then needs mount configuration before it can do anything.
**Zero-config pairing that demands NFS is not zero-config.**

The shared-storage path stays worth adding as an optimisation for workers that can already see the
library. It is just not the thing to build first, and the roadmap entry now says so.

## Two implementation notes

**The hash is computed once and kept on the job**, not per request. Re-reading gigabytes on every
resumed transfer would be its own performance bug. It exists for the next slice: a returned
candidate and its quality evidence must bind to the exact bytes that were encoded, because a
measurement taken against a different version of the file is not evidence about this one.

**Range support is not a nicety.** A worker pulling an 8 GB original over a home network will
sometimes drop the connection, and without resumption every drop costs the whole transfer again.

## Tests

Four, on the properties that matter rather than the happy path:

- The holder fetches its source, and the advertised hash matches the bytes received.
- **A different worker gets `403`; an unauthenticated caller gets `401`.**
- **A released lease returns `409`** — access ends with the claim.
- **A `Range` request returns `206` with the correct tail**, so a dropped transfer resumes.

## Verification

- `dotnet test` — **1603 passed, 0 failed**, stable across two runs. Zero build warnings.
- OpenAPI regenerated, `docs/api.md`, roadmap, history, `CHANGELOG.md`.

## Still to build

The result path: returning a candidate, re-probing it locally, and re-running every structural,
decode, duration, tail, stream-policy and size gate before it can go near a replacement. Plus the
per-library switch for whether a remote candidate may auto-replace, which I will add in the slice
where it actually takes effect rather than shipping a setting that does nothing.