### PR TITLE
Take delivery of a candidate encoded elsewhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,11 @@ config/
 # Swift Package Manager build output, and the assembled .app bundle
 sidecars/macos/.build/
 sidecars/macos/build/
+
+# The sidecar's bundled ffmpeg and its build tree. Built from pinned source by
+# sidecars/macos/scripts/build-ffmpeg.sh; an 80MB binary does not belong in git.
+sidecars/macos/vendor/
+sidecars/macos/.build-ffmpeg/
+
+# Work output written when tests exercise the queue against a relative work root.
+src/Optimisarr.Api/work/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   can pair or check in, so a normal single-container install is unchanged and never has to think
   about it. Turning it back off stops check-ins immediately but keeps what is already paired, so
   nothing is lost and turning it on again restores it.
+- **A remote worker can now download the file it has been given.** Transfers resume where they left
+  off if the connection drops, and come with a checksum so the worker can confirm it received the
+  file intact. A worker can only ever fetch the exact original it was assigned, and only while it
+  still holds the job.
 - **Remote workers can now claim jobs.** A paired sidecar asks for work, and Optimisarr hands it one
   job at a time, only where the worker has proved it has the encoder, VMAF support, scratch space
   and spare concurrency the job needs. A claimed job leaves the queue so this machine will not also

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   can pair or check in, so a normal single-container install is unchanged and never has to think
   about it. Turning it back off stops check-ins immediately but keeps what is already paired, so
   nothing is lost and turning it on again restores it.
+- **A remote worker can now return the file it encoded.** The upload is checksummed on arrival and
+  refused if it does not match, if it was encoded from a different source, or if the worker no
+  longer holds the job. An accepted file waits for verification and cannot replace anything until
+  every check Optimisarr runs on its own transcodes has passed against it too.
 - **A remote worker can now download the file it has been given.** Transfers resume where they left
   off if the connection drops, and come with a checksum so the worker can confirm it received the
   file intact. A worker can only ever fetch the exact original it was assigned, and only while it

--- a/docs/api.md
+++ b/docs/api.md
@@ -569,6 +569,13 @@ out of step with the threshold.
 | `POST` | `/api/workers/claim` | Ask for work. Returns one assignment, or `204` when nothing matches the worker's proved capabilities — the ordinary answer, not an error. Worker credential. |
 | `POST` | `/api/workers/leases/{leaseId}/renew` | Extend a claim. `403` if the lease belongs to another worker, `409` once it has lapsed. |
 | `POST` | `/api/workers/leases/{leaseId}/release` | Give a job back. It returns to the queue immediately. |
+| `GET` | `/api/workers/leases/{leaseId}/source` | Stream the source for a held lease. Supports `Range` for resumable transfer, and returns `X-Optimisarr-Source-Sha256` so the worker can verify what it received. |
+
+The source route takes no path, filename, or library parameter, by design. A worker presents a lease
+id and the server resolves the file from it, so a paired sidecar can only ever read the exact
+original the control plane already assigned to it — there is no shape of request that reads anything
+else. The original is opened shared and read-only, and access ends the moment the lease stops being
+held, so releasing a job also ends the worker's reach into the library.
 
 A claimed job leaves the `Queued` status for `Leased`, which is how the local queue stops seeing it:
 the dispatcher selects on `Queued`, so the exclusion is structural rather than a check a future

--- a/docs/api.md
+++ b/docs/api.md
@@ -569,7 +569,20 @@ out of step with the threshold.
 | `POST` | `/api/workers/claim` | Ask for work. Returns one assignment, or `204` when nothing matches the worker's proved capabilities — the ordinary answer, not an error. Worker credential. |
 | `POST` | `/api/workers/leases/{leaseId}/renew` | Extend a claim. `403` if the lease belongs to another worker, `409` once it has lapsed. |
 | `POST` | `/api/workers/leases/{leaseId}/release` | Give a job back. It returns to the queue immediately. |
+| `POST` | `/api/workers/leases/{leaseId}/result` | Deliver the encoded candidate. Requires `X-Optimisarr-Source-Sha256` and `X-Optimisarr-Candidate-Sha256`; `202` when accepted, `409` when the source does not match, the upload does not match its declared hash, or the lease is no longer held. |
 | `GET` | `/api/workers/leases/{leaseId}/source` | Stream the source for a held lease. Supports `Range` for resumable transfer, and returns `X-Optimisarr-Source-Sha256` so the worker can verify what it received. |
+
+A delivered candidate is written to the same work directory a local transcode would have used, and
+the job moves to `Verifying` — never to `ReadyToReplace`. Verification has not run at that point, and
+a candidate produced elsewhere earns nothing until every local gate has been repeated against it.
+Nothing about delivering a result touches the original.
+
+Checks run in an order chosen for what each protects: authenticate first, so nothing about a lease
+is revealed to a caller with no claim on it; then prove the claim is still held, which covers both
+the late result and the duplicate delivery; then prove the candidate was encoded from this job's
+source; and only then is anything written to disk. The upload is streamed and hashed as it arrives,
+under a temporary name, so a transfer that dies part-way never leaves something resembling a
+finished candidate.
 
 The source route takes no path, filename, or library parameter, by design. A worker presents a lease
 id and the server resolves the file from it, so a paired sidecar can only ever read the exact

--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -29,6 +29,30 @@ test asserts the field is a JSON string rather than a number, so the ordinal for
 unnoticed. Breaking for the worker contract, but its only consumer today is a curl command in
 testing; the cost of this change rises steeply once a tray app ships.
 
+**Started on dev (2026-08-24) — taking delivery of a candidate encoded elsewhere.** The tests were
+written before the endpoint and lead with the ways it goes wrong, because the happy path is not what
+loses media: a candidate encoded from a different source, a result arriving after the claim lapsed,
+a truncated upload, a second result for one lease, and a delivery attempted by a worker that never
+held the lease.
+
+The order of the checks is chosen for what each one protects rather than for convenience.
+Authenticate first, so nothing about a lease is revealed to a caller with no claim on it. Then prove
+the claim is still held — which covers the late result and the duplicate delivery in a single check,
+since a completed lease is no longer held. Then prove the candidate is about *this* source, using
+the hash recorded when the source was fetched: a file encoded from different bytes is not evidence
+about this job whatever its quality, and verifying one would mean judging a candidate against the
+wrong original. Only after all of that is anything written to disk.
+
+The upload is streamed and hashed in one pass under a `.partial` name, so a multi-gigabyte candidate
+never sits in memory and a transfer that dies leaves nothing that could be mistaken for a finished
+file. A hash mismatch deletes the staging file rather than keeping it.
+
+An accepted candidate sets `Verifying`, deliberately not `ReadyToReplace`. Nothing has judged it
+yet, and a candidate produced on another machine earns nothing until every local gate has been
+repeated against it. That does mean such a job currently sits in `Verifying` with nothing to advance
+it — a stalled job is the right failure while the verification slice is outstanding, where marking
+it replaceable would not be.
+
 **Started on dev (2026-08-24) — the sidecar can work out what it is actually capable of.** Probing
 mirrors the server's `HardwareCapabilityService` rather than inventing a second approach: parse
 `ffmpeg -encoders` for a cheap first pass, then confirm each hardware encoder with a real throwaway

--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -29,6 +29,27 @@ test asserts the field is a JSON string rather than a number, so the ordinal for
 unnoticed. Breaking for the worker contract, but its only consumer today is a curl command in
 testing; the cost of this change rises steeply once a tray app ships.
 
+**Started on dev (2026-08-24) — the sidecar can work out what it is actually capable of.** Probing
+mirrors the server's `HardwareCapabilityService` rather than inventing a second approach: parse
+`ffmpeg -encoders` for a cheap first pass, then confirm each hardware encoder with a real throwaway
+encode to the null muxer. The distinction matters more on Apple than elsewhere, because every macOS
+ffmpeg build lists VideoToolbox whether or not the machine in front of you can open it — listing
+alone would have the sidecar advertise encoders that fail on first use, and a job scheduled against
+a false capability can only fail. CPU encoders are trusted from the listing, as the server trusts
+them.
+
+VMAF can only ever be CPU here. Apple GPUs have no VMAF compute backend, so a test asserts the
+parser can never return `Cuda` — guarding the honesty of the capability rather than the parsing.
+
+A worker with no encoder reports zero concurrency too. Advertising capacity while advertising no
+encoder would show the server a live worker it can never actually use.
+
+ffmpeg will be bundled in the app rather than found on the system, so the worker's build matches the
+server's. The roadmap already treats FFmpeg build as a scheduling criterion, and the reason becomes
+concrete here: the server re-verifies a returned candidate, which only means something if the same
+encode settings produce comparable output at both ends. Nothing is bundled yet — the probing reports
+nothing without it, which is the correct behaviour rather than a gap to paper over.
+
 **Started on dev (2026-08-24) — a worker can fetch the file it was given.** The design constraint
 that shaped this route is that the worker names nothing. It presents a lease id and the server
 resolves lease → job → media file → path; there is deliberately no path, filename, or library

--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -29,6 +29,31 @@ test asserts the field is a JSON string rather than a number, so the ordinal for
 unnoticed. Breaking for the worker contract, but its only consumer today is a curl command in
 testing; the cost of this change rises steeply once a tray app ships.
 
+**Started on dev (2026-08-24) — a worker can fetch the file it was given.** The design constraint
+that shaped this route is that the worker names nothing. It presents a lease id and the server
+resolves lease → job → media file → path; there is deliberately no path, filename, or library
+parameter anywhere in the signature. Any of them would turn a paired sidecar into an arbitrary file
+reader on the host, and no amount of validation on such a parameter is as safe as not accepting one.
+Access is also bounded in time rather than only in scope: a lease that is no longer held serves
+nothing, so releasing a job ends the worker's reach into the library at the same moment it gives the
+work back.
+
+Delivery is over HTTP rather than a shared mount, chosen deliberately over the cheaper option. A
+shared SMB/NFS path mapping would avoid moving multi-gigabyte files across the network twice per
+job, but it would also mean a sidecar that pairs with a PIN in thirty seconds then requires mount
+configuration before it can do anything. Zero-config pairing that demands NFS is not zero-config.
+The shared-storage path remains worth adding as an optimisation for workers that can already see the
+library; it is not the thing to build first.
+
+The source hash is computed once and stored on the job rather than per request, because re-reading
+gigabytes on every resumed transfer would be its own performance bug. It exists for the slice after
+this one: a returned candidate and its quality evidence have to be bound to the exact bytes that
+were encoded, since a measurement taken against a different version of the file is not evidence
+about this one.
+
+Range support is not a nicety here. A worker on a home network pulling an 8 GB original will
+sometimes lose the connection, and without resumption every drop costs the whole transfer again.
+
 **Started on dev (2026-08-24) — leases become real, and a worker can claim a job.** The decision
 that carries the safety is representing a claim as a job *status* rather than a flag or a join. A
 claimed job moves from `Queued` to `Leased`, and the local dispatcher selects on `Queued`, so it

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1210,6 +1210,35 @@
         ],
         "type": "object"
       },
+      "ResultAcceptedDto": {
+        "properties": {
+          "bytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "candidateSha256": {
+            "type": "string"
+          },
+          "jobId": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          }
+        },
+        "required": [
+          "jobId",
+          "bytes",
+          "candidateSha256"
+        ],
+        "type": "object"
+      },
       "SaveActivityWatcherRequest": {
         "properties": {
           "apiToken": {
@@ -4731,6 +4760,47 @@
               }
             },
             "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      }
+    },
+    "/api/workers/leases/{leaseId}/result": {
+      "post": {
+        "operationId": "DeliverResult",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "leaseId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultAcceptedDto"
+                }
+              }
+            },
+            "description": "Accepted"
           },
           "401": {
             "content": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4748,6 +4748,37 @@
         ]
       }
     },
+    "/api/workers/leases/{leaseId}/source": {
+      "get": {
+        "operationId": "FetchLeaseSource",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "leaseId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      }
+    },
     "/api/workers/pair": {
       "post": {
         "operationId": "PairWorker",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -523,8 +523,16 @@ the replacement workflow is trustworthy.
      read anything other than the original already assigned to it. The source is opened shared and
      read-only, and access ends when the lease stops being held. The hash is computed once and kept
      on the job, which is what will later bind a returned candidate to the exact bytes encoded.
-     **Still to build:** the shared-storage path mapping for workers that can already see the
-     library, and returning the candidate.
+     `POST /api/workers/leases/{leaseId}/result` takes the candidate back, streamed and hashed as it
+     arrives under a temporary name so a dead transfer never leaves something resembling a finished
+     file. It is refused unless the worker still holds the lease, the declared source hash matches
+     the one recorded when the source was fetched, and the upload matches the hash the worker
+     declared — which together cover the late result, the duplicate delivery, the candidate encoded
+     from the wrong original, and the truncated upload. An accepted candidate lands in the work
+     directory a local transcode would have used and the job moves to `Verifying`, never to
+     `ReadyToReplace`. **Still to build:** the shared-storage path mapping for workers that can
+     already see the library, resumable upload, and the verification that actually judges a returned
+     candidate.
    - **Capability-aware leases and recovery: started.** Schedule only when OS, architecture, FFmpeg
      build, encoder, decoder, VMAF mode, free scratch space, and configured concurrency satisfy the
      job. Persist idempotent leases with expiry and heartbeats, expose drain/disable controls, and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -510,12 +510,21 @@ the replacement workflow is trustworthy.
      the status — and the Workers tab shows Online, Offline, Drained, or Revoked.
      **Still to build:** binding assignments and results to the credential and lease, credential
      rotation, and the TLS/LAN guidance.
-   - **Efficient, integrity-checked media delivery.** Support resumable, bounded, checksummed
+   - **Efficient, integrity-checked media delivery: started.** Support resumable, bounded, checksummed
      streaming when the sidecar cannot see the library. Also offer an explicit shared-storage path
      mapping for SMB/NFS-mounted media so multi-gigabyte sources need not cross the network twice.
      Shared sources remain read-only; sidecar scratch stays isolated. The main app verifies source
      identity before dispatch and rejects an output, report, or resumed transfer whose hashes,
      lease, size, or policy no longer match.
+     **Landed so far:** `GET /api/workers/leases/{leaseId}/source` streams an assigned original with
+     `Range` support so a dropped transfer resumes, and returns the source SHA-256 so the worker can
+     verify what it received. The route takes no path, filename, or library parameter — a worker
+     presents a lease and the server resolves the file — so a paired sidecar cannot be induced to
+     read anything other than the original already assigned to it. The source is opened shared and
+     read-only, and access ends when the lease stops being held. The hash is computed once and kept
+     on the job, which is what will later bind a returned candidate to the exact bytes encoded.
+     **Still to build:** the shared-storage path mapping for workers that can already see the
+     library, and returning the candidate.
    - **Capability-aware leases and recovery: started.** Schedule only when OS, architecture, FFmpeg
      build, encoder, decoder, VMAF mode, free scratch space, and configured concurrency satisfy the
      job. Persist idempotent leases with expiry and heartbeats, expose drain/disable controls, and

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -14,8 +14,11 @@ transcode would be claiming something neither end can do. Pairing exists now so 
 be set up and tested while the rest is built, and so this contract has a second implementation
 holding it honest.
 
-The app reports **no encoders and no VMAF support**, because it has none to prove: nothing is
-bundled with it. Optimisarr's capability matcher fails closed, so a worker advertising nothing is
+The app reports **no encoders and no VMAF support**, because it has none to prove: no ffmpeg is
+bundled with it yet. The probing that will report them is written and tested — it parses
+`ffmpeg -encoders` and then confirms each VideoToolbox encoder with a real throwaway encode, because
+every Apple build lists VideoToolbox whether or not a given machine can actually open it. With no
+ffmpeg present it reports nothing, which is the honest answer. Optimisarr's capability matcher fails closed, so a worker advertising nothing is
 never offered work. Honesty here is the safety mechanism — a sidecar that overstated itself would
 have jobs scheduled onto it that could only fail.
 

--- a/sidecars/macos/Sources/SidecarCore/CapabilityProber.swift
+++ b/sidecars/macos/Sources/SidecarCore/CapabilityProber.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// Runs a command and returns what it said. Behind a protocol so probing can be tested without a
+/// real ffmpeg — the parsing and the confirmation policy are the parts worth pinning, and neither
+/// needs an 80MB binary present to verify.
+public protocol CommandRunner: Sendable {
+    func run(_ executable: URL, _ arguments: [String]) async -> (exitCode: Int32, output: String)
+}
+
+public struct ProcessCommandRunner: CommandRunner {
+    public init() {}
+
+    public func run(_ executable: URL, _ arguments: [String]) async -> (exitCode: Int32, output: String) {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+        } catch {
+            return (-1, error.localizedDescription)
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (process.terminationStatus, String(decoding: data, as: UTF8.self))
+    }
+}
+
+/// Works out what this Mac can actually do.
+///
+/// Two stages, matching the server's `HardwareCapabilityService`: parse `ffmpeg -encoders` for a
+/// cheap first pass, then confirm each hardware encoder with a real throwaway encode. Every Apple
+/// ffmpeg build lists VideoToolbox whether or not this particular machine can open it, so listing
+/// alone would have the sidecar advertise encoders that fail on first use — and a job scheduled
+/// against a false capability is a job that can only fail.
+public struct CapabilityProber: Sendable {
+    private let runner: CommandRunner
+    private let ffmpeg: URL?
+    private let scratchDirectory: URL
+
+    public init(
+        ffmpeg: URL? = CapabilityProber.bundledFfmpeg(),
+        runner: CommandRunner = ProcessCommandRunner(),
+        scratchDirectory: URL = FileManager.default.temporaryDirectory
+    ) {
+        self.ffmpeg = ffmpeg
+        self.runner = runner
+        self.scratchDirectory = scratchDirectory
+    }
+
+    /// The ffmpeg shipped inside the app bundle.
+    ///
+    /// Bundled rather than found on the system so the worker's build matches the server's. The
+    /// roadmap treats FFmpeg build as a scheduling criterion for good reason: the same encode
+    /// settings must produce comparable output for the server's verification of a returned
+    /// candidate to mean anything.
+    public static func bundledFfmpeg() -> URL? {
+        guard let resource = Bundle.main.resourceURL?.appendingPathComponent("ffmpeg"),
+              FileManager.default.isExecutableFile(atPath: resource.path)
+        else {
+            return nil
+        }
+        return resource
+    }
+
+    /// What this machine has proved. With no ffmpeg there is nothing to prove, so it reports
+    /// nothing and the server's fail-closed matcher simply never offers it work.
+    public func probe(name: String, maxConcurrency: Int = 1) async -> SidecarCapabilities {
+        guard let ffmpeg else {
+            return SidecarCapabilities.provenToday(name: name)
+        }
+
+        let listing = await runner.run(ffmpeg, ["-hide_banner", "-encoders"])
+        guard listing.exitCode == 0 else {
+            return SidecarCapabilities.provenToday(name: name)
+        }
+
+        var proved: [String] = []
+        for encoder in EncoderListParser.parse(listing.output) {
+            if EncoderListParser.needsConfirmation(encoder) {
+                let probe = await runner.run(ffmpeg, EncoderProbeCommand.arguments(for: encoder))
+                guard probe.exitCode == 0 else { continue }
+            }
+            proved.append(encoder)
+        }
+
+        let filters = await runner.run(ffmpeg, ["-hide_banner", "-filters"])
+        let vmaf = filters.exitCode == 0 ? VmafSupportParser.parse(filters.output) : VmafCapability.none
+
+        return SidecarCapabilities(
+            name: name,
+            videoEncoders: proved,
+            hardwareDecoders: [],
+            vmaf: vmaf,
+            freeScratchBytes: freeScratchBytes(),
+            // Nothing to offer means nothing to accept. Reporting concurrency while advertising no
+            // encoder would have the server see a live worker it can never actually use.
+            maxConcurrency: proved.isEmpty ? 0 : maxConcurrency)
+    }
+
+    /// Real free space where the candidate would be written, not a guess. A worker that cannot hold
+    /// the output has no business starting the encode, and the server checks this before offering.
+    private func freeScratchBytes() -> Int64 {
+        let values = try? scratchDirectory.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        return values?.volumeAvailableCapacityForImportantUsage ?? 0
+    }
+}

--- a/sidecars/macos/Sources/SidecarCore/EncoderProbe.swift
+++ b/sidecars/macos/Sources/SidecarCore/EncoderProbe.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Parses `ffmpeg -encoders` output.
+///
+/// Listing is only the cheap first pass. The server's `HardwareCapabilityService` takes the same
+/// two-stage approach — parse, then confirm each hardware encoder with a real test encode — because
+/// ffmpeg lists what it was compiled with, not what this machine can actually open. A VideoToolbox
+/// encoder is present in every build for Apple platforms and can still fail at runtime, which is
+/// exactly why the roadmap says to probe rather than assume.
+public enum EncoderListParser {
+    /// Encoders worth reporting. Deliberately narrow: advertising an encoder the server would never
+    /// ask for only invites work this sidecar has no better claim to than the container.
+    static let interesting: Set<String> = [
+        "libx264", "libx265", "libsvtav1",
+        "h264_videotoolbox", "hevc_videotoolbox",
+    ]
+
+    /// `ffmpeg -encoders` prints a header, a separator line of dashes, then one row per encoder:
+    ///
+    ///     V....D hevc_videotoolbox    VideoToolbox H.265 Encoder
+    ///
+    /// The leading flags column starts with the media type, so video encoders begin with `V`.
+    public static func parse(_ output: String) -> [String] {
+        var found: [String] = []
+
+        for line in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Skip the header block; rows only start after the dashed separator, and every real row
+            // carries a flags column followed by the name.
+            let parts = trimmed.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
+            guard parts.count >= 2 else { continue }
+
+            let flags = String(parts[0])
+            let name = String(parts[1])
+
+            guard flags.hasPrefix("V"), interesting.contains(name), !found.contains(name) else {
+                continue
+            }
+            found.append(name)
+        }
+
+        return found
+    }
+
+    /// True when the encoder runs on the GPU and therefore needs proving rather than trusting.
+    /// CPU encoders are taken from the listing, matching how the server treats them.
+    public static func needsConfirmation(_ encoder: String) -> Bool {
+        encoder.hasSuffix("_videotoolbox")
+    }
+}
+
+/// Builds the throwaway encode that proves an encoder actually opens on this machine.
+///
+/// Mirrors the server's `EncoderProbeCommand`: a few frames of a synthetic source to the null
+/// muxer, at a resolution large enough to clear encoder minimums rather than a thumbnail. A clean
+/// exit means the encoder opened and produced packets.
+public enum EncoderProbeCommand {
+    public static func arguments(for encoder: String) -> [String] {
+        [
+            "-hide_banner", "-v", "error",
+            "-f", "lavfi", "-i", "color=c=black:s=320x240:r=25:d=0.2",
+            "-frames:v", "3",
+            "-c:v", encoder,
+            "-f", "null", "-",
+        ]
+    }
+}
+
+/// Parses `ffmpeg -filters` to decide whether VMAF can be measured.
+///
+/// Apple GPUs have no VMAF compute backend, so the only honest answer here is CPU or nothing —
+/// there is no arrangement of Apple hardware that yields `Cuda`.
+public enum VmafSupportParser {
+    public static func parse(_ filtersOutput: String) -> VmafCapability {
+        filtersOutput.contains("libvmaf") ? .cpu : .none
+    }
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/CapabilityProberTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/CapabilityProberTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import SidecarCore
+
+/// Answers scripted per command, so the two-stage probe can be walked without a real ffmpeg.
+final class ScriptedRunner: CommandRunner, @unchecked Sendable {
+    private let lock = NSLock()
+    private var replies: [String: (Int32, String)]
+    private(set) var probedEncoders: [String] = []
+
+    init(_ replies: [String: (Int32, String)]) { self.replies = replies }
+
+    func run(_ executable: URL, _ arguments: [String]) async -> (exitCode: Int32, output: String) {
+        lock.withLock {
+            if arguments.contains("-encoders") { return replies["encoders"] ?? (1, "") }
+            if arguments.contains("-filters") { return replies["filters"] ?? (1, "") }
+            // A confirmation encode; remember which encoder was proved.
+            if let index = arguments.firstIndex(of: "-c:v"), index + 1 < arguments.count {
+                let encoder = arguments[index + 1]
+                probedEncoders.append(encoder)
+                return replies[encoder] ?? (0, "")
+            }
+            return (1, "")
+        }
+    }
+}
+
+private let listing = """
+ V....D hevc_videotoolbox    VideoToolbox H.265 Encoder
+ V....D libx265              libx265 H.265 / HEVC
+"""
+
+@Suite("Capability probing")
+struct CapabilityProberTests {
+    private func prober(_ runner: ScriptedRunner) -> CapabilityProber {
+        CapabilityProber(ffmpeg: URL(fileURLWithPath: "/fake/ffmpeg"), runner: runner)
+    }
+
+    @Test("claims nothing at all when there is no ffmpeg to ask")
+    func noFfmpeg() async {
+        // The state this app ships in today. Nothing proved means the server's fail-closed matcher
+        // never offers it work, which is correct rather than a limitation to work around.
+        let capabilities = await CapabilityProber(ffmpeg: nil).probe(name: "Bare")
+
+        #expect(capabilities.videoEncoders.isEmpty)
+        #expect(capabilities.vmaf == .none)
+        #expect(capabilities.maxConcurrency == 0)
+    }
+
+    @Test("proves a VideoToolbox encoder with a real encode before advertising it")
+    func confirmsHardware() async {
+        let runner = ScriptedRunner([
+            "encoders": (0, listing),
+            "filters": (0, "libvmaf"),
+            "hevc_videotoolbox": (0, ""),
+        ])
+
+        let capabilities = await prober(runner).probe(name: "Mac", maxConcurrency: 2)
+
+        #expect(capabilities.videoEncoders.contains("hevc_videotoolbox"))
+        #expect(runner.probedEncoders.contains("hevc_videotoolbox"))
+        // CPU encoders are trusted from the listing, exactly as the server treats them.
+        #expect(!runner.probedEncoders.contains("libx265"))
+        #expect(capabilities.videoEncoders.contains("libx265"))
+    }
+
+    @Test("a listed but broken VideoToolbox encoder is not advertised")
+    func rejectsBrokenHardware() async {
+        // The reason listing alone is not enough: every Apple build lists VideoToolbox, and a job
+        // scheduled against a capability that fails on first use can only fail.
+        let runner = ScriptedRunner([
+            "encoders": (0, listing),
+            "filters": (0, "libvmaf"),
+            "hevc_videotoolbox": (1, "Error opening encoder"),
+        ])
+
+        let capabilities = await prober(runner).probe(name: "Mac")
+
+        #expect(!capabilities.videoEncoders.contains("hevc_videotoolbox"))
+        #expect(capabilities.videoEncoders.contains("libx265"))
+    }
+
+    @Test("reports CPU VMAF when the filter is present")
+    func detectsVmaf() async {
+        let runner = ScriptedRunner([
+            "encoders": (0, listing), "filters": (0, "libvmaf"), "hevc_videotoolbox": (0, ""),
+        ])
+
+        #expect(await prober(runner).probe(name: "Mac").vmaf == .cpu)
+    }
+
+    @Test("advertises no concurrency when it has no encoder to offer")
+    func noEncodersMeansNoConcurrency() async {
+        // Otherwise the server sees a live worker with capacity that it can never actually use.
+        let runner = ScriptedRunner(["encoders": (0, " A....D aac  AAC"), "filters": (0, "")])
+
+        let capabilities = await prober(runner).probe(name: "Mac", maxConcurrency: 4)
+
+        #expect(capabilities.videoEncoders.isEmpty)
+        #expect(capabilities.maxConcurrency == 0)
+    }
+
+    @Test("a failed listing is treated as no capability, not as an error to ignore")
+    func failedListing() async {
+        let runner = ScriptedRunner(["encoders": (1, "not found")])
+
+        #expect(await prober(runner).probe(name: "Mac").videoEncoders.isEmpty)
+    }
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/EncoderProbeTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/EncoderProbeTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+@testable import SidecarCore
+
+/// Real `ffmpeg -encoders` output from an Apple Silicon build, trimmed to the rows that matter plus
+/// enough noise to prove the parser is not just matching substrings anywhere in the text.
+private let encoderListing = """
+Encoders:
+ V..... = Video
+ A..... = Audio
+ S..... = Subtitle
+ ------
+ V....D h264_videotoolbox    VideoToolbox H.264 Encoder (codec h264)
+ V....D hevc_videotoolbox    VideoToolbox H.265 Encoder (codec hevc)
+ V....D libx264              libx264 H.264 / AVC / MPEG-4 AVC
+ V....D libx265              libx265 H.265 / HEVC
+ A....D aac                  AAC (Advanced Audio Coding)
+ S..... mov_text             3GPP Timed Text subtitle
+ V....D wrapped_avframe      AVFrame to AVPacket passthrough
+"""
+
+@Suite("Encoder listing")
+struct EncoderListParserTests {
+    @Test("finds the video encoders worth advertising")
+    func findsEncoders() {
+        let found = EncoderListParser.parse(encoderListing)
+
+        #expect(found.contains("hevc_videotoolbox"))
+        #expect(found.contains("h264_videotoolbox"))
+        #expect(found.contains("libx264"))
+        #expect(found.contains("libx265"))
+    }
+
+    @Test("ignores audio and subtitle encoders")
+    func ignoresNonVideo() {
+        let found = EncoderListParser.parse(encoderListing)
+
+        #expect(!found.contains("aac"))
+        #expect(!found.contains("mov_text"))
+    }
+
+    @Test("ignores video encoders that are not worth offering")
+    func ignoresUninteresting() {
+        // Advertising everything ffmpeg can emit would invite work this sidecar has no better claim
+        // to than the container already running it.
+        #expect(!EncoderListParser.parse(encoderListing).contains("wrapped_avframe"))
+    }
+
+    @Test("returns nothing for empty or unparseable output")
+    func handlesJunk() {
+        #expect(EncoderListParser.parse("").isEmpty)
+        #expect(EncoderListParser.parse("ffmpeg: command not found").isEmpty)
+    }
+
+    @Test("hardware encoders must be proved, CPU encoders may be trusted")
+    func confirmationPolicy() {
+        // The distinction that matters: ffmpeg lists what it was compiled with, and every Apple
+        // build lists VideoToolbox whether or not this machine can actually open it.
+        #expect(EncoderListParser.needsConfirmation("hevc_videotoolbox"))
+        #expect(EncoderListParser.needsConfirmation("h264_videotoolbox"))
+        #expect(!EncoderListParser.needsConfirmation("libx265"))
+        #expect(!EncoderListParser.needsConfirmation("libx264"))
+    }
+}
+
+@Suite("Encoder probe command")
+struct EncoderProbeCommandTests {
+    @Test("encodes a few frames of a synthetic source to null")
+    func probeShape() {
+        let args = EncoderProbeCommand.arguments(for: "hevc_videotoolbox")
+
+        #expect(args.contains("lavfi"))
+        #expect(args.contains("-frames:v"))
+        #expect(args.contains("hevc_videotoolbox"))
+        // Null muxer: the probe must prove the encoder opens without leaving a file behind.
+        #expect(args.contains("null"))
+    }
+
+    @Test("uses a resolution that clears encoder minimums")
+    func probeResolution() {
+        // A thumbnail-sized probe is rejected by some encoders, which would report a working
+        // encoder as broken. The server's probe uses the same 320x240 for this reason.
+        let args = EncoderProbeCommand.arguments(for: "hevc_videotoolbox").joined(separator: " ")
+
+        #expect(args.contains("320x240"))
+    }
+}
+
+@Suite("VMAF support")
+struct VmafSupportParserTests {
+    @Test("reports CPU when libvmaf is present")
+    func detectsVmaf() {
+        let filters = " ... T.. libvmaf           VV->V     Calculate the VMAF between two video streams."
+        #expect(VmafSupportParser.parse(filters) == .cpu)
+    }
+
+    @Test("reports none when libvmaf is absent")
+    func absentVmaf() {
+        #expect(VmafSupportParser.parse(" ... T.. scale  V->V  Scale the input video size.") == .none)
+    }
+
+    @Test("never reports CUDA, because Apple GPUs have no VMAF backend")
+    func neverCuda() {
+        // Guards the honesty of the capability rather than the parser. Claiming CUDA here would
+        // have the server schedule work on a measurement path that cannot exist on this hardware.
+        #expect(VmafSupportParser.parse("libvmaf libvmaf_cuda") != .cuda)
+    }
+}

--- a/src/Optimisarr.Api/Endpoints/WorkerResultEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerResultEndpoints.cs
@@ -1,0 +1,194 @@
+using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
+using Optimisarr.Api.Library;
+using Optimisarr.Api.Queue;
+using Optimisarr.Api.Workers;
+using Optimisarr.Core.Queue;
+using Optimisarr.Core.Workers;
+using Optimisarr.Data;
+
+namespace Optimisarr.Api.Endpoints;
+
+internal sealed record ResultAcceptedDto(int JobId, long Bytes, string CandidateSha256);
+
+internal static class WorkerResultEndpoints
+{
+    private const string SourceHashHeader = "X-Optimisarr-Source-Sha256";
+    private const string CandidateHashHeader = "X-Optimisarr-Candidate-Sha256";
+
+    public static void MapWorkerResultEndpoints(this WebApplication app)
+    {
+        // Takes delivery of a candidate encoded elsewhere.
+        //
+        // This is the point where bytes from another machine enter the pipeline, so the checks run
+        // in an order chosen for what each one protects: authenticate first, so nothing about a
+        // lease is revealed to a caller with no claim on it; then prove the claim is live; then
+        // prove the candidate is about *this* source; and only then write anything to disk.
+        //
+        // The candidate goes to the work directory a local transcode would have used. It does not
+        // go near the original, and nothing here marks the job replaceable — verification has not
+        // run yet, and a candidate that has not been verified must never be a replacement.
+        app.MapPost("/api/workers/leases/{leaseId:guid}/result", async (
+            Guid leaseId,
+            HttpRequest http,
+            SettingsStore settings,
+            OptimisarrDbContext db,
+            IHostEnvironment environment,
+            CancellationToken cancellationToken) =>
+        {
+            if (await WorkerGate.RefusedAsync(settings, cancellationToken) is { } refused)
+            {
+                return refused;
+            }
+
+            var worker = await WorkerAuth.ResolveAsync(http, db, cancellationToken);
+            if (worker is null)
+            {
+                return WorkerGate.Unauthenticated();
+            }
+
+            var lease = await db.JobLeases
+                .Include(l => l.Job)
+                .ThenInclude(job => job!.MediaFile)
+                .FirstOrDefaultAsync(l => l.Id == leaseId, cancellationToken);
+
+            if (lease is null)
+            {
+                return ApiErrors.NotFound("worker.lease.notFound", $"No lease with id {leaseId}.");
+            }
+
+            if (lease.WorkerId != worker.Id)
+            {
+                return Results.Json(
+                    new ApiError("worker.lease.notHolder", "That lease belongs to another worker."),
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            // The late-result and duplicate-delivery cases together. A lease that has lapsed may
+            // have had its job reassigned, and one already completed has had its result; in neither
+            // case is there a live claim for this candidate to arrive through.
+            if (lease.ToDomain().StateAt(DateTimeOffset.UtcNow) != LeaseState.Held)
+            {
+                return ApiErrors.Conflict("worker.lease.notHeld",
+                    "That lease is no longer held, so a result cannot be delivered through it.");
+            }
+
+            var job = lease.Job;
+            if (job?.MediaFile is null)
+            {
+                return ApiErrors.NotFound("worker.source.missing", "That lease has no source.");
+            }
+
+            var claimedSource = http.Headers[SourceHashHeader].ToString();
+            var claimedCandidate = http.Headers[CandidateHashHeader].ToString();
+
+            if (string.IsNullOrWhiteSpace(claimedSource) || string.IsNullOrWhiteSpace(claimedCandidate))
+            {
+                // Fail closed on missing evidence rather than accepting an unattributable file.
+                return ApiErrors.BadRequest("worker.result.evidenceMissing",
+                    $"Both {SourceHashHeader} and {CandidateHashHeader} are required.");
+            }
+
+            // The check the source hash exists for. A candidate encoded from different bytes is not
+            // evidence about this job whatever its quality, and quietly accepting one would mean
+            // verifying — and potentially replacing — against the wrong original.
+            if (!string.Equals(job.SourceSha256, claimedSource, StringComparison.OrdinalIgnoreCase))
+            {
+                return ApiErrors.Conflict("worker.result.sourceMismatch",
+                    "That candidate was encoded from a different source than this job's.");
+            }
+
+            var workRoot = WorkPaths.Resolve(environment);
+            var outputRoot = WorkOutputRoot.ForMediaFile(workRoot, job.MediaFileId);
+            Directory.CreateDirectory(outputRoot);
+
+            // Written under a temporary name and hashed on the way in, so a transfer that dies
+            // part-way never leaves something that looks like a finished candidate.
+            var finalPath = Path.Combine(outputRoot, $"remote-{job.Id}{Path.GetExtension(job.MediaFile.Path)}");
+            var stagingPath = finalPath + ".partial";
+
+            long written;
+            string actualHash;
+            try
+            {
+                (written, actualHash) = await StreamToFileAsync(http.Body, stagingPath, cancellationToken);
+            }
+            catch (Exception)
+            {
+                TryDelete(stagingPath);
+                throw;
+            }
+
+            if (!string.Equals(actualHash, claimedCandidate, StringComparison.OrdinalIgnoreCase))
+            {
+                // Truncated, corrupted, or misdescribed. Any of those verified as a real candidate
+                // could end up replacing an original with a broken file.
+                TryDelete(stagingPath);
+                return ApiErrors.Conflict("worker.result.hashMismatch",
+                    "The uploaded candidate does not match the hash the worker declared.");
+            }
+
+            TryDelete(finalPath);
+            File.Move(stagingPath, finalPath);
+
+            job.WorkOutputPath = finalPath;
+
+            // Deliberately not ReadyToReplace. Verification has not run, and a candidate produced
+            // elsewhere earns nothing until every local gate has been repeated against it.
+            job.Status = JobStatus.Verifying;
+
+            lease.Apply(lease.ToDomain().Complete(worker.Id, DateTimeOffset.UtcNow).Lease);
+            await db.SaveChangesAsync(cancellationToken);
+
+            // Accepted rather than OK: the candidate is delivered and intact, not yet judged.
+            return Results.Accepted(value: new ResultAcceptedDto(job.Id, written, actualHash));
+        })
+        .WithName("DeliverResult")
+        .Produces<ResultAcceptedDto>(StatusCodes.Status202Accepted)
+        .Produces<ApiError>(StatusCodes.Status401Unauthorized);
+    }
+
+    /// <summary>
+    /// Streams the body to disk while hashing it, so a multi-gigabyte candidate is never held in
+    /// memory and the hash costs no extra pass over the data.
+    /// </summary>
+    private static async Task<(long Bytes, string Sha256)> StreamToFileAsync(
+        Stream body,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        using var sha = SHA256.Create();
+        var buffer = new byte[128 * 1024];
+        long total = 0;
+
+        await using (var file = new FileStream(
+            path, FileMode.Create, FileAccess.Write, FileShare.None, buffer.Length, useAsync: true))
+        {
+            int read;
+            while ((read = await body.ReadAsync(buffer, cancellationToken)) > 0)
+            {
+                sha.TransformBlock(buffer, 0, read, null, 0);
+                await file.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+                total += read;
+            }
+            sha.TransformFinalBlock([], 0, 0);
+        }
+
+        return (total, Convert.ToHexString(sha.Hash!).ToLowerInvariant());
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover staging file is untidy, not dangerous — it is never treated as a candidate.
+        }
+    }
+}

--- a/src/Optimisarr.Api/Endpoints/WorkerSourceEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerSourceEndpoints.cs
@@ -1,0 +1,119 @@
+using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
+using Optimisarr.Api.Library;
+using Optimisarr.Api.Workers;
+using Optimisarr.Core.Workers;
+using Optimisarr.Data;
+
+namespace Optimisarr.Api.Endpoints;
+
+internal static class WorkerSourceEndpoints
+{
+    public static void MapWorkerSourceEndpoints(this WebApplication app)
+    {
+        // Streams the source a worker has been assigned.
+        //
+        // The single most important property here is that the worker names nothing. It presents a
+        // lease id; the server resolves lease -> job -> media file -> path. There is deliberately no
+        // path, filename, or library parameter anywhere in this route, because any of them would
+        // turn a paired sidecar into an arbitrary file reader on the host. A worker can only ever
+        // fetch the exact file the control plane already decided to give it.
+        //
+        // Read-only throughout: the original is opened for shared reading and never written,
+        // moved, or truncated. Optimisarr remains the only thing that touches originals.
+        app.MapGet("/api/workers/leases/{leaseId:guid}/source", async (
+            Guid leaseId,
+            HttpRequest http,
+            HttpResponse response,
+            SettingsStore settings,
+            OptimisarrDbContext db,
+            CancellationToken cancellationToken) =>
+        {
+            if (await WorkerGate.RefusedAsync(settings, cancellationToken) is { } refused)
+            {
+                return refused;
+            }
+
+            var worker = await WorkerAuth.ResolveAsync(http, db, cancellationToken);
+            if (worker is null)
+            {
+                return WorkerGate.Unauthenticated();
+            }
+
+            var lease = await db.JobLeases
+                .Include(l => l.Job)
+                .ThenInclude(job => job!.MediaFile)
+                .FirstOrDefaultAsync(l => l.Id == leaseId, cancellationToken);
+
+            if (lease is null)
+            {
+                return ApiErrors.NotFound("worker.lease.notFound", $"No lease with id {leaseId}.");
+            }
+
+            if (lease.WorkerId != worker.Id)
+            {
+                return Results.Json(
+                    new ApiError("worker.lease.notHolder", "That lease belongs to another worker."),
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            // A lapsed lease grants nothing. Otherwise a worker that lost its claim could keep
+            // pulling media indefinitely, which is exactly the access the lease is meant to bound.
+            if (lease.ToDomain().StateAt(DateTimeOffset.UtcNow) != LeaseState.Held)
+            {
+                return ApiErrors.Conflict("worker.lease.expired",
+                    "That lease is no longer held, so its source is no longer available.");
+            }
+
+            var job = lease.Job;
+            var path = job?.MediaFile?.Path;
+            if (job is null || string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                return ApiErrors.NotFound("worker.source.missing",
+                    "The source for that lease is no longer on disk.");
+            }
+
+            // Hashed once and remembered. Repeating it per request would re-read gigabytes every
+            // time a transfer resumed, and the value is what later proves a returned candidate was
+            // encoded from these exact bytes rather than some other version of the file.
+            if (string.IsNullOrWhiteSpace(job.SourceSha256))
+            {
+                job.SourceSha256 = await ComputeSha256Async(path, cancellationToken);
+                await db.SaveChangesAsync(cancellationToken);
+            }
+
+            // Let the worker verify what it received without a second pass over the network, and
+            // let it compare against what it will later be held to.
+            response.Headers["X-Optimisarr-Source-Sha256"] = job.SourceSha256;
+            response.Headers["X-Optimisarr-Job-Id"] = job.Id.ToString();
+
+            var stream = new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                // Shared so a scan or probe reading the same original is not blocked by a transfer
+                // that may take minutes.
+                FileShare.Read,
+                bufferSize: 128 * 1024,
+                useAsync: true);
+
+            // enableRangeProcessing is what makes a large transfer resumable: a worker whose
+            // connection drops resumes with a Range header instead of pulling the whole file again.
+            return Results.File(
+                stream,
+                contentType: "application/octet-stream",
+                fileDownloadName: Path.GetFileName(path),
+                enableRangeProcessing: true);
+        })
+        .WithName("FetchLeaseSource")
+        .Produces<ApiError>(StatusCodes.Status401Unauthorized);
+    }
+
+    private static async Task<string> ComputeSha256Async(string path, CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(
+            path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1024 * 1024, useAsync: true);
+        var hash = await SHA256.HashDataAsync(stream, cancellationToken);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}

--- a/src/Optimisarr.Api/Program.cs
+++ b/src/Optimisarr.Api/Program.cs
@@ -234,6 +234,8 @@ app.MapWorkerLeaseEndpoints();
 
 app.MapWorkerSourceEndpoints();
 
+app.MapWorkerResultEndpoints();
+
 app.MapHub<JobsHub>("/hubs/jobs");
 
 app.MapFallbackToFile("index.html", staticFileOptions);

--- a/src/Optimisarr.Api/Program.cs
+++ b/src/Optimisarr.Api/Program.cs
@@ -232,6 +232,8 @@ app.MapWorkerEndpoints();
 
 app.MapWorkerLeaseEndpoints();
 
+app.MapWorkerSourceEndpoints();
+
 app.MapHub<JobsHub>("/hubs/jobs");
 
 app.MapFallbackToFile("index.html", staticFileOptions);

--- a/src/Optimisarr.Data/Job.cs
+++ b/src/Optimisarr.Data/Job.cs
@@ -157,6 +157,16 @@ public sealed class Job
     /// </summary>
     public string? ProcessLog { get; set; }
 
+    /// <summary>
+    /// SHA-256 of the source as it was when a remote worker first fetched it.
+    ///
+    /// Computed once and kept, because hashing a multi-gigabyte file is not something to repeat per
+    /// request. It is what later binds a returned candidate and its quality evidence to the exact
+    /// bytes that were encoded: a result measured against a different source is not evidence about
+    /// this one.
+    /// </summary>
+    public string? SourceSha256 { get; set; }
+
     // --- Verification (Phase 4: populated once the output has been verified) ---
 
     /// <summary>Size of the produced output in bytes, recorded at verification time.</summary>

--- a/src/Optimisarr.Data/Migrations/20260824191153_AddJobSourceHash.Designer.cs
+++ b/src/Optimisarr.Data/Migrations/20260824191153_AddJobSourceHash.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Optimisarr.Data;
 
@@ -10,9 +11,11 @@ using Optimisarr.Data;
 namespace Optimisarr.Data.Migrations
 {
     [DbContext(typeof(OptimisarrDbContext))]
-    partial class OptimisarrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824191153_AddJobSourceHash")]
+    partial class AddJobSourceHash
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/src/Optimisarr.Data/Migrations/20260824191153_AddJobSourceHash.cs
+++ b/src/Optimisarr.Data/Migrations/20260824191153_AddJobSourceHash.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Optimisarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddJobSourceHash : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SourceSha256",
+                table: "Jobs",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SourceSha256",
+                table: "Jobs");
+        }
+    }
+}

--- a/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
+++ b/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
@@ -19,6 +19,10 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
     private readonly AdminTokenAuthEndpointTests.TokenedApi _api;
     private readonly List<int> _createdLibraries = [];
 
+    /// <summary>Small but non-trivial, so hashing and range requests have something to work on.</summary>
+    private static readonly byte[] SourceBytes =
+        Enumerable.Range(0, 4096).Select(i => (byte)(i % 251)).ToArray();
+
     public WorkerLeaseEndpointTests(AdminTokenAuthEndpointTests.TokenedApi api) => _api = api;
 
     public Task InitializeAsync() => Task.CompletedTask;
@@ -112,12 +116,18 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
         await db.SaveChangesAsync();
         _createdLibraries.Add(library.Id);
 
+        Directory.CreateDirectory(library.Path);
+        var sourcePath = Path.Combine(library.Path, "film.mkv");
+        // Real bytes on disk: the source route streams and hashes the actual file, so a row
+        // pointing at nothing would only exercise the missing-file path.
+        await File.WriteAllBytesAsync(sourcePath, SourceBytes);
+
         var file = new MediaFile
         {
             LibraryId = library.Id,
-            Path = Path.Combine(library.Path, "film.mkv"),
+            Path = sourcePath,
             RelativePath = "film.mkv",
-            SizeBytes = 8L * 1024 * 1024 * 1024,
+            SizeBytes = SourceBytes.Length,
         };
         db.MediaFiles.Add(file);
         await db.SaveChangesAsync();
@@ -265,6 +275,93 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
 
         using var claim = await incapable.PostAsJsonAsync("/api/workers/claim", new { });
         Assert.Equal(HttpStatusCode.NoContent, claim.StatusCode);
+    }
+
+
+    [Fact]
+    public async Task The_lease_holder_can_fetch_its_source_with_a_hash_it_can_verify()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Fetcher");
+        await QueueAJob();
+
+        var assignment = await (await worker.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+
+        using var source = await worker.GetAsync($"/api/workers/leases/{leaseId}/source");
+        Assert.Equal(HttpStatusCode.OK, source.StatusCode);
+
+        var received = await source.Content.ReadAsByteArrayAsync();
+        Assert.Equal(SourceBytes, received);
+
+        // The worker must be able to confirm what it received without a second pass, and the value
+        // is what later binds a returned candidate to these exact bytes.
+        var advertised = source.Headers.GetValues("X-Optimisarr-Source-Sha256").Single();
+        var actual = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(received)).ToLowerInvariant();
+        Assert.Equal(actual, advertised);
+    }
+
+    [Fact]
+    public async Task A_worker_cannot_fetch_a_source_for_a_lease_it_does_not_hold()
+    {
+        await EnableRemoteWorkers();
+        var holder = await PairCapableWorker("Source holder");
+        var intruder = await PairCapableWorker("Source intruder");
+        await QueueAJob();
+
+        var assignment = await (await holder.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+
+        using var stolen = await intruder.GetAsync($"/api/workers/leases/{leaseId}/source");
+        Assert.Equal(HttpStatusCode.Forbidden, stolen.StatusCode);
+
+        using var anonymous = await _api.CreateClient().GetAsync($"/api/workers/leases/{leaseId}/source");
+        Assert.Equal(HttpStatusCode.Unauthorized, anonymous.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_released_lease_stops_granting_access_to_the_media()
+    {
+        // The lease is what bounds a worker's reach into the library. Giving the job back must end
+        // that reach, or a worker could keep pulling media it no longer has any claim on.
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Handback");
+        await QueueAJob();
+
+        var assignment = await (await worker.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+
+        (await worker.PostAsJsonAsync($"/api/workers/leases/{leaseId}/release", new { }))
+            .EnsureSuccessStatusCode();
+
+        using var afterRelease = await worker.GetAsync($"/api/workers/leases/{leaseId}/source");
+        Assert.Equal(HttpStatusCode.Conflict, afterRelease.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_dropped_transfer_can_resume_with_a_range_request()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Resumer");
+        await QueueAJob();
+
+        var assignment = await (await worker.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/workers/leases/{leaseId}/source");
+        request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(1000, null);
+
+        using var partial = await worker.SendAsync(request);
+
+        // Without this a worker whose connection drops part-way through a multi-gigabyte source has
+        // to start again from zero.
+        Assert.Equal(HttpStatusCode.PartialContent, partial.StatusCode);
+        var tail = await partial.Content.ReadAsByteArrayAsync();
+        Assert.Equal(SourceBytes.Skip(1000).ToArray(), tail);
     }
 
     [Fact]

--- a/tests/Optimisarr.Tests/WorkerResultUploadTests.cs
+++ b/tests/Optimisarr.Tests/WorkerResultUploadTests.cs
@@ -1,0 +1,260 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Optimisarr.Data;
+
+namespace Optimisarr.Tests;
+
+/// <summary>
+/// Accepting a file produced on someone else's machine is the point in this feature where media can
+/// actually be lost, so these tests lead with the ways it goes wrong rather than the happy path: a
+/// candidate encoded from a different source, a result arriving after the claim lapsed, a truncated
+/// upload, and a second result for one lease.
+///
+/// Nothing here may touch an original. A returned candidate lands in the work directory exactly as
+/// a local transcode's output does, and goes no further until verification has run.
+/// </summary>
+[Collection(TokenedApiCollection.Name)]
+public sealed class WorkerResultUploadTests : IAsyncLifetime
+{
+    private readonly AdminTokenAuthEndpointTests.TokenedApi _api;
+    private readonly List<int> _createdLibraries = [];
+
+    private static readonly byte[] SourceBytes =
+        Enumerable.Range(0, 4096).Select(i => (byte)(i % 251)).ToArray();
+
+    private static readonly byte[] CandidateBytes =
+        Enumerable.Range(0, 2048).Select(i => (byte)(i % 199)).ToArray();
+
+    public WorkerResultUploadTests(AdminTokenAuthEndpointTests.TokenedApi api) => _api = api;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_createdLibraries.Count == 0) return;
+        using var scope = _api.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
+        var jobIds = await db.Jobs
+            .Where(job => job.LibraryId != null && _createdLibraries.Contains(job.LibraryId.Value))
+            .Select(job => job.Id).ToListAsync();
+        db.JobLeases.RemoveRange(db.JobLeases.Where(l => jobIds.Contains(l.JobId)));
+        await db.SaveChangesAsync();
+        db.Libraries.RemoveRange(db.Libraries.Where(l => _createdLibraries.Contains(l.Id)));
+        await db.SaveChangesAsync();
+    }
+
+    private static string Sha256(byte[] bytes) =>
+        Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+    private HttpClient Admin()
+    {
+        var client = _api.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", AdminTokenAuthEndpointTests.TokenedApi.Token);
+        return client;
+    }
+
+    private async Task EnableRemoteWorkers()
+    {
+        var admin = Admin();
+        var current = await (await admin.GetAsync("/api/settings")).Content.ReadFromJsonAsync<JsonElement>();
+        using var doc = JsonDocument.Parse(current.GetRawText());
+        var payload = new Dictionary<string, object?>();
+        foreach (var p in doc.RootElement.EnumerateObject())
+            payload[p.Name] = JsonSerializer.Deserialize<object?>(p.Value.GetRawText());
+        payload["remoteWorkersEnabled"] = true;
+        (await admin.PutAsJsonAsync("/api/settings", payload)).EnsureSuccessStatusCode();
+    }
+
+    private async Task<HttpClient> PairWorker(string name)
+    {
+        var admin = Admin();
+        var pin = (await (await admin.PostAsync("/api/workers/pairing-code", null))
+            .Content.ReadFromJsonAsync<JsonElement>()).GetProperty("code").GetString()!;
+        var paired = await _api.CreateClient().PostAsJsonAsync("/api/workers/pair", new
+        {
+            code = pin, name, operatingSystem = "linux", architecture = "x64",
+            protocolMinimum = 1, protocolMaximum = 1,
+            videoEncoders = new[] { "libx265" }, hardwareDecoders = Array.Empty<string>(),
+            vmaf = "Cpu", freeScratchBytes = 500L * 1024 * 1024 * 1024, maxConcurrency = 1,
+        });
+        paired.EnsureSuccessStatusCode();
+        var credential = (await paired.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("credential").GetString()!;
+        var client = _api.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", credential);
+        return client;
+    }
+
+    private async Task QueueAJob()
+    {
+        using var scope = _api.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
+        var library = new Library { Name = "Results", Path = Path.Combine(_api.LibraryDirectory, Guid.NewGuid().ToString("N")) };
+        db.Libraries.Add(library);
+        await db.SaveChangesAsync();
+        _createdLibraries.Add(library.Id);
+
+        Directory.CreateDirectory(library.Path);
+        var sourcePath = Path.Combine(library.Path, "film.mkv");
+        await File.WriteAllBytesAsync(sourcePath, SourceBytes);
+
+        var file = new MediaFile
+        {
+            LibraryId = library.Id, Path = sourcePath, RelativePath = "film.mkv",
+            SizeBytes = SourceBytes.Length,
+        };
+        db.MediaFiles.Add(file);
+        await db.SaveChangesAsync();
+
+        db.Jobs.Add(new Job
+        {
+            MediaFileId = file.Id, LibraryId = library.Id,
+            Status = JobStatus.Queued, Type = JobType.Normal, VideoEncoder = "libx265",
+        });
+        await db.SaveChangesAsync();
+    }
+
+    /// <summary>Claims a job and fetches its source, which is what records the source hash.</summary>
+    private async Task<(string LeaseId, string SourceHash)> ClaimAndFetch(HttpClient worker)
+    {
+        var assignment = await (await worker.PostAsJsonAsync("/api/workers/claim", new { }))
+            .Content.ReadFromJsonAsync<JsonElement>();
+        var leaseId = assignment.GetProperty("leaseId").GetString()!;
+
+        using var source = await worker.GetAsync($"/api/workers/leases/{leaseId}/source");
+        source.EnsureSuccessStatusCode();
+        var hash = source.Headers.GetValues("X-Optimisarr-Source-Sha256").Single();
+        return (leaseId, hash);
+    }
+
+    private static HttpRequestMessage Upload(string leaseId, byte[] body, string sourceHash, string? candidateHash = null)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/api/workers/leases/{leaseId}/result")
+        {
+            Content = new ByteArrayContent(body),
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        request.Headers.Add("X-Optimisarr-Source-Sha256", sourceHash);
+        request.Headers.Add("X-Optimisarr-Candidate-Sha256", candidateHash ?? Sha256(body));
+        return request;
+    }
+
+    [Fact]
+    public async Task A_candidate_encoded_from_a_different_source_is_refused()
+    {
+        // The case the source hash exists for. A worker that fetched one file and returns a
+        // candidate claiming a different origin has produced something that is not evidence about
+        // this job at all, whatever its quality.
+        await EnableRemoteWorkers();
+        var worker = await PairWorker("Wrong source");
+        await QueueAJob();
+        var (leaseId, _) = await ClaimAndFetch(worker);
+
+        var wrongSource = Sha256(Encoding.UTF8.GetBytes("a completely different original"));
+        using var response = await worker.SendAsync(Upload(leaseId, CandidateBytes, wrongSource));
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_truncated_upload_is_refused_rather_than_stored()
+    {
+        // A transfer that dies part-way leaves a shorter file whose hash cannot match. Accepting it
+        // would mean verifying a partial encode and potentially replacing an original with it.
+        await EnableRemoteWorkers();
+        var worker = await PairWorker("Truncated");
+        await QueueAJob();
+        var (leaseId, sourceHash) = await ClaimAndFetch(worker);
+
+        var truncated = CandidateBytes.Take(500).ToArray();
+        // Claims the hash of the whole file while sending only part of it.
+        using var response = await worker.SendAsync(
+            Upload(leaseId, truncated, sourceHash, candidateHash: Sha256(CandidateBytes)));
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_result_arriving_after_the_claim_lapsed_is_refused()
+    {
+        // The late-result case: the worker went away, the job moved on, and it comes back with a
+        // candidate. It must not be accepted through a claim it no longer holds.
+        await EnableRemoteWorkers();
+        var worker = await PairWorker("Late");
+        await QueueAJob();
+        var (leaseId, sourceHash) = await ClaimAndFetch(worker);
+
+        (await worker.PostAsJsonAsync($"/api/workers/leases/{leaseId}/release", new { }))
+            .EnsureSuccessStatusCode();
+
+        using var response = await worker.SendAsync(Upload(leaseId, CandidateBytes, sourceHash));
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_worker_cannot_deliver_a_result_for_someone_elses_lease()
+    {
+        await EnableRemoteWorkers();
+        var holder = await PairWorker("Result holder");
+        var intruder = await PairWorker("Result intruder");
+        await QueueAJob();
+        var (leaseId, sourceHash) = await ClaimAndFetch(holder);
+
+        using var stolen = await intruder.SendAsync(Upload(leaseId, CandidateBytes, sourceHash));
+        Assert.Equal(HttpStatusCode.Forbidden, stolen.StatusCode);
+
+        using var anonymous = await _api.CreateClient()
+            .SendAsync(Upload(leaseId, CandidateBytes, sourceHash));
+        Assert.Equal(HttpStatusCode.Unauthorized, anonymous.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_second_result_for_one_lease_is_refused()
+    {
+        // Duplicate delivery, which the roadmap calls out explicitly. The first result completes
+        // the lease, so the second has no live claim to arrive through.
+        await EnableRemoteWorkers();
+        var worker = await PairWorker("Duplicate");
+        await QueueAJob();
+        var (leaseId, sourceHash) = await ClaimAndFetch(worker);
+
+        using var first = await worker.SendAsync(Upload(leaseId, CandidateBytes, sourceHash));
+        Assert.Equal(HttpStatusCode.Accepted, first.StatusCode);
+
+        using var second = await worker.SendAsync(Upload(leaseId, CandidateBytes, sourceHash));
+        Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
+    }
+
+    [Fact]
+    public async Task An_accepted_candidate_lands_in_the_work_directory_and_never_over_the_original()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairWorker("Accepted");
+        await QueueAJob();
+        var (leaseId, sourceHash) = await ClaimAndFetch(worker);
+
+        using var response = await worker.SendAsync(Upload(leaseId, CandidateBytes, sourceHash));
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        using var scope = _api.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
+        var job = await db.Jobs.Include(j => j.MediaFile)
+            .FirstAsync(j => j.LibraryId != null && _createdLibraries.Contains(j.LibraryId.Value));
+
+        Assert.NotNull(job.WorkOutputPath);
+        Assert.True(File.Exists(job.WorkOutputPath));
+        Assert.Equal(CandidateBytes, await File.ReadAllBytesAsync(job.WorkOutputPath!));
+
+        // The original must be exactly as it was. A returned candidate is a proposal, not a
+        // replacement, and nothing about delivering one may touch the source.
+        Assert.Equal(SourceBytes, await File.ReadAllBytesAsync(job.MediaFile!.Path));
+    }
+}


### PR DESCRIPTION
## Outcome

`POST /api/workers/leases/{leaseId}/result` accepts the encoded candidate back from a worker,
streamed and hashed as it arrives.

## Tests written before the endpoint, leading with the failures

The happy path is not what loses media. These are the cases that do:

| Case | Result |
|---|---|
| Candidate encoded from a **different source** | `409` |
| **Truncated upload** claiming the full file's hash | `409`, staging file deleted |
| Result arriving **after the claim lapsed** | `409` |
| **Second result** for one lease | `409` |
| Delivery by a worker that **never held the lease** | `403` / `401` |
| Accepted candidate | lands in the work directory; **original byte-for-byte unchanged** |

## The order of the checks is the design

Chosen for what each one protects, not for convenience:

1. **Authenticate** — so nothing about a lease is revealed to a caller with no claim on it.
2. **Prove the claim is still held** — this covers the late result *and* the duplicate delivery in a
   single check, because a completed lease is no longer held. Two named roadmap failure modes, one
   condition.
3. **Prove the candidate is about this source** — using the hash recorded when the source was
   fetched. A file encoded from different bytes is not evidence about this job whatever its quality,
   and verifying one would mean judging a candidate against the wrong original.
4. **Only then** is anything written to disk.

## Streaming and staging

The upload goes to a `.partial` name and is hashed in the same pass, so a multi-gigabyte candidate
never sits in memory and the hash costs no extra read. A transfer that dies leaves nothing that
could be mistaken for a finished candidate, and a hash mismatch deletes the staging file rather than
keeping it around.

## The status it sets, and the honest consequence

An accepted candidate sets `Verifying` — **deliberately not `ReadyToReplace`**. Nothing has judged
it, and a candidate produced on another machine earns nothing until every local gate has been
repeated against it.

That does mean such a job currently sits in `Verifying` with nothing to advance it, because the
verification slice is still outstanding. **A stalled job is the right failure there**; marking it
replaceable would not be. Stated plainly in the roadmap and the history entry rather than left to be
discovered.

## Verification

- `dotnet test` — **1609 passed, 0 failed**. Zero build warnings.
- OpenAPI regenerated; `docs/api.md`, roadmap, history, `CHANGELOG.md` updated.

## Still to build

The verification that judges a returned candidate, resumable upload, the shared-storage path
mapping, and the per-library switch for whether a remote candidate may auto-replace.