### PR TITLE
Define what makes a remote quality measurement admissible

### DIFF
--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -29,6 +29,29 @@ test asserts the field is a JSON string rather than a number, so the ordinal for
 unnoticed. Breaking for the worker contract, but its only consumer today is a curl command in
 testing; the cost of this change rises steeply once a tray app ships.
 
+**Started on dev (2026-08-24) — what makes a remote quality measurement admissible.** VMAF is the
+one thing Optimisarr will accept from a sidecar without deriving it again, so the rule for believing
+it is worth stating precisely. Everything else about a returned candidate is re-checked locally
+because those checks are cheap relative to the encode; VMAF is not, at roughly half the cost of
+verification, so re-measuring it would give back most of the benefit of distributing the work.
+
+The failure this guards against is not a worker that lies loudly. It is one that answers a slightly
+different question — measuring a different encode, or grading itself against an easier policy — and
+returns a number that looks like an answer. So evidence is refused unless it names the exact source
+and candidate hashes, names the VMAF model, and was measured against thresholds at least as strict
+as the library requires. Stricter is accepted: passing a harder test than the one set still passes
+the one set.
+
+The model requirement is not bookkeeping. The same file scores differently under the HD and 4K
+models, so an unlabelled score cannot meaningfully be compared to a threshold at all.
+
+Absent evidence is refused rather than read as "nothing objected", which is the difference between
+failing closed and having a worker skip measuring entirely and sail through. Every objection is
+reported rather than the first, for the same reason the capability matcher names them all.
+
+Twelve tests, written before the validator and each describing a way this goes wrong rather than a
+way it goes right.
+
 **Started on dev (2026-08-24) — taking delivery of a candidate encoded elsewhere.** The tests were
 written before the endpoint and lead with the ways it goes wrong, because the happy path is not what
 loses media: a candidate encoded from a different source, a result arriving after the claim lapsed,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -530,9 +530,18 @@ the replacement workflow is trustworthy.
      declared — which together cover the late result, the duplicate delivery, the candidate encoded
      from the wrong original, and the truncated upload. An accepted candidate lands in the work
      directory a local transcode would have used and the job moves to `Verifying`, never to
-     `ReadyToReplace`. **Still to build:** the shared-storage path mapping for workers that can
-     already see the library, resumable upload, and the verification that actually judges a returned
-     candidate.
+     `ReadyToReplace`.
+     **Landed on the evidence side:** `RemoteQualityEvidenceValidator` defines what makes a remote
+     VMAF measurement admissible, failing closed on every path. Evidence is refused unless it names
+     the exact source and candidate hashes, names the VMAF model — an unlabelled score cannot be
+     compared to a threshold, since the same file scores differently under the HD and 4K models —
+     and was measured against thresholds at least as strict as the library requires. Stricter is
+     accepted: passing a harder test than the one set still passes the one set. Absent evidence is
+     refused rather than read as "nothing objected".
+     **Still to build:** the shared-storage path mapping for workers that can already see the
+     library, resumable upload, wiring the evidence contract into the result route, and running the
+     existing verification over a returned candidate so every structural, decode, duration, tail,
+     stream and size gate is repeated locally.
    - **Capability-aware leases and recovery: started.** Schedule only when OS, architecture, FFmpeg
      build, encoder, decoder, VMAF mode, free scratch space, and configured concurrency satisfy the
      job. Persist idempotent leases with expiry and heartbeats, expose drain/disable controls, and

--- a/src/Optimisarr.Core/Workers/RemoteQualityEvidence.cs
+++ b/src/Optimisarr.Core/Workers/RemoteQualityEvidence.cs
@@ -1,0 +1,115 @@
+namespace Optimisarr.Core.Workers;
+
+/// <summary>
+/// A perceptual quality measurement taken by a remote worker on the candidate it produced.
+///
+/// This is the one thing Optimisarr accepts from a sidecar without deriving it again. Everything
+/// else about a returned candidate — that it decodes, that its duration and tail are intact, that
+/// its streams and size are right — is re-checked locally, because those checks are cheap relative
+/// to the encode. VMAF is not: it is roughly half the cost of verification, so re-measuring it here
+/// would give back most of the benefit of having distributed the work at all.
+///
+/// Accepting it is only safe because the measurement is bound to the exact bytes it was taken from
+/// and the exact thresholds it was taken under. A score that cannot be tied to all three is not
+/// weak evidence — it is evidence about something else.
+/// </summary>
+public sealed record RemoteQualityEvidence(
+    string? SourceSha256,
+    string? CandidateSha256,
+    double HarmonicMean,
+    double Minimum,
+
+    /// <summary>
+    /// The VMAF model used. Without it the number has no defined meaning: the same file scores
+    /// differently under the HD and 4K models, so an unlabelled score cannot be compared to a
+    /// threshold at all.
+    /// </summary>
+    string? Model,
+
+    /// <summary>The harmonic-mean floor the worker says it was grading against.</summary>
+    double MeasuredAgainstHarmonicMean,
+
+    /// <summary>The per-frame floor the worker says it was grading against.</summary>
+    double MeasuredAgainstMinimum);
+
+/// <summary>What the control plane actually asked for, and of which bytes.</summary>
+public sealed record VmafRequirement(
+    string SourceSha256,
+    string CandidateSha256,
+    double MinimumHarmonicMean,
+    double MinimumMinimum);
+
+/// <summary>The verdict, with every objection named rather than only the first.</summary>
+public sealed record EvidenceVerdict(bool Accepted, IReadOnlyList<string> Reasons);
+
+/// <summary>
+/// Decides whether a remote quality measurement may be believed.
+///
+/// Fails closed throughout. The failure this guards against is not a worker that lies loudly — it
+/// is one that answers a slightly different question: measuring a different encode, or grading
+/// itself against an easier policy, and returning a number that looks like an answer.
+/// </summary>
+public static class RemoteQualityEvidenceValidator
+{
+    public static EvidenceVerdict Validate(RemoteQualityEvidence? evidence, VmafRequirement required)
+    {
+        if (evidence is null)
+        {
+            // Absent evidence must never read as "nothing objected", or a worker could skip
+            // measuring entirely and have its candidate sail through unexamined.
+            return new EvidenceVerdict(false, ["The worker returned no quality evidence for this candidate."]);
+        }
+
+        var reasons = new List<string>();
+
+        if (!Matches(evidence.SourceSha256, required.SourceSha256))
+        {
+            reasons.Add("The quality evidence was measured against a different source.");
+        }
+
+        if (!Matches(evidence.CandidateSha256, required.CandidateSha256))
+        {
+            // The dangerous shape: encode twice, measure the good one, deliver the other.
+            reasons.Add("The quality evidence was measured against a different candidate than the one delivered.");
+        }
+
+        if (string.IsNullOrWhiteSpace(evidence.Model))
+        {
+            reasons.Add("The quality evidence names no VMAF model, so its scores cannot be compared to a threshold.");
+        }
+
+        // Grading against an easier policy is not answering the question that was asked, however
+        // genuine the number. Stricter is fine — passing a harder test than the one set still
+        // passes the one set.
+        if (evidence.MeasuredAgainstHarmonicMean < required.MinimumHarmonicMean
+            || evidence.MeasuredAgainstMinimum < required.MinimumMinimum)
+        {
+            reasons.Add(
+                "The quality evidence was measured against a weaker policy than this library requires " +
+                $"({evidence.MeasuredAgainstHarmonicMean}/{evidence.MeasuredAgainstMinimum} " +
+                $"against {required.MinimumHarmonicMean}/{required.MinimumMinimum}).");
+        }
+
+        if (evidence.HarmonicMean < required.MinimumHarmonicMean)
+        {
+            reasons.Add(
+                $"The harmonic mean VMAF of {evidence.HarmonicMean} is below the required " +
+                $"{required.MinimumHarmonicMean}.");
+        }
+
+        if (evidence.Minimum < required.MinimumMinimum)
+        {
+            // Why a floor exists alongside a mean: an average hides a few seconds of ruined
+            // picture, and an average is exactly what a poor encode would rather be judged on.
+            reasons.Add(
+                $"The lowest measured VMAF of {evidence.Minimum} is below the required " +
+                $"{required.MinimumMinimum}.");
+        }
+
+        return new EvidenceVerdict(reasons.Count == 0, reasons);
+    }
+
+    private static bool Matches(string? supplied, string expected) =>
+        !string.IsNullOrWhiteSpace(supplied)
+        && string.Equals(supplied, expected, StringComparison.OrdinalIgnoreCase);
+}

--- a/tests/Optimisarr.Tests/RemoteQualityEvidenceTests.cs
+++ b/tests/Optimisarr.Tests/RemoteQualityEvidenceTests.cs
@@ -1,0 +1,144 @@
+using Optimisarr.Core.Workers;
+
+namespace Optimisarr.Tests;
+
+/// <summary>
+/// A quality score measured on someone else's machine is the one thing Optimisarr accepts without
+/// re-deriving it, so what makes a score admissible is worth pinning precisely. Everything else a
+/// returned candidate claims is re-checked locally; this is the exception, and it is only safe
+/// because the evidence is bound to the exact bytes and the exact policy it was measured under.
+///
+/// Every case here fails closed. A score that cannot be tied to this source, this candidate, and
+/// the thresholds actually asked for is not weak evidence — it is evidence about something else.
+/// </summary>
+public class RemoteQualityEvidenceTests
+{
+    private const string SourceHash = "aaaa1111";
+    private const string CandidateHash = "bbbb2222";
+
+    private static RemoteQualityEvidence Good() => new(
+        SourceSha256: SourceHash,
+        CandidateSha256: CandidateHash,
+        HarmonicMean: 96.2,
+        Minimum: 88.0,
+        Model: "vmaf_v0.6.1",
+        MeasuredAgainstHarmonicMean: 93.0,
+        MeasuredAgainstMinimum: 80.0);
+
+    private static VmafRequirement Required() => new(
+        SourceSha256: SourceHash,
+        CandidateSha256: CandidateHash,
+        MinimumHarmonicMean: 93.0,
+        MinimumMinimum: 80.0);
+
+    [Fact]
+    public void Evidence_for_this_source_and_candidate_at_the_requested_policy_is_accepted()
+    {
+        var verdict = RemoteQualityEvidenceValidator.Validate(Good(), Required());
+
+        Assert.True(verdict.Accepted);
+        Assert.Empty(verdict.Reasons);
+    }
+
+    [Fact]
+    public void Missing_evidence_is_refused_rather_than_treated_as_a_pass()
+    {
+        // Fail closed. Absent evidence must never read as "nothing objected", or a worker could
+        // skip measuring entirely and have its candidate sail through.
+        var verdict = RemoteQualityEvidenceValidator.Validate(null, Required());
+
+        Assert.False(verdict.Accepted);
+        Assert.Contains(verdict.Reasons, r => r.Contains("no quality evidence", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Evidence_measured_against_a_different_source_is_refused()
+    {
+        // The score may be perfectly real and still say nothing about this job.
+        var verdict = RemoteQualityEvidenceValidator.Validate(
+            Good() with { SourceSha256 = "different" }, Required());
+
+        Assert.False(verdict.Accepted);
+        Assert.Contains(verdict.Reasons, r => r.Contains("source", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Evidence_measured_against_a_different_candidate_is_refused()
+    {
+        // The dangerous shape: encode twice, measure the good one, deliver the bad one.
+        var verdict = RemoteQualityEvidenceValidator.Validate(
+            Good() with { CandidateSha256 = "another file" }, Required());
+
+        Assert.False(verdict.Accepted);
+        Assert.Contains(verdict.Reasons, r => r.Contains("candidate", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Evidence_measured_against_weaker_thresholds_than_were_asked_for_is_refused()
+    {
+        // A worker that graded itself against an easier policy has not answered the question the
+        // control plane asked, even if its score is genuine and high.
+        var verdict = RemoteQualityEvidenceValidator.Validate(
+            Good() with { MeasuredAgainstHarmonicMean = 80.0 }, Required());
+
+        Assert.False(verdict.Accepted);
+        Assert.Contains(verdict.Reasons, r => r.Contains("polic", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Evidence_measured_against_stricter_thresholds_is_accepted()
+    {
+        // Passing a harder test than the one set is still passing the one set.
+        var verdict = RemoteQualityEvidenceValidator.Validate(
+            Good() with { MeasuredAgainstHarmonicMean = 96.0, MeasuredAgainstMinimum = 90.0 },
+            Required());
+
+        Assert.True(verdict.Accepted);
+    }
+
+    [Fact]
+    public void A_score_below_the_required_harmonic_mean_is_refused()
+    {
+        var verdict = RemoteQualityEvidenceValidator.Validate(
+            Good() with { HarmonicMean = 91.0 }, Required());
+
+        Assert.False(verdict.Accepted);
+        Assert.Contains(verdict.Reasons, r => r.Contains("harmonic", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void A_single_catastrophic_frame_is_refused_even_when_the_mean_is_excellent()
+    {
+        // The reason a minimum exists at all: an average hides a few seconds of ruined picture, and
+        // an average is exactly what a worker would prefer to be judged on.
+        var verdict = RemoteQualityEvidenceValidator.Validate(
+            Good() with { HarmonicMean = 99.0, Minimum = 12.0 }, Required());
+
+        Assert.False(verdict.Accepted);
+        Assert.Contains(verdict.Reasons, r => r.Contains("lowest", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Evidence_naming_no_model_is_refused(string? model)
+    {
+        // Without the model, the number has no defined meaning — the same file scores differently
+        // under the HD and 4K models, so an unlabelled score is not comparable to a threshold.
+        var verdict = RemoteQualityEvidenceValidator.Validate(Good() with { Model = model }, Required());
+
+        Assert.False(verdict.Accepted);
+        Assert.Contains(verdict.Reasons, r => r.Contains("model", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Every_problem_is_reported_rather_than_only_the_first()
+    {
+        var verdict = RemoteQualityEvidenceValidator.Validate(
+            Good() with { SourceSha256 = "x", CandidateSha256 = "y", Model = null }, Required());
+
+        Assert.False(verdict.Accepted);
+        Assert.True(verdict.Reasons.Count >= 3, $"expected several reasons, got {verdict.Reasons.Count}");
+    }
+}


### PR DESCRIPTION
## Outcome

VMAF is **the one thing** Optimisarr accepts from a sidecar without deriving it again. This defines
the rule for believing it.

Everything else about a returned candidate is re-checked locally, because those checks are cheap
relative to the encode. VMAF is not — roughly half the cost of verification — so re-measuring it
here would give back most of the benefit of having distributed the work at all. That is why you
chose to accept it bound to hashes rather than re-run it, and this is what "bound" has to mean for
that to be safe.

## The failure it guards against

Not a worker that lies loudly. One that **answers a slightly different question** — measuring a
different encode, or grading itself against an easier policy — and returns a number that looks like
an answer.

Evidence is refused unless it:

- names the **exact source hash** — a real score measured on different bytes says nothing about this
  job
- names the **exact candidate hash** — the dangerous shape is: encode twice, measure the good one,
  deliver the other
- names the **VMAF model** — not bookkeeping. The same file scores differently under the HD and 4K
  models, so an unlabelled score cannot meaningfully be compared to a threshold at all
- was **measured against thresholds at least as strict** as the library requires

Stricter is accepted: passing a harder test than the one set still passes the one set.

**Absent evidence is refused**, never read as "nothing objected" — otherwise a worker could skip
measuring entirely and sail through unexamined.

Every objection is reported rather than the first, matching how the capability matcher behaves, so
an operator sees the whole picture rather than fixing one thing at a time.

## Tests

Twelve, written before the validator, each describing a way this goes wrong rather than a way it
goes right. The one I would point at:
`A_single_catastrophic_frame_is_refused_even_when_the_mean_is_excellent` — 99.0 mean, 12.0 minimum,
refused. An average hides a few seconds of ruined picture, and an average is exactly what a poor
encode would rather be judged on.

## Scope

This is the **contract**, not the wiring. The result route does not yet accept evidence headers, and
the existing verification does not yet run over a returned candidate. Both are named in the roadmap
entry as outstanding.

I stopped here deliberately: what counts as admissible evidence is the safety-critical decision, and
it is worth landing separately from the plumbing that carries it.

## Verification

- `dotnet test` — **1621 passed, 0 failed** (1609 before). Zero build warnings.
- `check_docs.py` passes; roadmap and history updated.