### PR TITLE
Write down the state a successor would otherwise have to rediscover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,10 @@
   short enough to retype stays safe. Paired workers are listed with their platform, encoders, and
   status, and can be revoked; revoking ends a worker's access immediately and keeps the record.
   Optimisarr remains the only thing that replaces, quarantines, moves, or deletes a file — a worker
-  never can. **No work is sent to a sidecar yet**, so pairing has no effect on your library today;
-  it is there so a connection can be set up and tested while the rest is built.
+  never can. **No work reaches a sidecar yet**, so pairing has no effect on your library today; it
+  is there so a connection can be set up and tested while the rest is built. The entries below
+  describe the routes a worker will use once that is true — claiming, fetching a source, returning
+  a candidate — none of which can currently be exercised end to end.
 - **Remote workers are off unless you turn them on.** Settings → General has a Remote workers
   switch, off by default and off on upgrade. While it is off there is no Workers tab and no sidecar
   can pair or check in, so a normal single-container install is unchanged and never has to think

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,9 @@ A change is done when **all** of these hold:
 
 1. `dotnet build` succeeds with **zero warnings**.
 2. `dotnet test` is fully green, and new behaviour has new tests.
-3. `npm run check` is clean if the frontend changed.
+3. `npm run check` is clean if the frontend changed, and `npm run test:e2e` passes. The e2e
+   suite catches whole classes of breakage the type checker cannot — a two-way binding onto
+   an absent prop throws at runtime and blanks a page while `npm run check` stays clean.
 4. Schema changes have a migration and re-running them is a no-op.
 5. The safety model is intact (or strengthened) — never weakened.
 6. `CHANGELOG.md` (Unreleased section) records the change.
@@ -157,6 +159,7 @@ Then:
 dotnet build Optimisarr.slnx          # build everything
 dotnet test  Optimisarr.slnx          # run the suite
 cd web && npm run check               # frontend type/lint check
+cd web && npm run test:e2e            # Playwright end-to-end suite (CI gate — run it)
 cd web && npm run build               # emits static assets into Optimisarr.Api/wwwroot
 ```
 
@@ -185,7 +188,9 @@ to `dev`/`main`, every tag `v*`, and every pull request targeting `dev`/`main`:
 - **backend** — `dotnet restore` → `dotnet build … -warnaserror` → `dotnet test`.
   The `-warnaserror` flag makes the §6 zero-warnings rule a hard gate; a warning
   fails the build. Do not silence it.
-- **frontend** — `npm ci` → `npm run check`. Must be clean.
+- **frontend** — `npm ci` → `npm run check` → `npx playwright install chromium` →
+  `npm run test:e2e`. Both must be clean. The end-to-end suite is a gate, not an optional
+  extra, so run it locally before pushing rather than discovering it here.
 - **docker** — builds the image (after backend + frontend pass) and **publishes
   to GHCR** as `ghcr.io/jellman86/optimisarr`.
 - [`.github/workflows/security.yml`](.github/workflows/security.yml) checks the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -576,6 +576,56 @@ the replacement workflow is trustworthy.
 
      **Still to build:** the resolved encode policy that makes an assignment executable (see below),
      the verification pass for a returned candidate, and drain controls.
+   - **The next four pieces, in dependency order (recorded 2026-09-01).** Everything below waits on
+     the first, and the first two are server work of similar size to a normal feature slice.
+
+     1. **A resolved encode policy in the assignment.** `AssignmentDto` currently carries
+        `LeaseId, JobId, SourcePath, SourceBytes, VideoEncoder, Vmaf, ExpiresUtc,
+        RenewWithinSeconds` — no quality, container, encoder effort, audio codec or bitrate, HDR
+        treatment, track removals, encoder tuning, or VMAF thresholds. A worker holding one cannot
+        know what to encode. This slice must also resolve the encoder *for the worker* from its
+        proved capabilities (which is what makes a claim possible at all — see the correction
+        above), and stop sending `job.MediaFile.Path`, since the source route deliberately takes no
+        path.
+
+        **Open design decision.** Either send a declarative policy and let the sidecar build its own
+        FFmpeg arguments — which duplicates `FfmpegCommandBuilder`'s ~589 lines of container,
+        subtitle, VFR and tone-map subtleties in Swift, and invites drift — or send the argument
+        array the server already builds for that encoder, with placeholders for input and output,
+        and have the worker validate it against an allowlist before substituting. The second keeps
+        one tested source of truth for the encode contract and suits a design where the *output* is
+        judged rather than the command; it needs care that a compromised or buggy server cannot
+        direct a worker's FFmpeg at anything but its own scratch paths. Not yet decided.
+
+     2. **A verification pass for a delivered candidate.** `POST /api/workers/leases/{id}/result`
+        accepts an upload, binds it to the lease and source hash, and sets the job to `Verifying`
+        — where nothing picks it up. `QueueDispatcher` only ever selects `Queued`. Worse, the
+        startup recovery sweep treats any `Verifying` job as interrupted, deletes its work output
+        and requeues it, so a returned candidate is silently discarded at the next restart. That is
+        an acceptable interim only because nothing can be delivered today; it becomes a race that
+        destroys a finished encode the moment a drainer exists, so both must land together.
+
+        `VerifyAndFinishAsync` reads only eight of `JobWork`'s twenty-four fields — `Spec`,
+        `Original`, `VerificationPolicy`, `VideoEncoder`, `VideoQuality`, `IsCalibration`,
+        `IsDisposable`, `UsedHardwareDecode` — and none is a local-transcode artefact, so extracting
+        a verification input that both paths build is tractable. `RemoteQualityEvidenceValidator`
+        (already merged, still unwired) judges the returned VMAF evidence.
+
+        **Open design decision.** A delivered-and-waiting job is currently indistinguishable from
+        one mid-verification locally. Either add a `JobStatus` such as `AwaitingVerification` —
+        honest, visible to operators, correct recovery semantics, but a migration, nine locales, UI
+        states, and a wider enum that sidecars observe — or a nullable marker on `Job`, which is one
+        column and no translation surface but hides the distinction. Not yet decided.
+
+     3. **The sidecar's work loop.** The client implements two of the ten worker routes. Claim,
+        renew, release, source download (Range plus hash check), transcode, VMAF measurement and
+        result upload are all unwritten, as are progress reporting and cancellation.
+
+     4. **Drain controls**, and then productionisation: launch-at-login, sleep/wake, App Nap,
+        low-disk handling, cancel-on-quit. Developer ID signing and notarisation are unblocked — a
+        paid Apple Developer membership is available — but remain the last step, and neither
+        platform is described as supported until there is real-hardware acceptance evidence.
+
    - **Preserve the verification boundary.** The sidecar returns the candidate, VMAF measurements,
      tool/model versions, preparation details, hashes, and captured process evidence as one result
      bound to the assignment. The main app independently re-probes the returned file and repeats the


### PR DESCRIPTION
Documentation only. No production code changes.

Three things that were true only in a session transcript are now in the repository.

## The end-to-end suite is a CI gate and the standards did not say so

`.github/workflows/ci.yml` runs `npm ci` → `npm run check` → `npx playwright install chromium` → `npm run test:e2e`. CLAUDE.md §7 listed neither the install nor the suite, and §9 described the job as *"`npm ci` → `npm run check`"* — which is simply not what it does.

Anyone following the documented commands pushes work CI then rejects. That happened this session: a two-way binding onto an absent prop threw `props_invalid_value` at runtime and blanked the entire library editor, while `npm run check` reported zero errors. §6 now states why the suite catches what the type checker cannot, and §7 lists it alongside the other local commands.

## The Unreleased changelog contradicted itself

It opened with *"**No work is sent to a sidecar yet**"* and then, below, described workers claiming jobs, downloading sources and returning candidates. Each entry was accurate the day it was written; read together they say opposite things. The opening now explains what those routes are for and that none can be exercised end to end.

## The plan and the decisions still open

The four remaining pieces of the distributed path are recorded in `docs/roadmap.md` in dependency order — resolved encode policy in the assignment, verification of a delivered candidate, the sidecar work loop, drain controls and productionisation — with the concrete detail a successor would otherwise have to re-derive:

- exactly which fields `AssignmentDto` is missing, and that the encoder must be resolved *for the worker*;
- that `VerifyAndFinishAsync` reads only 8 of `JobWork`'s 24 fields, and none is a local-transcode artefact, so the extraction is tractable;
- that the startup recovery sweep deletes any `Verifying` job's work output, which is harmless today but becomes a race destroying a finished encode the moment a drainer exists — so the two must land together;
- that Developer ID signing is unblocked (a paid Apple Developer membership is available) but stays last, and neither platform is called supported without real-hardware evidence.

**Two design decisions are written down as open rather than quietly settled**, because both have real trade-offs and neither should be decided by whoever happens to pick this up:

1. **How an assignment expresses the encode contract.** A declarative policy the sidecar turns into FFmpeg arguments itself duplicates ~589 lines of container, subtitle, VFR and tone-map subtlety in Swift and invites drift. Sending the server's own argument array with input/output placeholders keeps one tested source of truth and suits a design where the output is judged rather than the command — but needs care that a compromised server cannot aim a worker's FFmpeg anywhere but its own scratch.
2. **How a delivered candidate is distinguished from one being verified locally.** A new `JobStatus` is the honest state machine but costs a migration, nine locales, UI states and a wider enum sidecars observe. A marker column is one field and no translation surface, but hides the distinction.

## Verification

- `dotnet build -warnaserror` clean, `dotnet test` **1683 passed / 0 failed**
- `npm run check` clean, `npm run test:e2e` **51 passed** — run per the rule this PR adds
- Docs link check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)