### PR TITLE
Hand a remote worker an executable assignment, resolved for its own encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### Added
 
+- **A remote worker can now be handed an executable assignment.** Until now every claim returned
+  nothing: the assignment named no encoder and carried no encode policy, so no sidecar could be
+  offered work (the characterisation test that pinned this now asserts the opposite). A claim now
+  runs the same preparation as local dispatch — fresh probes, crop detection, the picture, audio
+  and track contract, verification policy — with the encoder chosen from what the worker proved,
+  in the same preference order this machine uses for its own hardware, and hands over the exact
+  FFmpeg argument array this machine would have run. Two tokens stand in for paths, `{{input}}`
+  and `{{output}}` with the container extension attached, so no path on the server is ever sent
+  and a worker substitutes only its own scratch. The assignment also states the VMAF requirement
+  (whether to measure, which model, frame subsample, clip mode, thresholds) so evidence can be bound
+  to the policy this machine will judge by. Not offered, each with a reason in the debug log:
+  remux, audio and image jobs, and jobs from adaptive-VMAF libraries whose per-title quality has
+  not yet been chosen, because that selection runs on this machine's encoder and a quality chosen
+  for one encoder means nothing on another. The VideoToolbox encoder family is now understood
+  end to end — selection, quality, preset, tuning and the command builder — so a Mac that proves
+  `hevc_videotoolbox` receives `-q:v` on Apple's scale rather than a CRF it would reject. That
+  quality line is a straight mapping and still owes calibration on real hardware; the VMAF gate,
+  not the mapping, is what guarantees a result.
+
 - **A library can now cap frame rate on re-encode.** Advanced options gain **Cap frame rate at**,
   with 60 and 30 fps stops, beside the resolution controls; this completes the framerate ask in
   #95. It is a cap, not a target: a faster source is halved until it sits under the cap (60 → 30,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -82,6 +82,12 @@
       },
       "AssignmentDto": {
         "properties": {
+          "arguments": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "expiresUtc": {
             "format": "date-time",
             "type": "string"
@@ -97,6 +103,12 @@
           "leaseId": {
             "format": "uuid",
             "type": "string"
+          },
+          "outputExtension": {
+            "type": "string"
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityRequirementDto"
           },
           "renewWithinSeconds": {
             "format": "int32",
@@ -114,9 +126,6 @@
               "string"
             ]
           },
-          "sourcePath": {
-            "type": "string"
-          },
           "videoEncoder": {
             "type": "string"
           },
@@ -127,12 +136,14 @@
         "required": [
           "leaseId",
           "jobId",
-          "sourcePath",
           "sourceBytes",
           "videoEncoder",
           "vmaf",
           "expiresUtc",
-          "renewWithinSeconds"
+          "renewWithinSeconds",
+          "arguments",
+          "outputExtension",
+          "quality"
         ],
         "type": "object"
       },
@@ -1160,6 +1171,52 @@
         },
         "required": [
           "token"
+        ],
+        "type": "object"
+      },
+      "QualityRequirementDto": {
+        "properties": {
+          "clipVmaf": {
+            "type": "boolean"
+          },
+          "frameSubsample": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "measure": {
+            "type": "boolean"
+          },
+          "minimumHarmonicMean": {
+            "format": "double",
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ]
+          },
+          "minimumMinimum": {
+            "format": "double",
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ]
+          },
+          "model": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "measure",
+          "model",
+          "frameSubsample",
+          "clipVmaf",
+          "minimumHarmonicMean",
+          "minimumMinimum"
         ],
         "type": "object"
       },

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -574,12 +574,13 @@ the replacement workflow is trustworthy.
      real shape. The deeper reason is the same one the next bullet describes: the assignment carries
      no resolved encode policy, so there is nothing to name an encoder *for this worker* from.
 
-     **Still to build:** the resolved encode policy that makes an assignment executable (see below),
-     the verification pass for a returned candidate, and drain controls.
+     **Corrected 2026-09-04:** the assignment now carries a resolved encode contract and a claim
+     can succeed; the same test asserts an executable command is returned. **Still to build:** the
+     verification pass for a returned candidate, and drain controls.
    - **The next four pieces, in dependency order (recorded 2026-09-01).** Everything below waits on
      the first, and the first two are server work of similar size to a normal feature slice.
 
-     1. **A resolved encode policy in the assignment.** `AssignmentDto` currently carries
+     1. **A resolved encode policy in the assignment: landed 2026-09-04.** Before it, `AssignmentDto` carried
         `LeaseId, JobId, SourcePath, SourceBytes, VideoEncoder, Vmaf, ExpiresUtc,
         RenewWithinSeconds` — no quality, container, encoder effort, audio codec or bitrate, HDR
         treatment, track removals, encoder tuning, or VMAF thresholds. A worker holding one cannot
@@ -595,7 +596,24 @@ the replacement workflow is trustworthy.
         and have the worker validate it against an allowlist before substituting. The second keeps
         one tested source of truth for the encode contract and suits a design where the *output* is
         judged rather than the command; it needs care that a compromised or buggy server cannot
-        direct a worker's FFmpeg at anything but its own scratch paths. Not yet decided.
+        direct a worker's FFmpeg at anything but its own scratch paths. **Decided 2026-09-04: the
+        argument array.** The worker validates it against an allowlist and substitutes only its
+        own scratch paths.
+
+        **Landed:** `QueueDispatcher.PrepareRemoteWorkAsync` runs the dispatcher's own preparation
+        with the encoder chosen from the worker's proved list (`WorkerEncoderCatalogue` feeding
+        `EncoderSelector` in Auto order), software decode, no thread limit, and `{{input}}` /
+        `{{output}}.<ext>` placeholders (`WorkerProtocol`). The assignment carries the argument
+        array, the output extension, and the VMAF requirement (measure, model, subsample, clip,
+        thresholds); it no longer carries a server path. Refused with a logged reason: remux, audio
+        and image jobs, and adaptive-VMAF libraries whose per-title quality has not been chosen,
+        since selection runs on this machine's encoder and does not transfer. The VideoToolbox
+        family is now known to the selector, the quality, preset and tuning policies, and the
+        command builder (`-q:v` on a linear map from the CRF scale; **real-hardware calibration of
+        that line is still owed**). Left for later pieces: adaptive selection on the worker,
+        hardware decode for a worker that proves a decoder, the VMAF command itself (piece 3 will
+        ship it as a second server-built array so crop, frame-rate and HDR preparation stay in one
+        place), and the worker-side allowlist validation.
 
      2. **A verification pass for a delivered candidate.** `POST /api/workers/leases/{id}/result`
         accepts an upload, binds it to the lease and source hash, and sets the job to `Verifying`
@@ -615,9 +633,12 @@ the replacement workflow is trustworthy.
         one mid-verification locally. Either add a `JobStatus` such as `AwaitingVerification` —
         honest, visible to operators, correct recovery semantics, but a migration, nine locales, UI
         states, and a wider enum that sidecars observe — or a nullable marker on `Job`, which is one
-        column and no translation surface but hides the distinction. Not yet decided.
+        column and no translation surface but hides the distinction. **Decided 2026-09-04: the
+        status.** The recovery sweep's mistake is a state-semantics one, and a hidden marker would
+        paper over exactly the distinction it gets wrong.
 
-     3. **The sidecar's work loop.** The client implements two of the ten worker routes. Claim,
+     3. **The sidecar's work loop.** Now the next server-independent piece; a claim returns an
+        executable command. The client implements two of the ten worker routes. Claim,
         renew, release, source download (Range plus hash check), transcode, VMAF measurement and
         result upload are all unwritten, as are progress reporting and cancellation.
 

--- a/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
@@ -1,6 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using Optimisarr.Api.Library;
+using Optimisarr.Api.Queue;
 using Optimisarr.Api.Workers;
+using Optimisarr.Core.Domain;
+using Optimisarr.Core.Queue;
 using Optimisarr.Core.Workers;
 using Optimisarr.Data;
 
@@ -8,17 +11,37 @@ namespace Optimisarr.Api.Endpoints;
 
 /// <summary>
 /// One job handed to one worker, with the deadline by which it must renew or lose it.
-/// The encode policy is resolved here rather than by the worker: the control plane owns the rules.
+/// The encode policy is resolved here rather than by the worker: the control plane owns the rules,
+/// and <see cref="Arguments"/> is the exact FFmpeg command this machine would have run for the
+/// worker's encoder. Two tokens stand in for paths — <see cref="WorkerProtocol.InputPlaceholder"/>
+/// for the worker's copy of the source and <see cref="WorkerProtocol.OutputPlaceholder"/>, carrying
+/// <see cref="OutputExtension"/>, for its candidate. No path on this machine is ever sent: the
+/// source is fetched by lease, and a worker substitutes only its own scratch paths.
 /// </summary>
 internal sealed record AssignmentDto(
     Guid LeaseId,
     int JobId,
-    string SourcePath,
     long SourceBytes,
     string VideoEncoder,
     string Vmaf,
     DateTimeOffset ExpiresUtc,
-    int RenewWithinSeconds);
+    int RenewWithinSeconds,
+    IReadOnlyList<string> Arguments,
+    string OutputExtension,
+    QualityRequirementDto Quality);
+
+/// <summary>
+/// What the worker's VMAF evidence will be held to. The thresholds and model are stated so the
+/// worker measures against the policy this machine will judge by, and its evidence can be bound to
+/// them; a score taken under an easier policy or another model is evidence about something else.
+/// </summary>
+internal sealed record QualityRequirementDto(
+    bool Measure,
+    string Model,
+    int FrameSubsample,
+    bool ClipVmaf,
+    double MinimumHarmonicMean,
+    double MinimumMinimum);
 
 internal sealed record LeaseRenewedDto(Guid LeaseId, DateTimeOffset ExpiresUtc);
 
@@ -32,8 +55,11 @@ internal static class WorkerLeaseEndpoints
             HttpRequest http,
             SettingsStore settings,
             OptimisarrDbContext db,
+            QueueDispatcher dispatcher,
+            ILoggerFactory loggerFactory,
             CancellationToken cancellationToken) =>
         {
+            var logger = loggerFactory.CreateLogger("Optimisarr.Api.Workers.Claim");
             if (await WorkerGate.RefusedAsync(settings, cancellationToken) is { } refused)
             {
                 return refused;
@@ -93,7 +119,8 @@ internal static class WorkerLeaseEndpoints
             }
 
             var loaded = await db.Jobs
-                .Include(job => job.MediaFile)
+                .Include(job => job.MediaFile)!
+                .ThenInclude(file => file!.Library)
                 .Where(job => shortlist.Contains(job.Id))
                 .ToListAsync(cancellationToken);
 
@@ -110,16 +137,43 @@ internal static class WorkerLeaseEndpoints
                     continue;
                 }
 
+                // Workers poll, and full preparation probes the source. Rule out the jobs that
+                // preparation would refuse anyway from what is already loaded, so a queue of
+                // adaptive-library or remux jobs does not cost an ffprobe per candidate per poll.
+                // Preparation repeats these refusals itself; this is only the cheap first pass.
+                if (!PlausiblyOfferable(job, capabilities))
+                {
+                    continue;
+                }
+
+                // The same preparation local dispatch runs, with the encoder chosen from what this
+                // worker proved. A refusal is ordinary — an adaptive library, a remux, an encoder
+                // the worker lacks — and is logged rather than surfaced, since the worker's answer
+                // is simply the next candidate or nothing.
+                var plan = await dispatcher.PrepareRemoteWorkAsync(job.Id, capabilities, cancellationToken);
+                if (plan.Assignment is not { } assignment)
+                {
+                    logger.LogDebug(
+                        "Job {JobId} not offered to worker {Worker}: {Reason}",
+                        job.Id, worker.Name, plan.Reason);
+                    continue;
+                }
+
                 var requirements = new JobRequirements(
-                    VideoEncoder: job.VideoEncoder ?? string.Empty,
+                    VideoEncoder: assignment.VideoEncoder,
                     HardwareDecoder: null,
-                    Vmaf: VmafCapability.Cpu,
+                    // Only a job whose policy will judge VMAF needs a worker that can score it.
+                    Vmaf: assignment.Verification.QualityGateEnabled ? VmafCapability.Cpu : VmafCapability.None,
                     // Scratch for the candidate plus headroom; a worker that cannot hold the output
                     // has no business starting the encode.
                     ScratchBytes: job.MediaFile.SizeBytes + (job.MediaFile.SizeBytes / 2));
 
-                if (!WorkerCapabilityMatcher.Match(capabilities, requirements).Accepted)
+                var match = WorkerCapabilityMatcher.Match(capabilities, requirements);
+                if (!match.Accepted)
                 {
+                    logger.LogDebug(
+                        "Job {JobId} not offered to worker {Worker}: {Reasons}",
+                        job.Id, worker.Name, string.Join(" ", match.Reasons));
                     continue;
                 }
 
@@ -151,15 +205,24 @@ internal static class WorkerLeaseEndpoints
                     continue;
                 }
 
+                var policy = assignment.Verification;
                 return Results.Ok(new AssignmentDto(
                     lease.Id,
                     job.Id,
-                    job.MediaFile.Path,
                     job.MediaFile.SizeBytes,
-                    job.VideoEncoder ?? string.Empty,
-                    VmafCapability.Cpu.ToString(),
+                    assignment.VideoEncoder,
+                    requirements.Vmaf.ToString(),
                     lease.ExpiresUtc,
-                    (int)WorkerLiveness.HeartbeatInterval.TotalSeconds));
+                    (int)WorkerLiveness.HeartbeatInterval.TotalSeconds,
+                    assignment.Arguments,
+                    assignment.OutputExtension,
+                    new QualityRequirementDto(
+                        policy.QualityGateEnabled,
+                        assignment.VmafModel,
+                        policy.VmafFrameSubsample,
+                        policy.ClipVmafEnabled,
+                        policy.MinimumVmafHarmonicMean,
+                        policy.MinimumVmafMin)));
             }
 
             return Results.NoContent();
@@ -308,6 +371,34 @@ internal static class WorkerLeaseEndpoints
         }
 
         await db.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// The refusals that need nothing beyond the loaded rows: only a video re-encode is offered,
+    /// an adaptive library's job waits for its per-title quality, and the worker must prove an
+    /// encoder for the target codec. Mirrors <see cref="QueueDispatcher.PrepareRemoteWorkAsync"/>,
+    /// which remains the authority.
+    /// </summary>
+    private static bool PlausiblyOfferable(Job job, WorkerCapabilities capabilities)
+    {
+        var media = job.MediaFile!;
+        if (media.MediaKind is MediaKind.Audio or MediaKind.Image)
+        {
+            return false;
+        }
+
+        var library = media.Library;
+        if (library?.VideoQualityStrategy == VideoQualityStrategy.AdaptiveVmaf && job.AdaptiveVideoQuality is null)
+        {
+            return false;
+        }
+
+        var targetCodec = LibraryRuleResolution.Resolve(library).TargetVideoCodec;
+        return targetCodec is not null
+            && EncoderSelector.Select(
+                targetCodec,
+                EncoderMode.Auto,
+                WorkerEncoderCatalogue.Describe(capabilities.VideoEncoders)).Succeeded;
     }
 
     private static WorkerCapabilities ToCapabilities(Worker worker) => new(

--- a/src/Optimisarr.Api/Queue/QueueDispatcher.cs
+++ b/src/Optimisarr.Api/Queue/QueueDispatcher.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Optimisarr.Api.Library;
 using Optimisarr.Api.Realtime;
 using Optimisarr.Api.Replacement;
+using Optimisarr.Api.Workers;
 using Optimisarr.Core.Activity;
 using Optimisarr.Core.Library;
 using Optimisarr.Core.Domain;
@@ -14,6 +15,7 @@ using Optimisarr.Core.Scheduling;
 using Optimisarr.Core.Queue;
 using Optimisarr.Core.Tools;
 using Optimisarr.Core.Verification;
+using Optimisarr.Core.Workers;
 using Optimisarr.Data;
 
 namespace Optimisarr.Api.Queue;
@@ -753,7 +755,10 @@ public sealed class QueueDispatcher(
         // present only when the primary command used a hardware path that can safely fall back.
         IReadOnlyList<string>? SoftwareFallbackArguments = null,
         bool UsedHardwareDecode = false,
-        bool UsedHardwareToneMap = false)
+        bool UsedHardwareToneMap = false,
+        // The inventory's picture size, when it has one. A remote assignment names the VMAF
+        // model from it so the worker's evidence can be held to the model this machine would use.
+        PictureSize? SourcePicture = null)
     {
         public void Deconstruct(out TranscodeSpec spec, out IReadOnlyList<string> arguments)
         {
@@ -786,7 +791,79 @@ public sealed class QueueDispatcher(
                 library?.MinimumImageSsim,
                 library?.ImageMetadataGateEnabled));
 
-    private async Task<JobWork?> LoadWorkAsync(int jobId, CancellationToken cancellationToken)
+    /// <summary>
+    /// Resolves one queued job into an assignment a remote worker could execute, or a reason it
+    /// cannot. Runs the same preparation as local dispatch — fresh probes, crop detection, the
+    /// picture and audio contract, verification policy — with the encoder chosen from the worker's
+    /// proved capabilities and the command made portable. A refusal is ordinary and never throws.
+    /// </summary>
+    public async Task<RemoteWorkPlan> PrepareRemoteWorkAsync(
+        int jobId,
+        WorkerCapabilities worker,
+        CancellationToken cancellationToken)
+    {
+        JobWork? prepared;
+        try
+        {
+            prepared = await LoadWorkAsync(jobId, new EncodePlacement(worker), cancellationToken);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or JobNoLongerEligibleException)
+        {
+            return RemoteWorkPlan.Refused(ex.Message);
+        }
+
+        if (prepared is not { } work)
+        {
+            return RemoteWorkPlan.Refused("The job or its media file no longer exists.");
+        }
+
+        // Only a video re-encode has an encoder to match and arguments worth shipping; a remux,
+        // audio or image job is cheap enough that distributing it buys nothing yet.
+        if (work.Spec.VideoCodec is null || work.VideoEncoder is null)
+        {
+            return RemoteWorkPlan.Refused("Only video re-encodes are offered to remote workers.");
+        }
+
+        // Adaptive selection runs sample encodes on this machine's encoder, and a quality chosen
+        // for one encoder means nothing on another. Until selection can run on the worker, an
+        // adaptive library's jobs stay local rather than silently encoding at the fixed quality.
+        if (work.VideoQualityStrategy == VideoQualityStrategy.AdaptiveVmaf && work.AdaptiveVideoQuality is null)
+        {
+            return RemoteWorkPlan.Refused(
+                "Adaptive quality selection has not run for this job and cannot run on a remote worker.");
+        }
+
+        var (width, height) = work.SourcePicture is { } picture
+            ? (work.Spec.CropTo?.Width ?? picture.Width, work.Spec.CropTo?.Height ?? picture.Height)
+            : (0, 0);
+
+        return RemoteWorkPlan.For(new RemoteAssignment(
+            work.VideoEncoder,
+            work.Arguments,
+            Path.GetExtension(work.Spec.OutputPath).TrimStart('.'),
+            work.VerificationPolicy,
+            QualityScoreCommandBuilder.ModelVersionFor(width, height)));
+    }
+
+    /// <summary>
+    /// Where an encode will run. Local work resolves its encoder from this machine's probe and may
+    /// use its hardware decoder; remote work resolves it from the worker's proved capabilities and
+    /// receives a portable command with placeholder paths.
+    /// </summary>
+    private readonly record struct EncodePlacement(WorkerCapabilities? RemoteWorker)
+    {
+        public static EncodePlacement Local => default;
+
+        public bool IsRemote => RemoteWorker is not null;
+    }
+
+    private Task<JobWork?> LoadWorkAsync(int jobId, CancellationToken cancellationToken) =>
+        LoadWorkAsync(jobId, EncodePlacement.Local, cancellationToken);
+
+    private async Task<JobWork?> LoadWorkAsync(
+        int jobId,
+        EncodePlacement placement,
+        CancellationToken cancellationToken)
     {
         await using var scope = scopeFactory.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
@@ -1052,11 +1129,20 @@ public sealed class QueueDispatcher(
             var sourceBitDepth = PixelFormatInfo.Parse(
                 freshSourceProbe?.PixelFormat ?? media.PixelFormat,
                 freshSourceProbe?.BitsPerRawSample ?? media.BitsPerRawSample)?.BitDepth;
-            var videoEncoder = await ResolveVideoEncoderAsync(
-                spec.VideoCodec,
-                queueSettings.EncoderMode,
-                sourceBitDepth,
-                cancellationToken);
+            // A worker's encoder is chosen from what it proved, in the same preference order this
+            // machine uses for its own hardware. The queue's encoder mode describes this machine's
+            // GPU and says nothing about the worker's, so Auto is the only honest mode there.
+            var videoEncoder = placement.RemoteWorker is { } remoteWorker
+                ? EncoderSelector.Select(
+                    spec.VideoCodec,
+                    EncoderMode.Auto,
+                    WorkerEncoderCatalogue.Describe(remoteWorker.VideoEncoders),
+                    sourceBitDepth)
+                : await ResolveVideoEncoderAsync(
+                    spec.VideoCodec,
+                    queueSettings.EncoderMode,
+                    sourceBitDepth,
+                    cancellationToken);
             if (videoEncoder is { Succeeded: false })
             {
                 throw new InvalidOperationException(videoEncoder.Error);
@@ -1121,7 +1207,9 @@ public sealed class QueueDispatcher(
         // reordering around an input seek can move the clip several frames before its VMAF
         // reference. Hardware encoding remains enabled. Normal jobs retain the existing
         // hardware-decode path and transparent software fallback.
-        var hardwareDecode = HardwareDecodePolicy.ShouldUse(
+        // A remote worker's decoders are not yet part of the contract, so its command decodes in
+        // software: the path every filter here is proven on, and the one that needs no device.
+        var hardwareDecode = !placement.IsRemote && HardwareDecodePolicy.ShouldUse(
             queueSettings.HardwareDecode,
             isDisposable,
             spec.Kind,
@@ -1173,16 +1261,28 @@ public sealed class QueueDispatcher(
             hardwareToneMapDolbyVision,
             hardwareToneMapTransfer,
             videoEncoderName);
+        // A remote command names no path on this machine: the worker substitutes its own copy of
+        // the source and its own scratch output, and the output keeps the container extension the
+        // contract chose. The thread limit is this machine's, so a worker receives none.
+        if (placement.IsRemote)
+        {
+            spec = spec with
+            {
+                InputPath = WorkerProtocol.InputPlaceholder,
+                OutputPath = WorkerProtocol.OutputPlaceholder + Path.GetExtension(spec.OutputPath)
+            };
+        }
+        var threads = placement.IsRemote ? 0 : queueSettings.CpuThreadLimit;
         var primaryArguments = FfmpegCommandBuilder.Build(
             spec,
-            queueSettings.CpuThreadLimit,
+            threads,
             videoEncoderName,
             OptimisedMarkerValue,
             hardwareDecode,
             hardwareToneMap);
         var softwareArguments = FfmpegCommandBuilder.Build(
             spec,
-            queueSettings.CpuThreadLimit,
+            threads,
             videoEncoderName,
             OptimisedMarkerValue,
             hardwareDecode: false,
@@ -1213,7 +1313,10 @@ public sealed class QueueDispatcher(
             hardwareToneMap,
             usedHardwareDecode ? softwareArguments : null,
             usedHardwareDecode,
-            hardwareToneMap);
+            hardwareToneMap,
+            media.Width is > 0 && media.Height is > 0
+                ? new PictureSize(media.Width.Value, media.Height.Value)
+                : null);
     }
 
     /// <summary>
@@ -2437,13 +2540,15 @@ public sealed class QueueDispatcher(
         return EncoderSelector.Select(targetCodec, encoderMode, detected.Encoders, sourceBitDepth);
     }
 
-    // A hardware encoder is named after its API (e.g. hevc_qsv, h264_vaapi, hevc_nvenc); the
-    // software libraries (libx265, libx264, libsvtav1) are not. Used to flag GPU-backed work.
+    // A hardware encoder is named after its API (e.g. hevc_qsv, h264_vaapi, hevc_nvenc,
+    // hevc_videotoolbox); the software libraries (libx265, libx264, libsvtav1) are not. Used to
+    // flag GPU-backed work.
     private static bool IsHardwareEncoder(string? encoder) =>
         encoder is not null
         && (encoder.EndsWith("_qsv", StringComparison.OrdinalIgnoreCase)
             || encoder.EndsWith("_vaapi", StringComparison.OrdinalIgnoreCase)
-            || encoder.EndsWith("_nvenc", StringComparison.OrdinalIgnoreCase));
+            || encoder.EndsWith("_nvenc", StringComparison.OrdinalIgnoreCase)
+            || encoder.EndsWith("_videotoolbox", StringComparison.OrdinalIgnoreCase));
 
     private Task NotifyAsync() => hub.Clients.All.SendAsync("jobsChanged");
 

--- a/src/Optimisarr.Api/Workers/RemoteWorkPlan.cs
+++ b/src/Optimisarr.Api/Workers/RemoteWorkPlan.cs
@@ -1,0 +1,30 @@
+using Optimisarr.Core.Verification;
+
+namespace Optimisarr.Api.Workers;
+
+/// <summary>
+/// Everything a remote worker needs to execute one job, resolved by the control plane for that
+/// worker's proved encoder. The argument array is the same one the local dispatcher would run,
+/// built by the same code, with the worker's paths standing in as placeholders — one tested source
+/// of truth for the encode contract rather than a second implementation on the other side.
+/// </summary>
+public sealed record RemoteAssignment(
+    string VideoEncoder,
+    IReadOnlyList<string> Arguments,
+    string OutputExtension,
+    VerificationPolicy Verification,
+    string VmafModel);
+
+/// <summary>
+/// Whether a job may be offered to a worker, and why not when it may not. A refusal is the
+/// ordinary answer for many jobs and workers — it names its reason so an idle sidecar can be
+/// explained, and it is never an error.
+/// </summary>
+public sealed record RemoteWorkPlan(RemoteAssignment? Assignment, string? Reason)
+{
+    public bool Accepted => Assignment is not null;
+
+    public static RemoteWorkPlan For(RemoteAssignment assignment) => new(assignment, null);
+
+    public static RemoteWorkPlan Refused(string reason) => new(null, reason);
+}

--- a/src/Optimisarr.Core/Queue/EncoderPresetPolicy.cs
+++ b/src/Optimisarr.Core/Queue/EncoderPresetPolicy.cs
@@ -128,7 +128,9 @@ public static class EncoderPresetPolicy
             });
         }
 
-        if (encoder.EndsWith("_vaapi", StringComparison.Ordinal))
+        // Neither VA-API nor VideoToolbox has a preset vocabulary; each takes its driver's defaults.
+        if (encoder.EndsWith("_vaapi", StringComparison.Ordinal)
+            || encoder.EndsWith("_videotoolbox", StringComparison.Ordinal))
         {
             return Success(effort, null);
         }

--- a/src/Optimisarr.Core/Queue/EncoderQualityPolicy.cs
+++ b/src/Optimisarr.Core/Queue/EncoderQualityPolicy.cs
@@ -23,6 +23,8 @@ public static class EncoderQualityPolicy
             "qsv" => ("ICQ", HardwareHeadroom),
             "nvenc" => ("CQ", HardwareHeadroom),
             "vaapi" => ("QP", HardwareHeadroom),
+            // Kept on the CRF scale; FfmpegCommandBuilder translates it onto Apple's 1–100 control.
+            "videotoolbox" => ("VT-Q", HardwareHeadroom),
             _ => ("CRF", 0)
         };
         var effective = Math.Max(0, boundedRequested - headroom - (boundedRetry * RetryStep));
@@ -59,6 +61,7 @@ public static class EncoderQualityPolicy
         return encoder.EndsWith("_qsv", StringComparison.OrdinalIgnoreCase) ? "qsv"
             : encoder.EndsWith("_nvenc", StringComparison.OrdinalIgnoreCase) ? "nvenc"
             : encoder.EndsWith("_vaapi", StringComparison.OrdinalIgnoreCase) ? "vaapi"
+            : encoder.EndsWith("_videotoolbox", StringComparison.OrdinalIgnoreCase) ? "videotoolbox"
             : "cpu";
     }
 }

--- a/src/Optimisarr.Core/Queue/EncoderSelector.cs
+++ b/src/Optimisarr.Core/Queue/EncoderSelector.cs
@@ -39,7 +39,9 @@ public static class EncoderSelector
         string[] preferredModes = mode switch
         {
             EncoderMode.Auto when requiresHighBitDepthCpuH264 => ["CPU"],
-            EncoderMode.Auto => ["NVIDIA NVENC", "Intel QSV", "VAAPI", "CPU"],
+            // VideoToolbox is only ever advertised by a macOS sidecar; the local probe never lists
+            // it, so its place in the order matters only when choosing for a worker.
+            EncoderMode.Auto => ["NVIDIA NVENC", "Intel QSV", "VAAPI", "VideoToolbox", "CPU"],
             EncoderMode.Cpu => ["CPU"],
             EncoderMode.NvidiaNvenc => ["NVIDIA NVENC"],
             EncoderMode.IntelQsv => ["Intel QSV"],

--- a/src/Optimisarr.Core/Queue/FfmpegCommandBuilder.cs
+++ b/src/Optimisarr.Core/Queue/FfmpegCommandBuilder.cs
@@ -359,8 +359,9 @@ public static class FfmpegCommandBuilder
         AppendQualityArguments(args, family, spec.Crf);
 
         // The dispatcher has already resolved the portable effort onto this exact encoder's
-        // vocabulary. VAAPI has no cross-codec equivalent and therefore receives no preset.
-        if (family != EncoderFamily.Vaapi && !string.IsNullOrWhiteSpace(spec.Preset))
+        // vocabulary. VAAPI and VideoToolbox have no cross-codec equivalent and receive no preset.
+        if (family is not (EncoderFamily.Vaapi or EncoderFamily.VideoToolbox)
+            && !string.IsNullOrWhiteSpace(spec.Preset))
         {
             args.Add("-preset");
             args.Add(spec.Preset);
@@ -546,13 +547,20 @@ public static class FfmpegCommandBuilder
 
     // The hardware family is inferred from the resolved encoder name, so quality and device
     // arguments stay correct whatever codec was selected (e.g. h264_vaapi vs hevc_vaapi).
-    private enum EncoderFamily { Cpu, Nvenc, Qsv, Vaapi }
+    private enum EncoderFamily { Cpu, Nvenc, Qsv, Vaapi, VideoToolbox }
 
     private static EncoderFamily FamilyOf(string encoder) =>
         encoder.EndsWith("_nvenc", StringComparison.OrdinalIgnoreCase) ? EncoderFamily.Nvenc
         : encoder.EndsWith("_qsv", StringComparison.OrdinalIgnoreCase) ? EncoderFamily.Qsv
         : encoder.EndsWith("_vaapi", StringComparison.OrdinalIgnoreCase) ? EncoderFamily.Vaapi
+        : encoder.EndsWith("_videotoolbox", StringComparison.OrdinalIgnoreCase) ? EncoderFamily.VideoToolbox
         : EncoderFamily.Cpu;
+
+    // Apple's encoders take constant quality as -q:v on a 1–100 scale where higher is better, the
+    // inverse of CRF. A straight line through the two ranges keeps the operator's number meaning
+    // "lower is better" everywhere else; the VMAF gate, not this mapping, is what guarantees the
+    // result, and real-hardware calibration of the line is still owed (see the roadmap).
+    private static int VideoToolboxQuality(int crf) => Math.Clamp(100 - 2 * crf, 1, 100);
 
     // VAAPI/QSV need a hardware device declared before the input. The render node is the
     // conventional default; CUDA uses the first GPU exposed to the container.
@@ -622,6 +630,9 @@ public static class FfmpegCommandBuilder
                 break;
             case EncoderFamily.Vaapi:
                 args.AddRange(["-rc_mode", "CQP", "-qp", q]);
+                break;
+            case EncoderFamily.VideoToolbox:
+                args.AddRange(["-q:v", VideoToolboxQuality(quality).ToString()]);
                 break;
             default:
                 args.AddRange(["-crf", q]);

--- a/src/Optimisarr.Core/Verification/QualityScoreCommandBuilder.cs
+++ b/src/Optimisarr.Core/Verification/QualityScoreCommandBuilder.cs
@@ -68,6 +68,14 @@ public static class QualityScoreCommandBuilder
     public const string HdModelVersion = "vmaf_v0.6.1";
     public const string UhdModelVersion = "vmaf_4k_v0.6.1";
     public const int MaximumFrameSubsample = 10;
+
+    /// <summary>
+    /// The viewing model for a picture of this size. Cropped cinema masters are commonly
+    /// 3840x1600-ish while still intended for a 4K display, so either UHD axis selects the 4K
+    /// model. Public so an assignment can tell a remote worker which model its evidence must name.
+    /// </summary>
+    public static string ModelVersionFor(int referenceWidth, int referenceHeight) =>
+        referenceWidth >= 3840 || referenceHeight >= 2160 ? UhdModelVersion : HdModelVersion;
     private const int SampleSeekPrerollSeconds = 5;
     private const string DefaultRenderDevice = "/dev/dri/renderD128";
 
@@ -112,11 +120,7 @@ public static class QualityScoreCommandBuilder
         var referenceWidth = context.ReferenceCrop?.Width ?? context.ReferenceWidth;
         var referenceHeight = context.ReferenceCrop?.Height ?? context.ReferenceHeight;
 
-        // Cropped cinema masters are commonly 3840x1600-ish while still intended
-        // for a 4K display, so either UHD axis selects the 4K viewing model.
-        var model = referenceWidth >= 3840 || referenceHeight >= 2160
-            ? UhdModelVersion
-            : HdModelVersion;
+        var model = ModelVersionFor(referenceWidth, referenceHeight);
         var colourPreprocessing = context.ReferenceIsHdr
             ? context.HdrConvertedToSdr
                 ? "HDR reference tone-mapped to SDR"

--- a/src/Optimisarr.Core/Workers/WorkerEncoderCatalogue.cs
+++ b/src/Optimisarr.Core/Workers/WorkerEncoderCatalogue.cs
@@ -1,0 +1,53 @@
+using Optimisarr.Core.Tools;
+
+namespace Optimisarr.Core.Workers;
+
+/// <summary>
+/// Describes a sidecar's advertised encoder names in the vocabulary <see cref="Queue.EncoderSelector"/>
+/// understands, so the control plane can choose an encoder for a worker exactly the way it chooses
+/// one for itself. Fails closed: a name this has not been taught is dropped, because no assignment
+/// could carry arguments for an encoder the command builder does not know.
+/// </summary>
+public static class WorkerEncoderCatalogue
+{
+    public static IReadOnlyList<EncoderCapability> Describe(IEnumerable<string> advertised)
+    {
+        var described = new List<EncoderCapability>();
+        foreach (var raw in advertised)
+        {
+            var name = raw.Trim().ToLowerInvariant();
+            if (name.Length == 0 || described.Any(existing => existing.Name == name))
+            {
+                continue;
+            }
+
+            if (Family(name) is { } mode && Codec(name) is { } codec)
+            {
+                described.Add(new EncoderCapability(name, codec, mode, Available: true));
+            }
+        }
+
+        return described;
+    }
+
+    // The mode strings are the ones the local hardware probe reports, so the selector's preference
+    // order applies unchanged to a remote worker.
+    private static string? Family(string name) =>
+        name is "libx264" or "libx265" or "libsvtav1" ? "CPU"
+        : name.EndsWith("_nvenc", StringComparison.Ordinal) ? "NVIDIA NVENC"
+        : name.EndsWith("_qsv", StringComparison.Ordinal) ? "Intel QSV"
+        : name.EndsWith("_vaapi", StringComparison.Ordinal) ? "VAAPI"
+        : name.EndsWith("_videotoolbox", StringComparison.Ordinal) ? "VideoToolbox"
+        : null;
+
+    private static string? Codec(string name) => name switch
+    {
+        "libx264" => "h264",
+        "libx265" => "hevc",
+        "libsvtav1" => "av1",
+        _ when name.StartsWith("h264_", StringComparison.Ordinal) => "h264",
+        _ when name.StartsWith("hevc_", StringComparison.Ordinal) => "hevc",
+        _ when name.StartsWith("av1_", StringComparison.Ordinal) => "av1",
+        _ => null
+    };
+}

--- a/src/Optimisarr.Core/Workers/WorkerProtocol.cs
+++ b/src/Optimisarr.Core/Workers/WorkerProtocol.cs
@@ -26,6 +26,20 @@ public static class WorkerProtocol
     public const int MinimumSupported = 1;
 
     /// <summary>
+    /// Stands in for the worker's local copy of the source inside an assignment's argument array.
+    /// The server never sends a path: the source route takes only a lease, and the worker decides
+    /// where its scratch lives. A worker substitutes its own paths and nothing else.
+    /// </summary>
+    public const string InputPlaceholder = "{{input}}";
+
+    /// <summary>
+    /// Stands in for the worker's candidate output. It appears as a prefix carrying the container
+    /// extension the server chose (<c>{{output}}.mkv</c>), because the extension is part of the
+    /// encode contract — it decides subtitle codecs and muxer — and must not be the worker's guess.
+    /// </summary>
+    public const string OutputPlaceholder = "{{output}}";
+
+    /// <summary>
     /// Picks the highest version both sides support, or refuses with a reason. Refusal is the
     /// safe outcome: assuming an unknown sidecar is compatible is exactly the silent-upgrade
     /// failure this negotiation exists to prevent.

--- a/tests/Optimisarr.Tests/EncoderPresetPolicyTests.cs
+++ b/tests/Optimisarr.Tests/EncoderPresetPolicyTests.cs
@@ -33,6 +33,9 @@ public sealed class EncoderPresetPolicyTests
     [InlineData("h264_vaapi")]
     [InlineData("hevc_vaapi")]
     [InlineData("av1_vaapi")]
+    // VideoToolbox likewise has no preset vocabulary; Apple's encoder takes its own defaults.
+    [InlineData("hevc_videotoolbox")]
+    [InlineData("h264_videotoolbox")]
     public void Vaapi_uses_its_driver_default_instead_of_receiving_an_invalid_preset(string encoder)
     {
         var result = EncoderPresetPolicy.Resolve(encoder, "efficient");

--- a/tests/Optimisarr.Tests/EncoderQualityPolicyTests.cs
+++ b/tests/Optimisarr.Tests/EncoderQualityPolicyTests.cs
@@ -9,6 +9,9 @@ public sealed class EncoderQualityPolicyTests
     [InlineData("hevc_qsv", 24, 20, "ICQ")]
     [InlineData("hevc_nvenc", 24, 20, "CQ")]
     [InlineData("hevc_vaapi", 24, 20, "QP")]
+    // VideoToolbox stays on the CRF scale here; the command builder owns the translation to the
+    // encoder's own 1–100 control, the same division of labour as -cq and -global_quality.
+    [InlineData("hevc_videotoolbox", 24, 20, "VT-Q")]
     public void Hardware_encoders_receive_conservative_quality_headroom(
         string encoder, int requested, int expected, string mode)
     {

--- a/tests/Optimisarr.Tests/FfmpegCommandBuilderTests.cs
+++ b/tests/Optimisarr.Tests/FfmpegCommandBuilderTests.cs
@@ -334,6 +334,54 @@ public sealed class FfmpegCommandBuilderTests
         Assert.DoesNotContain("-filter:v:0", args);
     }
 
+    // --- VideoToolbox (a macOS sidecar's hardware encoder) ----------------------------------
+
+    [Fact]
+    public void Videotoolbox_receives_its_own_quality_control_on_its_own_scale()
+    {
+        // Apple's encoders take -q:v on a 1–100 scale where higher is better, the inverse of CRF.
+        // The policy keeps the operator-facing number on the CRF scale (with hardware headroom);
+        // this is where it becomes the encoder's vocabulary. 20 on the CRF scale lands at 60.
+        var args = FfmpegCommandBuilder.Build(
+            Reencode(crf: 20, preset: null), videoEncoder: "hevc_videotoolbox");
+
+        Assert.Equal("hevc_videotoolbox", args[IndexOf(args, "-c:v:0") + 1]);
+        Assert.Equal("60", args[IndexOf(args, "-q:v") + 1]);
+        Assert.DoesNotContain("-crf", args);
+        Assert.DoesNotContain("-cq", args);
+        Assert.DoesNotContain("-global_quality", args);
+    }
+
+    [Fact]
+    public void Videotoolbox_quality_stays_inside_the_encoder_range_at_the_extremes()
+    {
+        var best = FfmpegCommandBuilder.Build(Reencode(crf: 0, preset: null), videoEncoder: "hevc_videotoolbox");
+        var worst = FfmpegCommandBuilder.Build(Reencode(crf: 51, preset: null), videoEncoder: "hevc_videotoolbox");
+
+        Assert.Equal("100", best[IndexOf(best, "-q:v") + 1]);
+        Assert.Equal("1", worst[IndexOf(worst, "-q:v") + 1]);
+    }
+
+    [Fact]
+    public void Videotoolbox_never_receives_a_preset_a_device_or_tuning_it_cannot_read()
+    {
+        var args = FfmpegCommandBuilder.Build(
+            Reencode(preset: "medium") with
+            {
+                Tuning = new EncoderTuning(ContentTune.Animation, MaxBitrateKbps: 8000, MinBitrateKbps: null, StrongerAdaptiveQuantisation: true)
+            },
+            videoEncoder: "hevc_videotoolbox",
+            hardwareDecode: true);
+
+        Assert.DoesNotContain("-preset", args);
+        Assert.DoesNotContain("-tune", args);
+        Assert.DoesNotContain("-maxrate", args);
+        Assert.DoesNotContain("-init_hw_device", args);
+        Assert.DoesNotContain("-vaapi_device", args);
+        Assert.DoesNotContain("-hwaccel", args);
+        Assert.DoesNotContain("hwupload", string.Join(" ", args));
+    }
+
     private static TranscodeSpec Reencode(
         string? videoCodec = "hevc",
         int? crf = 23,

--- a/tests/Optimisarr.Tests/WorkerEncoderCatalogueTests.cs
+++ b/tests/Optimisarr.Tests/WorkerEncoderCatalogueTests.cs
@@ -1,0 +1,60 @@
+using Optimisarr.Core.Queue;
+using Optimisarr.Core.Workers;
+
+namespace Optimisarr.Tests;
+
+/// <summary>
+/// A sidecar advertises encoder names; the selector wants codec and family. The catalogue is the
+/// bridge, and it fails closed: a name it has not been taught is not offered, because an encoder
+/// nothing here can build arguments for is one no assignment could execute.
+/// </summary>
+public sealed class WorkerEncoderCatalogueTests
+{
+    [Theory]
+    [InlineData("libx265", "hevc", "CPU")]
+    [InlineData("libx264", "h264", "CPU")]
+    [InlineData("libsvtav1", "av1", "CPU")]
+    [InlineData("hevc_nvenc", "hevc", "NVIDIA NVENC")]
+    [InlineData("h264_qsv", "h264", "Intel QSV")]
+    [InlineData("av1_vaapi", "av1", "VAAPI")]
+    [InlineData("hevc_videotoolbox", "hevc", "VideoToolbox")]
+    [InlineData("h264_videotoolbox", "h264", "VideoToolbox")]
+    public void A_known_encoder_name_resolves_to_its_codec_and_family(string name, string codec, string mode)
+    {
+        var capability = Assert.Single(WorkerEncoderCatalogue.Describe([name]));
+
+        Assert.Equal(name, capability.Name);
+        Assert.Equal(codec, capability.Codec);
+        Assert.Equal(mode, capability.Mode);
+        Assert.True(capability.Available);
+    }
+
+    [Fact]
+    public void An_unknown_name_is_dropped_rather_than_guessed()
+    {
+        var described = WorkerEncoderCatalogue.Describe(["libx265", "mystery_encoder", "prores_ks"]);
+
+        var only = Assert.Single(described);
+        Assert.Equal("libx265", only.Name);
+    }
+
+    [Fact]
+    public void Names_are_matched_case_insensitively_and_trimmed()
+    {
+        var capability = Assert.Single(WorkerEncoderCatalogue.Describe([" HEVC_VideoToolbox "]));
+
+        Assert.Equal("hevc_videotoolbox", capability.Name);
+    }
+
+    [Fact]
+    public void A_mac_that_proves_videotoolbox_is_offered_it_ahead_of_its_cpu_encoder()
+    {
+        // The whole point of a sidecar is idle hardware; a proved hardware encoder wins.
+        var capabilities = WorkerEncoderCatalogue.Describe(["libx265", "hevc_videotoolbox"]);
+
+        var selection = EncoderSelector.Select("hevc", EncoderMode.Auto, capabilities);
+
+        Assert.True(selection.Succeeded);
+        Assert.Equal("hevc_videotoolbox", selection.EncoderName);
+    }
+}

--- a/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
+++ b/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
@@ -4,6 +4,8 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Optimisarr.Core.Domain;
+using Optimisarr.Core.Queue;
 using Optimisarr.Data;
 
 namespace Optimisarr.Tests;
@@ -75,7 +77,13 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
     }
 
     /// <summary>Pairs a worker that can actually satisfy a job, and returns its credential.</summary>
-    private async Task<HttpClient> PairCapableWorker(string name, int concurrency = 1)
+    private Task<HttpClient> PairCapableWorker(string name, int concurrency = 1) =>
+        PairWorkerWithEncoders(name, concurrency, "libx265");
+
+    private Task<HttpClient> PairWorkerWithEncoders(string name, params string[] encoders) =>
+        PairWorkerWithEncoders(name, 1, encoders);
+
+    private async Task<HttpClient> PairWorkerWithEncoders(string name, int concurrency, params string[] encoders)
     {
         var admin = Admin();
         var issued = await admin.PostAsync("/api/workers/pairing-code", null);
@@ -90,7 +98,7 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
             architecture = "x64",
             protocolMinimum = 1,
             protocolMaximum = 1,
-            videoEncoders = new[] { "libx265" },
+            videoEncoders = encoders,
             hardwareDecoders = Array.Empty<string>(),
             vmaf = "Cpu",
             freeScratchBytes = 500L * 1024 * 1024 * 1024,
@@ -106,12 +114,21 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
     }
 
     /// <summary>Puts one queued job in front of the workers and returns its id.</summary>
-    private async Task<int> QueueAJob(string? videoEncoder = "libx265")
+    private async Task<int> QueueAJob(
+        string? videoEncoder = "libx265",
+        VideoQualityStrategy strategy = VideoQualityStrategy.Fixed,
+        RuleProfile profile = RuleProfile.ConservativeHevc)
     {
         using var scope = _api.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
 
-        var library = new Library { Name = "Leases", Path = Path.Combine(_api.LibraryDirectory, Guid.NewGuid().ToString("N")) };
+        var library = new Library
+        {
+            Name = "Leases",
+            Path = Path.Combine(_api.LibraryDirectory, Guid.NewGuid().ToString("N")),
+            VideoQualityStrategy = strategy,
+            RuleProfile = profile,
+        };
         db.Libraries.Add(library);
         await db.SaveChangesAsync();
         _createdLibraries.Add(library.Id);
@@ -128,6 +145,12 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
             Path = sourcePath,
             RelativePath = "film.mkv",
             SizeBytes = SourceBytes.Length,
+            // The inventory's picture facts, as a scan would have recorded them: the assignment
+            // names its VMAF model from the size, and a re-encode needs a video to re-encode.
+            MediaKind = MediaKind.Video,
+            VideoCodec = "h264",
+            Width = 1920,
+            Height = 1080,
         };
         db.MediaFiles.Add(file);
         await db.SaveChangesAsync();
@@ -153,19 +176,86 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task A_job_enqueued_the_way_the_application_enqueues_one_is_never_offered()
+    public async Task A_job_enqueued_the_way_the_application_enqueues_one_is_offered_with_an_executable_command()
     {
-        // Every other test here hand-sets VideoEncoder on a Queued job. The application never
-        // does: that column is written once, during local dispatch, to record what actually ran.
-        // A job sitting in the queue — the only state this endpoint selects — has it null, so the
-        // matcher correctly refuses the assignment as unnamed and no work is ever handed out.
+        // The application never sets VideoEncoder on a queued job; that column records what ran.
+        // The encoder is resolved here, for this worker, from what it proved — and the assignment
+        // carries the exact command this machine would have run, with the worker's paths as tokens.
         await EnableRemoteWorkers();
         var worker = await PairCapableWorker("Claimer");
-        await QueueAJob(videoEncoder: null);
+        var jobId = await QueueAJob(videoEncoder: null);
+
+        using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+
+        Assert.Equal(HttpStatusCode.OK, claim.StatusCode);
+        var assignment = await claim.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(jobId, assignment.GetProperty("jobId").GetInt32());
+        Assert.Equal("libx265", assignment.GetProperty("videoEncoder").GetString());
+
+        var arguments = assignment.GetProperty("arguments").EnumerateArray()
+            .Select(element => element.GetString()!).ToList();
+        Assert.Equal("{{input}}", arguments[arguments.IndexOf("-i") + 1]);
+        // ConservativeHevc targets MP4, and the extension is part of the contract: it decides the
+        // muxer and the subtitle codec, so it travels with the placeholder rather than being guessed.
+        Assert.Equal("{{output}}.mp4", arguments[^1]);
+        Assert.Equal("mp4", assignment.GetProperty("outputExtension").GetString());
+        Assert.Equal("libx265", arguments[arguments.IndexOf("-c:v:0") + 1]);
+        Assert.Contains("-crf", arguments);
+        // No path on this machine reaches a worker, and no thread limit either — that is ours.
+        Assert.DoesNotContain(arguments, argument => argument.StartsWith('/'));
+        Assert.DoesNotContain("-threads", arguments);
+        Assert.False(assignment.TryGetProperty("sourcePath", out _));
+
+        var quality = assignment.GetProperty("quality");
+        Assert.Equal("vmaf_v0.6.1", quality.GetProperty("model").GetString());
+        Assert.True(quality.GetProperty("minimumHarmonicMean").GetDouble() > 0);
+    }
+
+    [Fact]
+    public async Task A_job_from_an_adaptive_library_stays_local_until_its_quality_has_been_chosen()
+    {
+        // Adaptive selection runs sample encodes on this machine's encoder; a quality chosen for
+        // one encoder means nothing on another. Offering the job at the fixed quality instead
+        // would silently change what the library asked for, so it is not offered at all.
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Claimer");
+        await QueueAJob(videoEncoder: null, strategy: VideoQualityStrategy.AdaptiveVmaf);
 
         using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
 
         Assert.Equal(HttpStatusCode.NoContent, claim.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_remux_only_job_is_not_offered_to_a_remote_worker()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Claimer");
+        await QueueAJob(videoEncoder: null, profile: RuleProfile.RemuxCleanup);
+
+        using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+
+        Assert.Equal(HttpStatusCode.NoContent, claim.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_worker_that_proves_a_hardware_encoder_is_handed_a_command_for_it()
+    {
+        // A Mac proving VideoToolbox gets VideoToolbox's own quality control, not a CRF it would
+        // reject — the same builder that serves local hardware encoders resolved it for the worker.
+        await EnableRemoteWorkers();
+        var worker = await PairWorkerWithEncoders("MacMini", "libx265", "hevc_videotoolbox");
+        await QueueAJob(videoEncoder: null);
+
+        using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+
+        Assert.Equal(HttpStatusCode.OK, claim.StatusCode);
+        var assignment = await claim.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("hevc_videotoolbox", assignment.GetProperty("videoEncoder").GetString());
+        var arguments = assignment.GetProperty("arguments").EnumerateArray()
+            .Select(element => element.GetString()!).ToList();
+        Assert.Contains("-q:v", arguments);
+        Assert.DoesNotContain("-crf", arguments);
     }
 
     [Fact]


### PR DESCRIPTION
Piece 1 of the four-piece sidecar plan in `docs/roadmap.md`. Server-only; the Swift client does not yet decode assignments, so nothing on the Mac side changes.

## Outcome

A worker's claim can now succeed, and what it receives is executable. Before this, the assignment named no encoder and carried no policy, so every claim fell through to 204 (pinned by a characterisation test, which now asserts the opposite).

- `QueueDispatcher.PrepareRemoteWorkAsync` runs the same preparation as local dispatch, with the encoder chosen from the worker's proved list via `WorkerEncoderCatalogue` → `EncoderSelector` (Auto order), software decode, no thread limit, and placeholder paths.
- `AssignmentDto` gains `arguments`, `outputExtension` and a `quality` requirement (measure, model, frame subsample, clip mode, thresholds), and loses `sourcePath`. `{{input}}` / `{{output}}.<ext>` are defined once in `WorkerProtocol`.
- Refused with a debug-logged reason: remux, audio and image jobs; adaptive-VMAF libraries whose per-title quality is not yet chosen. A cheap pre-filter in the endpoint spares an ffprobe per refused candidate per poll; the dispatcher remains the authority and repeats the refusals.
- VideoToolbox is now a known encoder family: selector, quality policy (`VT-Q`, hardware headroom), preset policy (no preset), tuning policy (nothing), command builder (`-q:v` = clamp(100 − 2·CRF)). No device init, no hwaccel, no hwupload for it.

## Decisions recorded as taken (roadmap)

- Encode contract: the server-built argument array with worker-side allowlist validation.
- Delivered-but-unverified state: a new `JobStatus.AwaitingVerification` (piece 2).

## Excluded

- The VMAF command array (piece 3 will ship it the same way so crop, fps and HDR preparation stay in one place).
- Hardware decode for a worker that proves a decoder.
- Adaptive selection on the worker.
- Real-hardware calibration of the VideoToolbox quality line. The VMAF gate guarantees the result; the mapping only chooses the starting point.

## Verification

- `dotnet build -warnaserror`: 0 warnings. `dotnet test`: 1809 passed (24 new: catalogue, family policies, builder, four endpoint tests including a VideoToolbox worker).
- `scripts/check_openapi.py` updated; `scripts/check_docs.py` clean. No frontend change.

## Safety

No original is touched by this change: a lease still only moves a job to `Leased`, and nothing yet consumes a delivered candidate (piece 2). The one new outward-facing surface is the argument array, which contains no server path by construction and is asserted so in the endpoint test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
