### PR TITLE
Pin the reason no worker can be offered a job

### DIFF
--- a/docs/engineering/history.md
+++ b/docs/engineering/history.md
@@ -3,6 +3,34 @@
 Detailed, dated engineering record: what shipped, the per-phase plan, and current status.
 The forward-looking summary lives in [`../roadmap.md`](../roadmap.md).
 
+**Corrected on dev (2026-09-01) — no job could ever be offered to a remote worker.** The claim
+route builds its `JobRequirements` with `VideoEncoder: job.VideoEncoder ?? string.Empty`, and
+`Job.VideoEncoder` is assigned in exactly one place: `QueueDispatcher`, when a *local* transcode
+resolves an encoder. Its own doc comment says as much — "so the UI can show whether it ran on the
+GPU or CPU". A queued job has never dispatched, so the value is null, and
+`WorkerCapabilityMatcher` refuses an unnamed encoder because "an unnamed encoder is a malformed
+assignment, not a wildcard". Every claim fell through to `204`.
+
+That refusal is right; the requirement was wrong. Two endpoint test suites missed it because both
+construct a queued job with `VideoEncoder = "libx265"` set by hand — a row the application never
+writes. Tests that build state the production code cannot produce will agree with themselves
+forever. A test now queues a job the way the app does and pins the `204`, so the gap is visible
+rather than inferred, and it will fail the moment an assignment can name an encoder properly.
+
+The fix is not to populate the column earlier. The encoder recorded on a job is the one *this
+machine* resolved, which for a Mac worker would usually be the wrong answer anyway — a job marked
+`libx265` would never match a machine advertising `hevc_videotoolbox`. The encoder has to be
+resolved *for the worker* from its proved capabilities at claim time, which is part of the resolved
+encode policy the assignment does not yet carry: `AssignmentDto` names an encoder and a VMAF
+capability and nothing else — no quality, container, effort, audio, HDR treatment, track removals,
+or thresholds. A worker holding one cannot know what to encode. That payload is the keystone the
+rest of the distributed path waits on.
+
+Noted alongside it: the assignment hands the worker `job.MediaFile.Path`, the server's absolute
+library path. The source route was deliberately built to take no path — "a worker presents a lease
+and the server resolves the file" — so leaking the layout through the assignment works against that
+design and should go when the payload is rebuilt.
+
 **Corrected on dev (2026-08-24) — worker capabilities cross the wire as names, not ordinals.** The
 pairing slice exposed `VmafCapability` directly on its DTOs, making it the only enum in the whole
 generated OpenAPI document rendered as `{"type": "integer"}`. That was justified at the time as

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -563,8 +563,19 @@ the replacement workflow is trustworthy.
      structural rather than a check a future query could forget. A unique filtered index over held
      leases means two holders is a database error rather than a possible outcome. Lapsed leases are
      reclaimed whenever a worker asks for work, so recovery needs no background sweeper.
-     **Still to build:** drain controls, and returning a finished candidate — until that exists a
-     worker can take a job but not complete one.
+
+     **Corrected 2026-09-01: no job can currently be offered to a worker, so nothing is dispatched
+     in practice.** The claim route names the required encoder from `Job.VideoEncoder`, which is
+     written once during *local* dispatch to record what actually ran. A job sitting in the queue —
+     the only state this route selects — has none, and the matcher correctly refuses an unnamed
+     encoder as a malformed assignment rather than treating it as a wildcard. Every claim therefore
+     falls through to `204`. The endpoint tests did not catch this because each hand-sets
+     `VideoEncoder` on a queued job, a state the application never produces; a test now pins the
+     real shape. The deeper reason is the same one the next bullet describes: the assignment carries
+     no resolved encode policy, so there is nothing to name an encoder *for this worker* from.
+
+     **Still to build:** the resolved encode policy that makes an assignment executable (see below),
+     the verification pass for a returned candidate, and drain controls.
    - **Preserve the verification boundary.** The sidecar returns the candidate, VMAF measurements,
      tool/model versions, preparation details, hashes, and captured process evidence as one result
      bound to the assignment. The main app independently re-probes the returned file and repeats the
@@ -584,14 +595,18 @@ the replacement workflow is trustworthy.
      permission prompts without requiring broad access to the user's filesystem.
      **Landed so far:** `sidecars/macos`, a Swift package (not an `.xcodeproj`, so the build is
      reviewable as text) building a `MenuBarExtra` app that pairs by URL and PIN, keeps its
-     credential in the Keychain, and checks in on the interval the server states. It reports no
-     encoders and no VMAF support because it can prove none, so the fail-closed matcher will never
-     offer it work — which is correct until it can do any. Revocation, an incompatible protocol,
+     credential in the Keychain, and checks in on the interval the server states. It now bundles an
+     ffmpeg built from pinned source and reports what this Mac proves it can do — each VideoToolbox
+     encoder confirmed by a real throwaway encode, hardware decode by an encode-then-decode round
+     trip — because every Apple build lists VideoToolbox whether or not a machine can open it. A Mac
+     that proves nothing still reports nothing, and the fail-closed matcher never offers it work. Revocation, an incompatible protocol,
      and the feature being switched off server-side are each surfaced distinctly rather than as a
      generic failure. A live test suite runs the real client against a running server, which is how
      this contract gets a second implementation holding it honest. **Still to build:** claiming
      work, media transfer, transcoding, VMAF, launch-at-login, sleep/wake and App Nap handling,
-     Developer ID signing and notarisation.
+     Developer ID signing and notarisation. The client implements two of the ten worker routes
+     (`pair` and `heartbeat`); claim, renew, release, source and result are all unwritten, and
+     `SidecarSession` has no work loop.
    - **Operational UI and acceptance evidence.** The main app shows each worker's trustworthy name,
      platform, version, capabilities, health, load, active lease, transfer progress, and last error;
      worker removal immediately prevents new assignments. Automated contract and end-to-end tests

--- a/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
+++ b/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
@@ -106,7 +106,7 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
     }
 
     /// <summary>Puts one queued job in front of the workers and returns its id.</summary>
-    private async Task<int> QueueAJob()
+    private async Task<int> QueueAJob(string? videoEncoder = "libx265")
     {
         using var scope = _api.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
@@ -138,7 +138,7 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
             LibraryId = library.Id,
             Status = JobStatus.Queued,
             Type = JobType.Normal,
-            VideoEncoder = "libx265",
+            VideoEncoder = videoEncoder,
         };
         db.Jobs.Add(job);
         await db.SaveChangesAsync();
@@ -150,6 +150,22 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
         using var scope = _api.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
         return (await db.Jobs.FindAsync(jobId))!.Status;
+    }
+
+    [Fact]
+    public async Task A_job_enqueued_the_way_the_application_enqueues_one_is_never_offered()
+    {
+        // Every other test here hand-sets VideoEncoder on a Queued job. The application never
+        // does: that column is written once, during local dispatch, to record what actually ran.
+        // A job sitting in the queue — the only state this endpoint selects — has it null, so the
+        // matcher correctly refuses the assignment as unnamed and no work is ever handed out.
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Claimer");
+        await QueueAJob(videoEncoder: null);
+
+        using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+
+        Assert.Equal(HttpStatusCode.NoContent, claim.StatusCode);
     }
 
     [Fact]


### PR DESCRIPTION
Groundwork for the sidecar. No behaviour change — this establishes what is actually true before building on top of it.

## What I found

`POST /api/workers/claim` builds its capability requirement as `VideoEncoder: job.VideoEncoder ?? string.Empty`. `Job.VideoEncoder` is written in exactly one place — `QueueDispatcher`, once a **local** transcode has resolved an encoder — and its own doc comment says why: *"so the UI can show whether it ran on the GPU or CPU"*.

A queued job has never dispatched, so the value is null. `WorkerCapabilityMatcher` then refuses it, correctly, because *"an unnamed encoder is a malformed assignment, not a wildcard"*.

**Every claim returns `204`. No remote worker has ever been able to take a job.**

## Why the tests didn't catch it

Both `WorkerLeaseEndpointTests` and `WorkerResultUploadTests` construct their fixture as:

```csharp
Status = JobStatus.Queued, Type = JobType.Normal, VideoEncoder = "libx265",
```

That row is not one the application can produce. A test that builds state the production code cannot reach will agree with itself indefinitely.

This PR adds `A_job_enqueued_the_way_the_application_enqueues_one_is_never_offered`, which queues a job as the app does and asserts the `204`. It documents the gap rather than blessing it, and it will fail the day an assignment can name an encoder properly.

## Why there is no fix here

Populating the column earlier would be the wrong fix. The encoder recorded on a job is the one *this machine* resolved — for a Mac worker usually the wrong answer entirely, since a job marked `libx265` would never match a machine advertising `hevc_videotoolbox`.

The encoder has to be resolved **for the worker**, from its proved capabilities, at claim time. That is part of the resolved encode policy the assignment does not carry: `AssignmentDto` is

```
LeaseId, JobId, SourcePath, SourceBytes, VideoEncoder, Vmaf, ExpiresUtc, RenewWithinSeconds
```

— no quality, container, encoder effort, audio codec or bitrate, HDR treatment, track removals, or VMAF thresholds. A worker holding one cannot know what to encode. That payload is the keystone the rest of the distributed path waits on, and it deserves its own PR.

## Documentation corrected

The roadmap was wrong in **both** of the directions it explicitly warns against:

- it claimed *"work is dispatched against them"* — nothing is;
- it listed *"returning a finished candidate"* as still-to-build — that shipped in #92.

Also corrected: the macOS entry still said the sidecar *"reports no encoders and no VMAF support because it can prove none"*, which #93 changed, and it now records that the client implements 2 of the 10 worker routes.

Noted in `engineering/history.md` for the record, including one thing to fix when the payload is rebuilt: the assignment hands the worker `job.MediaFile.Path`, the server's absolute library path. The source route was deliberately built to take no path — *"a worker presents a lease and the server resolves the file"* — so leaking the layout through the assignment works against that design.

## Verification

- `dotnet build -warnaserror` clean, `dotnet test` **1683 passed / 0 failed**
- Docs link check clean

## Risk

None. One added test, documentation only. No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)