### PR TITLE
Build ffmpeg from source, prove hardware encode and decode, and use the app's own mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Added
 
+- **The macOS sidecar now knows what its Mac can actually do.** It bundles its own ffmpeg, built
+  from pinned source rather than downloaded — no prebuilt Apple Silicon build met the requirement,
+  and a worker that cannot measure quality cannot do the job at all. It then proves its hardware
+  instead of assuming it: each VideoToolbox encoder is confirmed with a real throwaway encode, and
+  hardware decode by encoding a clip and decoding it back, because every Apple build lists
+  VideoToolbox whether or not a given machine can open it. Capabilities are probed at pairing, so
+  what the server records is what the machine could do just then. A Mac that proves nothing reports
+  nothing and is never offered work. **It still transcodes nothing** — no work is requested, because
+  the server cannot yet finish a job returned by a worker.
+
 - **Video re-encodes can now be fine-tuned per library.** Advanced options gain a **Fine-tune the
   encoder** group with three settings: a **content tune** for animation or film grain, a **maximum
   bitrate** ceiling on top of the quality target, and **stronger adaptive quantisation** to spend

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -5,22 +5,24 @@ capacity.
 
 ## What this version does, and does not
 
-**It does not transcode anything yet.** It pairs, stores its credential, and checks in. That is the
-whole of version 0.1.0.
+**It does not transcode anything yet.** It pairs, stores its credential, reports what this Mac can
+actually do, and checks in. That is the whole of it.
 
-That is deliberate rather than unfinished. The server cannot dispatch work to a sidecar yet — job
-leasing, media delivery, and the result path are all still to build — so an app that claimed to
-transcode would be claiming something neither end can do. Pairing exists now so the connection can
-be set up and tested while the rest is built, and so this contract has a second implementation
-holding it honest.
+That is deliberate rather than unfinished. Nothing here asks the server for work, because the server
+cannot yet finish a job that came back from a worker: it accepts a returned candidate and leaves it
+waiting for a verification pass that does not exist. An app that claimed to transcode would be
+claiming something neither end can complete.
 
-The app reports **no encoders and no VMAF support**, because it has none to prove: no ffmpeg is
-bundled with it yet. The probing that will report them is written and tested — it parses
-`ffmpeg -encoders` and then confirms each VideoToolbox encoder with a real throwaway encode, because
-every Apple build lists VideoToolbox whether or not a given machine can actually open it. With no
-ffmpeg present it reports nothing, which is the honest answer. Optimisarr's capability matcher fails closed, so a worker advertising nothing is
-never offered work. Honesty here is the safety mechanism — a sidecar that overstated itself would
-have jobs scheduled onto it that could only fail.
+What it *does* now report is real. It bundles its own ffmpeg, built from pinned source by
+[`scripts/build-ffmpeg.sh`](scripts/build-ffmpeg.sh), and probes this machine in two stages: parse
+`ffmpeg -encoders`, then confirm each VideoToolbox encoder with a real throwaway encode. Every Apple
+build lists VideoToolbox whether or not a given machine can open it, so listing alone would have the
+sidecar advertise encoders that fail on first use. Hardware *decode* is proved the same way — encode
+a clip, decode it back with VideoToolbox engaged, and both halves must succeed.
+
+A machine that proves nothing reports nothing, and Optimisarr's capability matcher fails closed, so
+such a worker is never offered work. Honesty here is the safety mechanism: a sidecar that overstated
+itself would have jobs scheduled onto it that could only fail.
 
 Optimisarr remains the only thing that replaces, quarantines, moves, or deletes a file. A sidecar
 never can, by design, and nothing in this app is capable of touching media.
@@ -90,7 +92,8 @@ width. Once visible it can be ⌘-dragged wherever suits.
 swift test
 ```
 
-21 tests covering the protocol client, the pairing and check-in lifecycle, and address handling.
+43 tests covering the protocol client, the pairing and check-in lifecycle, address handling,
+and capability probing — including live probes against the bundled ffmpeg.
 
 There is also a live suite that runs against a real server, skipped unless you point it at one:
 

--- a/sidecars/macos/Sources/OptimisarrSidecar/MenuBarIcon.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/MenuBarIcon.swift
@@ -1,0 +1,127 @@
+import AppKit
+import SidecarCore
+
+/// The menu bar mark: Optimisarr's isometric wireframe cube, drawn rather than scaled from the app
+/// icon.
+///
+/// A menu bar icon must be a *template* — flat shapes with no colour of their own, which macOS
+/// tints for light and dark and inverts while the menu is open. The app icon is a glowing cyan
+/// render on a dark ground; thresholding that into a silhouette gives mud at 16pt, and it would
+/// look wrong the moment the menu highlighted. Redrawing the mark as strokes keeps it crisp at menu
+/// bar size and lets the system own the colour, which is what makes it sit correctly next to
+/// Apple's own icons.
+///
+/// The cube is simplified deliberately. All twelve wireframe edges read as a smudge at this size,
+/// so it draws the hexagonal silhouette plus the three edges meeting at the centre — the projection
+/// the full wireframe resolves to anyway, and the part the eye actually reads as "cube".
+enum MenuBarIcon {
+    /// Menu bar content is 16pt tall by convention; a touch smaller leaves optical breathing room.
+    private static let size = NSSize(width: 18, height: 18)
+
+    static func image(for status: SidecarStatus) -> NSImage {
+        let image = NSImage(size: size, flipped: false) { rect in
+            let badge = badge(for: status)
+            drawCube(in: rect, badged: badge != nil)
+            if let badge {
+                draw(badge: badge, in: rect)
+            }
+            return true
+        }
+
+        // The whole point: macOS colours it, so it adapts to the menu bar's appearance and to
+        // being highlighted rather than staying one fixed shade.
+        image.isTemplate = true
+        return image
+    }
+
+    private static func drawCube(in rect: NSRect, badged: Bool) {
+        // Shifted up and left when badged so the dot gets its own corner. Overlapping the mark
+        // instead means punching a hole through an edge, which reads as a broken cube rather than
+        // a cube with a status dot.
+        var inset = rect.insetBy(dx: 2, dy: 2)
+        if badged {
+            inset = NSRect(
+                x: inset.minX,
+                y: inset.minY + 2.5,
+                width: inset.width - 2.5,
+                height: inset.height - 2.5)
+        }
+        let centre = NSPoint(x: inset.midX, y: inset.midY)
+        let radius = min(inset.width, inset.height) / 2
+
+        // A cube in isometric projection is a regular hexagon with three spokes to alternating
+        // vertices. Starting at 90° puts a vertex at the top, which is how the app icon sits.
+        var vertices: [NSPoint] = []
+        for step in 0..<6 {
+            let angle = CGFloat.pi / 2 + CGFloat(step) * (CGFloat.pi / 3)
+            vertices.append(NSPoint(
+                x: centre.x + radius * cos(angle),
+                y: centre.y + radius * sin(angle)))
+        }
+
+        let path = NSBezierPath()
+        path.lineWidth = 1.4
+        path.lineJoinStyle = .round
+        path.lineCapStyle = .round
+
+        path.move(to: vertices[0])
+        for vertex in vertices.dropFirst() {
+            path.line(to: vertex)
+        }
+        path.close()
+
+        // The three visible front edges, meeting at the centre — what makes it read as a solid
+        // rather than a flat hexagon.
+        for index in stride(from: 1, to: 6, by: 2) {
+            path.move(to: centre)
+            path.line(to: vertices[index])
+        }
+
+        NSColor.black.setStroke()
+        path.stroke()
+    }
+
+    /// Whether the state needs saying, and how loudly.
+    ///
+    /// Connected carries no badge at all: the ordinary state should look ordinary, and a permanent
+    /// marker would train the eye to ignore it. Anything else gets a dot, because the reason to
+    /// glance at a menu bar icon is to find out whether something needs attention.
+    private static func badge(for status: SidecarStatus) -> Badge? {
+        switch status {
+        case .connected: return nil
+        case .pairing: return .hollow
+        case .unpaired: return .hollow
+        case .unreachable, .disabledOnServer: return .solid
+        case .revoked, .pairingFailed: return .solid
+        }
+    }
+
+    private enum Badge {
+        case hollow
+        case solid
+    }
+
+    private static func draw(badge: Badge, in rect: NSRect) {
+        let diameter: CGFloat = 5
+        // Bottom-trailing, where a badge conventionally sits and where it overlaps least of the
+        // mark.
+        let dot = NSRect(
+            x: rect.maxX - diameter - 1,
+            y: rect.minY + 1,
+            width: diameter,
+            height: diameter)
+
+        // No clearance punch: the cube has already moved aside, so the dot sits in free space
+        // rather than being cut out of a stroke.
+        let path = NSBezierPath(ovalIn: dot.insetBy(dx: 0.6, dy: 0.6))
+        NSColor.black.set()
+
+        switch badge {
+        case .solid:
+            path.fill()
+        case .hollow:
+            path.lineWidth = 1.4
+            path.stroke()
+        }
+    }
+}

--- a/sidecars/macos/Sources/OptimisarrSidecar/OptimisarrSidecarApp.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/OptimisarrSidecarApp.swift
@@ -26,8 +26,10 @@ struct OptimisarrSidecarApp: App {
         MenuBarExtra {
             SidecarMenu(session: session)
         } label: {
-            // The icon carries the state, so a glance answers "is it working?" without clicking.
-            Image(systemName: session.status.symbolName)
+            // Optimisarr's own mark rather than a stock symbol, drawn as a template so macOS tints
+            // it for the menu bar's appearance. State rides along as a badge instead of swapping
+            // the icon wholesale, so the thing in the menu bar stays recognisably this app.
+            Image(nsImage: MenuBarIcon.image(for: session.status))
         }
         .menuBarExtraStyle(.window)
     }
@@ -61,9 +63,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// no reason to know it lives in the menu bar, and if the icon is hidden they would otherwise
     /// see nothing happen at all.
     func applicationDidFinishLaunching(_ notification: Notification) {
-        AppState.shared.session.restore()
-        if case .unpaired = AppState.shared.session.status {
-            showPairingWindow()
+        // Deferred rather than run inline. Restoring reads the Keychain, and anything that touches
+        // the Keychain can in principle block; doing it here on the launch path once left the app
+        // running with no menu bar icon and no window at all, because it was stuck behind a modal
+        // authorisation prompt. Letting launch finish first means the icon appears whatever the
+        // Keychain does.
+        Task { @MainActor in
+            AppState.shared.session.restore()
+            if case .unpaired = AppState.shared.session.status {
+                showPairingWindow()
+            }
         }
     }
 
@@ -90,16 +99,3 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 }
 
-extension SidecarStatus {
-    var symbolName: String {
-        switch self {
-        case .connected: return "checkmark.circle.fill"
-        case .pairing: return "ellipsis.circle"
-        case .unpaired: return "link.badge.plus"
-        case .unreachable: return "exclamationmark.triangle"
-        case .revoked: return "xmark.circle.fill"
-        case .disabledOnServer: return "pause.circle"
-        case .pairingFailed: return "exclamationmark.triangle"
-        }
-    }
-}

--- a/sidecars/macos/Sources/SidecarCore/CapabilityProber.swift
+++ b/sidecars/macos/Sources/SidecarCore/CapabilityProber.swift
@@ -92,15 +92,46 @@ public struct CapabilityProber: Sendable {
         let filters = await runner.run(ffmpeg, ["-hide_banner", "-filters"])
         let vmaf = filters.exitCode == 0 ? VmafSupportParser.parse(filters.output) : VmafCapability.none
 
+        let decoders = await provedHardwareDecoders(ffmpeg: ffmpeg, provedEncoders: proved)
+
         return SidecarCapabilities(
             name: name,
             videoEncoders: proved,
-            hardwareDecoders: [],
+            hardwareDecoders: decoders,
             vmaf: vmaf,
             freeScratchBytes: freeScratchBytes(),
             // Nothing to offer means nothing to accept. Reporting concurrency while advertising no
             // encoder would have the server see a live worker it can never actually use.
             maxConcurrency: proved.isEmpty ? 0 : maxConcurrency)
+    }
+
+    /// Proves hardware decode rather than trusting the accelerator listing.
+    ///
+    /// Encodes a throwaway clip and decodes it back with VideoToolbox engaged. Both halves must
+    /// succeed: listing an accelerator only says ffmpeg was compiled for it, and a decoder that
+    /// cannot open is the same problem as an encoder that cannot — a job scheduled against it can
+    /// only fail. Needs a proved hardware encoder to make the clip, so a machine with no hardware
+    /// encode reports no hardware decode, which is conservative rather than exact.
+    private func provedHardwareDecoders(ffmpeg: URL, provedEncoders: [String]) async -> [String] {
+        let accelerators = await runner.run(ffmpeg, ["-hide_banner", "-hwaccels"])
+        guard accelerators.exitCode == 0,
+              !HardwareAcceleratorParser.parse(accelerators.output).isEmpty,
+              let encoder = provedEncoders.first(where: { $0.hasSuffix("_videotoolbox") })
+        else {
+            return []
+        }
+
+        let clip = scratchDirectory
+            .appendingPathComponent("optimisarr-hwprobe-\(UUID().uuidString).mp4")
+        defer { try? FileManager.default.removeItem(at: clip) }
+
+        let encoded = await runner.run(
+            ffmpeg, HardwareDecodeProbeCommand.encodeArguments(to: clip.path, using: encoder))
+        guard encoded.exitCode == 0 else { return [] }
+
+        let decoded = await runner.run(
+            ffmpeg, HardwareDecodeProbeCommand.decodeArguments(from: clip.path))
+        return decoded.exitCode == 0 ? ["videotoolbox"] : []
     }
 
     /// Real free space where the candidate would be written, not a guess. A worker that cannot hold

--- a/sidecars/macos/Sources/SidecarCore/CredentialStore.swift
+++ b/sidecars/macos/Sources/SidecarCore/CredentialStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LocalAuthentication
 import Security
 
 /// Where a paired credential is kept between launches.
@@ -52,10 +53,31 @@ public struct KeychainCredentialStore: CredentialStore {
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
 
+        // Never allow the Keychain to put a dialog on screen.
+        //
+        // An ad-hoc signature is not stable across builds, so a rebuilt app is a *different*
+        // application as far as the Keychain is concerned, and reading an item the previous build
+        // created raises an authorisation prompt. That prompt is modal, and this call sits on the
+        // launch path — so the app hangs behind it with no menu bar icon and no window, looking for
+        // all the world like it failed to start. Asking for the item without interaction turns that
+        // into an ordinary error we can handle instead.
+        let context = LAContext()
+        context.interactionNotAllowed = true
+        query[kSecUseAuthenticationContext as String] = context
+
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
 
         if status == errSecItemNotFound { return nil }
+
+        // Present but unreadable — typically an item written by a previous build of this app.
+        // Treated as "not paired" rather than as a failure: the credential is unrecoverable either
+        // way, and asking the operator to pair again is far better than blocking the app or
+        // nagging them for a password they should not be typing into an unsigned build.
+        if status == errSecInteractionNotAllowed || status == errSecAuthFailed {
+            return nil
+        }
+
         guard status == errSecSuccess, let data = item as? Data else {
             throw KeychainError.unexpectedStatus(status)
         }

--- a/sidecars/macos/Sources/SidecarCore/EncoderProbe.swift
+++ b/sidecars/macos/Sources/SidecarCore/EncoderProbe.swift
@@ -76,3 +76,45 @@ public enum VmafSupportParser {
         filtersOutput.contains("libvmaf") ? .cpu : .none
     }
 }
+
+/// Parses `ffmpeg -hwaccels`.
+///
+/// On Apple the only entry that matters is `videotoolbox`, which covers hardware decode. Unlike an
+/// encoder there is no per-codec decoder name to advertise — decode is requested as
+/// `-hwaccel videotoolbox` — so that is the name reported, and it is reported only once a real
+/// decode has been shown to work.
+public enum HardwareAcceleratorParser {
+    public static func parse(_ output: String) -> [String] {
+        output
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { $0 == "videotoolbox" }
+    }
+}
+
+/// Builds the round trip that proves hardware decode actually works.
+///
+/// Listing `videotoolbox` under `-hwaccels` only says ffmpeg was compiled for it. Proving it needs
+/// something real to decode, so a short clip is encoded first and then decoded back with the
+/// accelerator engaged. Both halves have to succeed, which is stricter than either alone.
+public enum HardwareDecodeProbeCommand {
+    /// Encodes a throwaway clip to a file, using the hardware encoder already proved.
+    public static func encodeArguments(to path: String, using encoder: String) -> [String] {
+        [
+            "-hide_banner", "-v", "error", "-y",
+            "-f", "lavfi", "-i", "testsrc=s=320x240:r=25:d=1",
+            "-c:v", encoder,
+            path,
+        ]
+    }
+
+    /// Decodes it back with the accelerator engaged, to the null muxer.
+    public static func decodeArguments(from path: String) -> [String] {
+        [
+            "-hide_banner", "-v", "error",
+            "-hwaccel", "videotoolbox",
+            "-i", path,
+            "-f", "null", "-",
+        ]
+    }
+}

--- a/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
@@ -39,7 +39,8 @@ public final class SidecarSession: ObservableObject {
 
     private let client: SidecarClient
     private let store: CredentialStore
-    private let capabilities: SidecarCapabilities
+    private let prober: CapabilityProber?
+    private var capabilities: SidecarCapabilities
     private let sleep: @Sendable (TimeInterval) async throws -> Void
 
     private var pairing: StoredPairing?
@@ -49,6 +50,7 @@ public final class SidecarSession: ObservableObject {
         client: SidecarClient = SidecarClient(),
         store: CredentialStore = KeychainCredentialStore(),
         capabilities: SidecarCapabilities = .provenToday(name: Host.current().localizedName ?? "Mac"),
+        prober: CapabilityProber? = CapabilityProber(),
         sleep: @escaping @Sendable (TimeInterval) async throws -> Void = { seconds in
             try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
         }
@@ -56,6 +58,7 @@ public final class SidecarSession: ObservableObject {
         self.client = client
         self.store = store
         self.capabilities = capabilities
+        self.prober = prober
         self.sleep = sleep
     }
 
@@ -75,6 +78,14 @@ public final class SidecarSession: ObservableObject {
     public func pair(serverAddress address: String, pin: String) async {
         status = .pairing
         serverAddress = address
+
+        // Probed at the moment of pairing rather than at launch, so what the server records is what
+        // this machine could do just now — a driver or an ffmpeg that changed since startup would
+        // otherwise be reported as it was, and a capability the server believes but the machine
+        // cannot honour is a job that can only fail.
+        if let prober {
+            capabilities = await prober.probe(name: capabilities.name, maxConcurrency: 1)
+        }
 
         do {
             let result = try await client.pair(

--- a/sidecars/macos/Tests/SidecarCoreTests/CapabilityProberTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/CapabilityProberTests.swift
@@ -14,6 +14,9 @@ final class ScriptedRunner: CommandRunner, @unchecked Sendable {
         lock.withLock {
             if arguments.contains("-encoders") { return replies["encoders"] ?? (1, "") }
             if arguments.contains("-filters") { return replies["filters"] ?? (1, "") }
+            if arguments.contains("-hwaccels") { return replies["hwaccels"] ?? (1, "") }
+            // The decode half of the hardware round trip.
+            if arguments.contains("-hwaccel") { return replies["decode"] ?? (1, "") }
             // A confirmation encode; remember which encoder was proved.
             if let index = arguments.firstIndex(of: "-c:v"), index + 1 < arguments.count {
                 let encoder = arguments[index + 1]
@@ -105,5 +108,46 @@ struct CapabilityProberTests {
         let runner = ScriptedRunner(["encoders": (1, "not found")])
 
         #expect(await prober(runner).probe(name: "Mac").videoEncoders.isEmpty)
+    }
+
+    @Test("hardware decode is proved by a real round trip, not by the accelerator listing")
+    func provesHardwareDecode() async {
+        let runner = ScriptedRunner([
+            "encoders": (0, listing), "filters": (0, "libvmaf"),
+            "hevc_videotoolbox": (0, ""),
+            "hwaccels": (0, "Hardware acceleration methods:\nvideotoolbox"),
+            "decode": (0, ""),
+        ])
+
+        let capabilities = await prober(runner).probe(name: "Mac")
+
+        #expect(capabilities.hardwareDecoders.contains("videotoolbox"))
+    }
+
+    @Test("an accelerator that lists but cannot decode is not advertised")
+    func rejectsBrokenDecode() async {
+        // Same reasoning as the encoder: listing says ffmpeg was compiled for it, not that this
+        // machine can open it.
+        let runner = ScriptedRunner([
+            "encoders": (0, listing), "filters": (0, "libvmaf"),
+            "hevc_videotoolbox": (0, ""),
+            "hwaccels": (0, "Hardware acceleration methods:\nvideotoolbox"),
+            "decode": (1, "Failed to open decoder"),
+        ])
+
+        #expect(await prober(runner).probe(name: "Mac").hardwareDecoders.isEmpty)
+    }
+
+    @Test("no hardware encoder means no hardware decode is claimed")
+    func conservativeWithoutHardwareEncoder() async {
+        // The round trip needs a hardware encoder to produce something to decode. Reporting decode
+        // without having proved it would be a guess, and the conservative answer is silence.
+        let runner = ScriptedRunner([
+            "encoders": (0, " V....D libx265  libx265 H.265 / HEVC"),
+            "filters": (0, "libvmaf"),
+            "hwaccels": (0, "Hardware acceleration methods:\nvideotoolbox"),
+        ])
+
+        #expect(await prober(runner).probe(name: "Mac").hardwareDecoders.isEmpty)
     }
 }

--- a/sidecars/macos/Tests/SidecarCoreTests/LiveCapabilityTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/LiveCapabilityTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import SidecarCore
+
+/// Runs the real prober against the real bundled ffmpeg.
+///
+/// Skipped unless `OPTIMISARR_FFMPEG` points at one, because it needs a build that
+/// `scripts/build-ffmpeg.sh` produces. The stubbed tests prove the prober behaves as intended
+/// against scripted output; only this proves the intent matches what ffmpeg actually says on real
+/// hardware — which is the whole reason the probe confirms with an encode instead of trusting a
+/// listing.
+///
+///     OPTIMISARR_FFMPEG=$(pwd)/vendor/ffmpeg swift test
+@Suite("Live capability", .enabled(if: ProcessInfo.processInfo.environment["OPTIMISARR_FFMPEG"] != nil))
+struct LiveCapabilityTests {
+    private var ffmpeg: URL {
+        URL(fileURLWithPath: ProcessInfo.processInfo.environment["OPTIMISARR_FFMPEG"] ?? "")
+    }
+
+    @Test("proves what this machine can really do")
+    func provesRealCapabilities() async {
+        let capabilities = await CapabilityProber(ffmpeg: ffmpeg).probe(name: "Live probe", maxConcurrency: 2)
+
+        // libx265 is compiled in, so it must be advertised.
+        #expect(capabilities.videoEncoders.contains("libx265"))
+
+        // VMAF is the reason this ffmpeg is built from source rather than downloaded; without it
+        // the worker could not measure the quality of what it encodes.
+        #expect(capabilities.vmaf == .cpu)
+
+        // Free space is read from the real volume, not guessed.
+        #expect(capabilities.freeScratchBytes > 0)
+
+        // Something was proved, so capacity is offered.
+        #expect(capabilities.maxConcurrency == 2)
+    }
+
+    @Test("advertises VideoToolbox encode only after a real encode succeeds")
+    func videoToolboxEncodeIsProved() async {
+        let capabilities = await CapabilityProber(ffmpeg: ffmpeg).probe(name: "Live probe")
+
+        // On Apple Silicon this should pass its confirmation encode. If it ever does not, the right
+        // outcome is absence from this list rather than a claim that fails on the first real job.
+        #expect(capabilities.videoEncoders.contains("hevc_videotoolbox"))
+    }
+
+    @Test("proves VideoToolbox decode with a real encode-then-decode round trip")
+    func videoToolboxDecodeIsProved() async {
+        let capabilities = await CapabilityProber(ffmpeg: ffmpeg).probe(name: "Live probe")
+
+        // Listing an accelerator says ffmpeg was compiled for it, not that this machine can open
+        // it — so the prober encodes a throwaway clip and decodes it back before claiming decode.
+        #expect(capabilities.hardwareDecoders.contains("videotoolbox"))
+    }
+}

--- a/sidecars/macos/scripts/build-ffmpeg.sh
+++ b/sidecars/macos/scripts/build-ffmpeg.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Builds the ffmpeg and ffprobe the sidecar bundles, from source.
+#
+# Built rather than downloaded because no prebuilt macOS binary met the requirement. The one
+# Apple Silicon build available published a checksum that did not match the file it served, and
+# omitted libvmaf entirely; the build that does ship libvmaf is Intel-only. Since the worker has to
+# measure the quality of what it encodes, and the control plane will only accept that measurement
+# bound to exact hashes, an ffmpeg without libvmaf cannot do the job at all.
+#
+# Everything is pinned to a git tag. Codec libraries are built static into a private prefix so the
+# result carries no dependency on Homebrew or on anything else that happens to be installed — a
+# binary inside a signed app must not stop working because someone ran `brew uninstall`.
+#
+# Takes a while. x265 in particular is not quick.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VENDOR="$(pwd)/vendor"
+BUILD="$(pwd)/.build-ffmpeg"
+PREFIX="${BUILD}/prefix"
+
+# Pinned. Moving any of these is a deliberate act, not a drift.
+X264_TAG="stable"
+X265_TAG="4.2"
+VMAF_TAG="v3.0.0"
+FFMPEG_TAG="n7.1"
+
+JOBS="$(sysctl -n hw.ncpu)"
+
+mkdir -p "${VENDOR}" "${BUILD}" "${PREFIX}"
+export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
+export PATH="${PREFIX}/bin:${PATH}"
+
+clone_at() {
+  local url="$1" tag="$2" dir="$3"
+  if [[ -d "${BUILD}/${dir}/.git" ]]; then
+    echo "  ${dir}: already cloned"
+    return
+  fi
+  echo "  ${dir}: cloning ${tag}…"
+  git clone --depth 1 --branch "${tag}" "${url}" "${BUILD}/${dir}" >/dev/null 2>&1
+}
+
+echo "==> Fetching sources"
+clone_at "https://code.videolan.org/videolan/x264.git" "${X264_TAG}" x264
+clone_at "https://bitbucket.org/multicoreware/x265_git.git" "${X265_TAG}" x265
+clone_at "https://github.com/Netflix/vmaf.git" "${VMAF_TAG}" vmaf
+clone_at "https://github.com/FFmpeg/FFmpeg.git" "${FFMPEG_TAG}" ffmpeg
+
+echo "==> Recording exactly what was built"
+{
+  echo "built: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  for d in x264 x265 vmaf ffmpeg; do
+    printf '%-8s %s %s\n' "${d}" "$(git -C "${BUILD}/${d}" describe --tags --always 2>/dev/null || echo '?')" \
+      "$(git -C "${BUILD}/${d}" rev-parse HEAD 2>/dev/null || echo '?')"
+  done
+} > "${VENDOR}/BUILD-INFO.txt"
+cat "${VENDOR}/BUILD-INFO.txt"
+
+if [[ ! -f "${PREFIX}/lib/libx264.a" ]]; then
+  echo "==> x264"
+  (cd "${BUILD}/x264" && ./configure --prefix="${PREFIX}" --enable-static --enable-pic \
+      --disable-cli --disable-opencl >/dev/null && make -j"${JOBS}" >/dev/null && make install >/dev/null)
+fi
+
+if [[ ! -f "${PREFIX}/lib/libx265.a" ]]; then
+  echo "==> x265"
+  # x265 predates CMake 4, which removed both the pre-3.5 minimum and the OLD setting for policies
+  # the project sets explicitly. CMAKE_POLICY_VERSION_MINIMUM alone is not enough — an explicit
+  # cmake_policy(SET ... OLD) still errors — so the tag is the fix and this flag covers the
+  # minimum-version half.
+  (cd "${BUILD}/x265/build" && cmake ../source -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+      -DENABLE_SHARED=OFF -DENABLE_CLI=OFF >/dev/null && make -j"${JOBS}" >/dev/null && make install >/dev/null)
+fi
+
+if [[ ! -f "${PREFIX}/lib/libvmaf.a" ]]; then
+  echo "==> libvmaf"
+  (cd "${BUILD}/vmaf/libvmaf" && meson setup build --buildtype release --default-library static \
+      --prefix "${PREFIX}" -Denable_tests=false -Denable_docs=false >/dev/null \
+    && ninja -C build >/dev/null && ninja -C build install >/dev/null)
+fi
+
+echo "==> ffmpeg"
+# VideoToolbox comes from the platform rather than a third-party library, and is what makes hardware
+# encoding possible here at all. libvmaf is the reason this script exists.
+(cd "${BUILD}/ffmpeg" && ./configure \
+    --prefix="${PREFIX}" \
+    --pkg-config-flags="--static" \
+    --extra-cflags="-I${PREFIX}/include" \
+    --extra-ldflags="-L${PREFIX}/lib" \
+    `# libvmaf is partly C++ (its SVM model parser), and ffmpeg links through the C driver, so the` \
+    `# C++ runtime has to be named explicitly or the link fails on __cxa_throw and friends.` \
+    --extra-libs="-lc++" \
+    --enable-gpl \
+    --enable-version3 \
+    --enable-static --disable-shared \
+    --enable-libx264 \
+    --enable-libx265 \
+    --enable-libvmaf \
+    --enable-videotoolbox \
+    --disable-doc \
+    --disable-debug \
+    --disable-ffplay \
+    >/dev/null && make -j"${JOBS}" >/dev/null)
+
+cp "${BUILD}/ffmpeg/ffmpeg" "${VENDOR}/ffmpeg"
+cp "${BUILD}/ffmpeg/ffprobe" "${VENDOR}/ffprobe"
+chmod +x "${VENDOR}/ffmpeg" "${VENDOR}/ffprobe"
+
+echo
+echo "==> Built"
+"${VENDOR}/ffmpeg" -hide_banner -version | head -1
+echo "libvmaf present: $("${VENDOR}/ffmpeg" -hide_banner -filters 2>/dev/null | grep -c libvmaf)"
+echo "videotoolbox encoders: $("${VENDOR}/ffmpeg" -hide_banner -encoders 2>/dev/null | grep -c videotoolbox)"
+echo "non-system dynamic links (should be none):"
+otool -L "${VENDOR}/ffmpeg" | tail -n +2 | grep -v '/usr/lib/\|/System/' || echo "  none"

--- a/sidecars/macos/scripts/make-app.sh
+++ b/sidecars/macos/scripts/make-app.sh
@@ -23,6 +23,17 @@ rm -rf "${BUNDLE}"
 mkdir -p "${BUNDLE}/Contents/MacOS" "${BUNDLE}/Contents/Resources"
 cp "${BINARY}" "${BUNDLE}/Contents/MacOS/${APP_NAME}"
 
+# The bundled ffmpeg, if it has been built. Without it the app still runs and pairs; it simply
+# proves no encoders and is never offered work, which is the honest state rather than a broken one.
+if [[ -x vendor/ffmpeg ]]; then
+  cp vendor/ffmpeg "${BUNDLE}/Contents/Resources/ffmpeg"
+  [[ -x vendor/ffprobe ]] && cp vendor/ffprobe "${BUNDLE}/Contents/Resources/ffprobe"
+  [[ -f vendor/BUILD-INFO.txt ]] && cp vendor/BUILD-INFO.txt "${BUNDLE}/Contents/Resources/"
+  echo "Bundled ffmpeg: $(vendor/ffmpeg -hide_banner -version | head -1)"
+else
+  echo "warning: no vendor/ffmpeg — run scripts/build-ffmpeg.sh; the app will prove no encoders" >&2
+fi
+
 # LSUIElement keeps it out of the Dock and the app switcher. The app also sets its activation
 # policy at startup, so it behaves correctly even when run straight from the build directory.
 cat > "${BUNDLE}/Contents/Info.plist" <<'PLIST'


### PR DESCRIPTION
**Stacked on #91** — it builds on the capability probing there, so it targets that branch rather
than `dev`. Merge #91 first and this retargets automatically.

## ffmpeg is built from source, not downloaded

No prebuilt macOS binary met the requirement:

- **osxexperts** (the only Apple Silicon build): the published SHA-256 did not match the file it
  served, and the build omits **libvmaf** entirely.
- **evermeet** (the one ffmpeg.org links to): has libvmaf, but the maintainer states plainly they do
  not build for Apple Silicon.
- **The FFmpeg project publishes no official binaries at all**, for any platform.

Since the worker must measure the quality of what it encodes, and the control plane accepts that
measurement only bound to exact hashes, an ffmpeg without libvmaf cannot do the job. Building is the
conservative option here, not the elaborate one.

`build-ffmpeg.sh` pins x264 `stable`, x265 `4.2`, libvmaf `v3.0.0` and ffmpeg `n7.1` to git tags and
links the codec libraries statically into a private prefix, so the result depends on nothing that
happens to be installed. It records every commit hash to `BUILD-INFO.txt` and asserts at the end
that nothing links outside `/usr/lib` and `/System`.

**Verified:** ffmpeg n7.1, libvmaf present, 3 VideoToolbox encoders, zero external dynamic links.

Two failures on the way, both recorded in the script's comments: x265 4.1 will not configure under
CMake 4 (fixed by 4.2 upstream rather than patching a vendored `CMakeLists`), and static libvmaf
needs `-lc++` because its SVM parser is C++ while ffmpeg links through the C driver.

## Hardware decode is now probed, not assumed

The prober hardcoded `hardwareDecoders: []`, so the server could never know decode was available.

It now encodes a throwaway clip with a proved hardware encoder and decodes it back with VideoToolbox
engaged — **both halves must succeed**. Listing an accelerator only says ffmpeg was compiled for it.
A machine with no hardware encoder reports no hardware decode, which is conservative rather than
exact.

**Confirmed on real hardware:** `hevc_videotoolbox` encodes, and VideoToolbox decodes a real HEVC
file.

Capabilities are also probed **at pairing** rather than at launch, so what the server records is
what the machine could do just then.

## The menu bar mark

Optimisarr's isometric cube, drawn as a **template image** so macOS tints it for light and dark and
inverts it when the menu opens. The app icon is a glowing cyan render on a dark ground — it
thresholds to mud at 16pt and would look wrong the instant the menu highlighted.

State rides as a badge rather than swapping the icon, so what sits in the menu bar stays
recognisably this app. Connected carries **no badge**: the ordinary state should look ordinary. When
badged the cube shifts aside to give the dot its own corner, because overlapping punched a hole
through an edge and read as a broken cube.

## A launch bug this exposed, and a warning

The app was launching with **no menu bar icon and no window**. That looked like a rendering fault
and was not — it was blocked behind a modal Keychain authorisation prompt.

An ad-hoc signature is not stable across builds, so a rebuilt app is a *different* application to
the Keychain, and reading an item the previous build wrote raises a prompt. **That prompt asks for a
login password, which nobody should be typing into an unsigned development build.**

The load now refuses interaction outright (`LAContext.interactionNotAllowed`) and treats an
unreadable item as "not paired" — the credential is unrecoverable either way and re-pairing takes
seconds. Restore is deferred off the launch path, so nothing the Keychain does can stop the icon
appearing.

## Verification

- `swift build` — clean. `swift test` — **43 passed**, including live probes against the real binary.
- App relaunched: 2 menu bars, status item present, pairing window open, no prompt.