### PR TITLE
Give the macOS sidecar its work loop: claim, validate, fetch, encode, deliver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- **The macOS sidecar now does work.** On each healthy check-in while idle it claims a job, and
+  runs it end to end: the server's command is validated against an explicit contract before a byte
+  is fetched (known options only, the only input and output are the two placeholder tokens, no value
+  that looks like a path — anything else is refused whole and the job handed back with the token
+  named); the source is fetched by lease into the app's own scratch and hashed, and a transfer that
+  does not match the server's hash is never encoded; the bundled ffmpeg runs while the lease is
+  renewed, and losing the lease stops the encode; the candidate is hashed and delivered with both
+  hashes for the server to verify exactly as it would a local encode. The menu shows the job and
+  stage, and how the last job ended. Scratch is removed on every exit path; forgetting the pairing
+  cancels a running job. One job at a time. VMAF is not yet measured on the Mac; the server measures
+  it itself for now.
+
 - **A candidate delivered by a remote worker is now verified and can earn replacement.** Before
   this, a delivered candidate was set to Verifying, where nothing picked it up, and the next
   restart's recovery sweep deleted it as an interrupted encode. Delivery now lands the job in a new

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -651,10 +651,17 @@ the replacement workflow is trustworthy.
         `RemoteQualityEvidenceValidator` is wired in with piece 3, when a worker can produce
         evidence to validate.
 
-     3. **The sidecar's work loop.** Now the next server-independent piece; a claim returns an
-        executable command. The client implements two of the ten worker routes. Claim,
-        renew, release, source download (Range plus hash check), transcode, VMAF measurement and
-        result upload are all unwritten, as are progress reporting and cancellation.
+     3. **The sidecar's work loop: landed 2026-09-04.** Claim, renew, release, source download
+        with a hash check, transcode with progress, and result upload are implemented
+        (`SidecarClient`, `JobRunner`, `AssignmentCommand`), and `SidecarSession` claims one job
+        per healthy check-in while idle. The command contract on the worker side is an explicit
+        allowlist of the options the server's builder emits, the two placeholder tokens as the only
+        input and output, and no path-like value; a refused command hands the job back naming the
+        token. Losing the lease cancels the encode; forgetting the pairing cancels the job; scratch
+        is removed on every exit path. **Left for later:** Range-resumed downloads (a dropped
+        transfer restarts today), VMAF measurement on the worker and the evidence upload that
+        `RemoteQualityEvidenceValidator` will judge (the server re-measures until then), and
+        real-hardware acceptance evidence for the whole loop.
 
      4. **Drain controls**, and then productionisation: launch-at-login, sleep/wake, App Nap,
         low-disk handling, cancel-on-quit. Developer ID signing and notarisation are unblocked — a
@@ -687,11 +694,11 @@ the replacement workflow is trustworthy.
      that proves nothing still reports nothing, and the fail-closed matcher never offers it work. Revocation, an incompatible protocol,
      and the feature being switched off server-side are each surfaced distinctly rather than as a
      generic failure. A live test suite runs the real client against a running server, which is how
-     this contract gets a second implementation holding it honest. **Still to build:** claiming
-     work, media transfer, transcoding, VMAF, launch-at-login, sleep/wake and App Nap handling,
-     Developer ID signing and notarisation. The client implements two of the ten worker routes
-     (`pair` and `heartbeat`); claim, renew, release, source and result are all unwritten, and
-     `SidecarSession` has no work loop.
+     this contract gets a second implementation holding it honest. It now claims work, fetches the
+     source by lease, validates and runs the server's command with the bundled ffmpeg, renews the
+     lease throughout, and delivers the candidate with both hashes (see piece 3 above). **Still to
+     build:** VMAF on the worker, Range-resumed transfers, launch-at-login, sleep/wake and App Nap
+     handling, Developer ID signing and notarisation, and real-hardware acceptance evidence.
    - **Operational UI and acceptance evidence.** The main app shows each worker's trustworthy name,
      platform, version, capabilities, health, load, active lease, transfer progress, and last error;
      worker removal immediately prevents new assignments. Automated contract and end-to-end tests

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -5,15 +5,31 @@ capacity.
 
 ## What this version does, and does not
 
-**It does not transcode anything yet.** It pairs, stores its credential, reports what this Mac can
-actually do, and checks in. That is the whole of it.
+It pairs, stores its credential, reports what this Mac can actually do, checks in, and — once the
+server has verified it can finish a job that came back — asks for work. A job runs like this:
 
-That is deliberate rather than unfinished. Nothing here asks the server for work, because the server
-cannot yet finish a job that came back from a worker: it accepts a returned candidate and leaves it
-waiting for a verification pass that does not exist. An app that claimed to transcode would be
-claiming something neither end can complete.
+1. **Claim.** On each healthy check-in while idle, the app asks for one job. The server answers
+   with the exact FFmpeg command it would have run itself, resolved for an encoder this Mac
+   proved, with two tokens standing in for paths.
+2. **Validate.** The command is checked before a byte is fetched: every option is one the server's
+   builder is known to emit, the only input is the `{{input}}` token, the only output is the
+   `{{output}}` token in last position carrying the promised extension, and no other value looks
+   like a path. Anything else is refused whole and the job handed back with the offending token
+   named. The server decides *what* to encode; it never names files on this machine.
+3. **Fetch and prove.** The source is downloaded by lease into the app's own scratch and hashed;
+   a transfer that does not match the server's hash is never encoded.
+4. **Encode, renewing.** The bundled ffmpeg runs the command against this Mac's paths. The lease
+   is renewed throughout; losing it stops the encode rather than finishing work the server has
+   already given to someone else.
+5. **Deliver.** The candidate is hashed and uploaded with both hashes, so the server can bind it to
+   this exact source. The server then verifies it against the original exactly as it would a local
+   encode. Nothing is replaced from here, ever.
 
-What it *does* now report is real. It bundles its own ffmpeg, built from pinned source by
+Scratch lives under `~/Library/Application Support/OptimisarrSidecar/work` and is removed on every
+exit path. One job at a time. Quality evidence (VMAF) is not yet measured here; the server measures
+it itself for now.
+
+What it reports is real. It bundles its own ffmpeg, built from pinned source by
 [`scripts/build-ffmpeg.sh`](scripts/build-ffmpeg.sh), and probes this machine in two stages: parse
 `ffmpeg -encoders`, then confirm each VideoToolbox encoder with a real throwaway encode. Every Apple
 build lists VideoToolbox whether or not a given machine can open it, so listing alone would have the

--- a/sidecars/macos/Sources/OptimisarrSidecar/MenuBarIcon.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/MenuBarIcon.swift
@@ -88,7 +88,8 @@ enum MenuBarIcon {
     /// glance at a menu bar icon is to find out whether something needs attention.
     private static func badge(for status: SidecarStatus) -> Badge? {
         switch status {
-        case .connected: return nil
+        // Working is as ordinary as connected: a job running is the machine doing its job.
+        case .connected, .working: return nil
         case .pairing: return .hollow
         case .unpaired: return .hollow
         case .unreachable, .disabledOnServer: return .solid

--- a/sidecars/macos/Sources/OptimisarrSidecar/SidecarMenu.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/SidecarMenu.swift
@@ -99,9 +99,21 @@ struct SidecarMenu: View {
                     .font(.caption)
             }
 
-            // Said plainly rather than buried. Someone who pairs a machine reasonably expects it to
-            // start doing something, and it will not yet.
-            Text("This sidecar does not transcode yet. It pairs and reports in so the connection can be set up and tested while the rest is built.")
+            if case let .working(jobId, progress) = session.status {
+                LabeledContent("Job", value: "#\(jobId)").font(.caption)
+                LabeledContent("Stage", value: progress.label).font(.caption)
+            }
+
+            if let outcome = session.lastOutcome {
+                Text(outcome.label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            // Said plainly: a delivered candidate is a proposal. Optimisarr verifies it against the
+            // original before anything is replaced, and this machine never sees that decision.
+            Text("Encodes are delivered to Optimisarr for verification; nothing is replaced from here.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -114,10 +126,38 @@ struct SidecarMenu: View {
     }
 }
 
+private extension JobProgress {
+    var label: String {
+        switch self {
+        case .fetchingSource: return "Fetching the source"
+        case let .encoding(seconds):
+            let whole = Int(seconds)
+            return String(format: "Encoding · %d:%02d:%02d of output", whole / 3600, whole % 3600 / 60, whole % 60)
+        case .delivering: return "Delivering the candidate"
+        }
+    }
+}
+
+private extension JobOutcome {
+    var label: String {
+        switch self {
+        case let .delivered(jobId, bytes):
+            let size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+            return "Last job #\(jobId): delivered \(size) for verification."
+        case let .released(jobId, reason):
+            return "Last job #\(jobId): handed back — \(reason)"
+        case let .leaseLost(jobId, reason):
+            return "Last job #\(jobId): lease lost — \(reason)"
+        }
+    }
+}
+
 private extension SidecarStatus {
     var isHealthy: Bool {
-        if case .connected = self { return true }
-        return false
+        switch self {
+        case .connected, .working: return true
+        default: return false
+        }
     }
 
     /// The explanation behind the state, where there is one worth reading.

--- a/sidecars/macos/Sources/SidecarCore/AssignmentCommand.swift
+++ b/sidecars/macos/Sources/SidecarCore/AssignmentCommand.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Why an assignment's command was refused. Each names the offending token so an operator reading
+/// the log can see what the server sent, not merely that it was rejected.
+public enum AssignmentCommandError: Error, Equatable, Sendable {
+    case empty
+    case unknownOption(String)
+    case optionWithoutValue(String)
+    case inputMustBePlaceholder(String)
+    case exactlyOneInputRequired(Int)
+    case outputMustBeLast(expected: String)
+    case invalidOutputExtension(String)
+    case pathLikeValue(String)
+    case strayPlaceholder(String)
+}
+
+/// The server's argument array, checked before this machine will run it.
+///
+/// The server is trusted to decide *what* to encode; it is not trusted to name *files* on this
+/// machine. A compromised or merely buggy server could otherwise point FFmpeg at anything a
+/// worker's user can read, or write over anything they can write. So the command must satisfy a
+/// small, explicit contract: every option is one the server's own command builder is known to
+/// emit, the only input is the `{{input}}` token, the only output is the `{{output}}` token in
+/// last position carrying the promised extension, and no other value looks like a path. The
+/// worker then substitutes only its own scratch paths. Anything outside that contract is refused
+/// whole rather than repaired, because a repaired command is one nobody wrote.
+public struct AssignmentCommand: Sendable, Equatable {
+    /// Options that take no value.
+    static let flags: Set<String> = ["-y", "-nostats"]
+
+    /// Options that take exactly one value. Drawn from `FfmpegCommandBuilder` and
+    /// `EncoderTuningPolicy`; an option the server starts emitting must be added here, which is
+    /// deliberate — the failure is a refused job with a named token, never a silently run one.
+    /// Device and hardware-decode options are absent on purpose: a remote command decodes in
+    /// software, and the server never sends them to a worker.
+    static let valued: Set<String> = [
+        "-progress", "-threads", "-fflags", "-i", "-map", "-map_metadata", "-metadata",
+        "-disposition:v:0", "-c", "-c:v", "-c:v:0", "-c:a", "-c:s", "-filter:v:0", "-vf",
+        "-crf", "-preset", "-q:v", "-qp", "-cq", "-rc", "-b:v", "-b:a", "-ac",
+        "-global_quality", "-rc_mode", "-quality", "-lossless",
+        "-tune", "-maxrate", "-minrate", "-bufsize", "-x264-params", "-x265-params",
+        "-spatial-aq", "-temporal-aq", "-fps_mode", "-enc_time_base:v:0",
+        "-ss", "-t", "-movflags",
+    ]
+
+    public let arguments: [String]
+    public let outputExtension: String
+
+    /// Checks the array against the contract above. Throws rather than returning a partial
+    /// result, so a caller cannot forget to look.
+    public static func validate(_ arguments: [String], outputExtension: String) throws -> AssignmentCommand {
+        guard let last = arguments.last else { throw AssignmentCommandError.empty }
+
+        guard Self.isPlainExtension(outputExtension) else {
+            throw AssignmentCommandError.invalidOutputExtension(outputExtension)
+        }
+        let expectedOutput = "\(Assignment.outputPlaceholder).\(outputExtension)"
+        guard last == expectedOutput else {
+            throw AssignmentCommandError.outputMustBeLast(expected: expectedOutput)
+        }
+
+        var index = 0
+        var inputs = 0
+        let body = arguments.dropLast()
+        while index < body.count {
+            let token = body[index]
+            if flags.contains(token) {
+                index += 1
+                continue
+            }
+            guard valued.contains(token) else {
+                throw AssignmentCommandError.unknownOption(token)
+            }
+            guard index + 1 < body.count else {
+                throw AssignmentCommandError.optionWithoutValue(token)
+            }
+            let value = body[index + 1]
+            if token == "-i" {
+                guard value == Assignment.inputPlaceholder else {
+                    throw AssignmentCommandError.inputMustBePlaceholder(value)
+                }
+                inputs += 1
+            } else {
+                try Self.checkValue(value)
+            }
+            index += 2
+        }
+
+        guard inputs == 1 else { throw AssignmentCommandError.exactlyOneInputRequired(inputs) }
+        return AssignmentCommand(arguments: arguments, outputExtension: outputExtension)
+    }
+
+    /// Substitutes this machine's paths for the two tokens. The output must already carry the
+    /// promised extension: the extension chooses the muxer and the subtitle codec, so it is part
+    /// of the contract rather than a worker preference.
+    public func materialise(input: URL, output: URL) -> [String] {
+        precondition(output.pathExtension == outputExtension, "output must carry the contract's extension")
+        var result = arguments
+        result[result.count - 1] = output.path
+        for index in result.indices where result[index] == Assignment.inputPlaceholder {
+            result[index] = input.path
+        }
+        return result
+    }
+
+    private static func checkValue(_ value: String) throws {
+        if value.contains(Assignment.inputPlaceholder) || value.contains(Assignment.outputPlaceholder) {
+            throw AssignmentCommandError.strayPlaceholder(value)
+        }
+        // A filter chain, a metadata marker or a rate control value never needs a path
+        // separator or a home shorthand; an argument that has one is trying to name a file.
+        if value.contains("/") || value.contains("\\") || value.hasPrefix("~") {
+            throw AssignmentCommandError.pathLikeValue(value)
+        }
+    }
+
+    private static func isPlainExtension(_ extension: String) -> Bool {
+        !`extension`.isEmpty
+            && `extension`.count <= 8
+            && `extension`.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
+    }
+}

--- a/sidecars/macos/Sources/SidecarCore/JobRunner.swift
+++ b/sidecars/macos/Sources/SidecarCore/JobRunner.swift
@@ -1,0 +1,276 @@
+import CryptoKit
+import Foundation
+
+/// A line of FFmpeg's `-progress pipe:1` protocol, reduced to the one number the menu shows.
+///
+/// Every field arrives as `key=value`, one per line, and a block ends with `progress=continue`
+/// or `progress=end`. Only the encoded time is read; the server owns the frame arithmetic.
+public enum FfmpegProgressLine {
+    /// Seconds of output produced so far, when the line carries it.
+    public static func encodedSeconds(_ line: String) -> Double? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        // out_time_us is microseconds. out_time_ms is, despite its name, also microseconds in
+        // every FFmpeg that prints it; both are read the same way so a build that drops one
+        // still reports progress.
+        for key in ["out_time_us=", "out_time_ms="] where trimmed.hasPrefix(key) {
+            guard let micro = Double(trimmed.dropFirst(key.count)), micro >= 0 else { return nil }
+            return micro / 1_000_000
+        }
+        return nil
+    }
+}
+
+/// Runs the transcode itself, so the job flow can be tested with a runner that merely writes a
+/// file. Cancellation of the calling task must stop the process: a lease that is lost or a
+/// pairing that is forgotten must not leave an encode running for nobody.
+public protocol TranscodeRunner: Sendable {
+    func run(
+        _ executable: URL,
+        _ arguments: [String],
+        progress: @escaping @Sendable (Double) -> Void
+    ) async throws -> (exitCode: Int32, stderr: String)
+}
+
+public struct ProcessTranscodeRunner: TranscodeRunner {
+    public init() {}
+
+    /// Process and its pipes are thread-safe Foundation objects that the compiler cannot see as
+    /// such; the box lets the cancellation handler reach the process to terminate it.
+    private final class RunningProcess: @unchecked Sendable {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+    }
+
+    public func run(
+        _ executable: URL,
+        _ arguments: [String],
+        progress: @escaping @Sendable (Double) -> Void
+    ) async throws -> (exitCode: Int32, stderr: String) {
+        let running = RunningProcess()
+        running.process.executableURL = executable
+        running.process.arguments = arguments
+        running.process.standardOutput = running.stdout
+        running.process.standardError = running.stderr
+
+        try running.process.run()
+
+        return try await withTaskCancellationHandler {
+            let stderrTask = Task.detached {
+                running.stderr.fileHandleForReading.readDataToEndOfFile()
+            }
+            for try await line in running.stdout.fileHandleForReading.bytes.lines {
+                if let seconds = FfmpegProgressLine.encodedSeconds(line) {
+                    progress(seconds)
+                }
+            }
+            let errorOutput = await stderrTask.value
+            running.process.waitUntilExit()
+            return (
+                running.process.terminationStatus,
+                String(decoding: errorOutput.suffix(4_096), as: UTF8.self))
+        } onCancel: {
+            running.process.terminate()
+        }
+    }
+}
+
+/// How one assignment ended, in terms the menu can show and a log can keep.
+public enum JobOutcome: Sendable, Equatable {
+    /// The candidate reached the server intact. Verification there decides what it is worth.
+    case delivered(jobId: Int, bytes: Int64)
+
+    /// The job was handed back for the server to reassign, with the reason it could not be done.
+    case released(jobId: Int, reason: String)
+
+    /// The lease lapsed or was refused mid-job; the server has already moved on.
+    case leaseLost(jobId: Int, reason: String)
+}
+
+/// What is happening inside a running job, for the menu.
+public enum JobProgress: Sendable, Equatable {
+    case fetchingSource
+    case encoding(encodedSeconds: Double)
+    case delivering
+}
+
+/// Executes assignments, so the session can be driven in tests without an ffmpeg or a server.
+public protocol WorkExecutor: Sendable {
+    func execute(
+        _ assignment: Assignment,
+        pairing: StoredPairing,
+        progress: @escaping @Sendable (JobProgress) -> Void
+    ) async -> JobOutcome
+}
+
+/// Takes one assignment from claim to delivery.
+///
+/// The order is chosen for what each step protects. The command is validated before a byte is
+/// fetched, so nothing this machine will not run is ever downloaded for. The source is hashed on
+/// arrival and compared to the server's hash, so a corrupt transfer is never encoded and passed
+/// off as a candidate. The lease is renewed throughout, and losing it cancels the encode rather
+/// than finishing work the server has already given to someone else. Everything lives under one
+/// scratch directory per lease and is removed on every exit path, so a failed job leaves nothing
+/// behind but a line in the log.
+public struct JobRunner: WorkExecutor {
+    private let client: SidecarClient
+    private let ffmpeg: URL?
+    private let runner: TranscodeRunner
+    private let scratchRoot: URL
+    private let sleep: @Sendable (TimeInterval) async throws -> Void
+
+    public init(
+        client: SidecarClient = SidecarClient(),
+        ffmpeg: URL? = CapabilityProber.bundledFfmpeg(),
+        runner: TranscodeRunner = ProcessTranscodeRunner(),
+        scratchRoot: URL = JobRunner.defaultScratchRoot(),
+        sleep: @escaping @Sendable (TimeInterval) async throws -> Void = { seconds in
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+        }
+    ) {
+        self.client = client
+        self.ffmpeg = ffmpeg
+        self.runner = runner
+        self.scratchRoot = scratchRoot
+        self.sleep = sleep
+    }
+
+    /// Scratch under the app's own support directory rather than a shared temp location, so a
+    /// multi-gigabyte source is somewhere an operator can find, and never in anyone else's way.
+    public static func defaultScratchRoot() -> URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return base.appendingPathComponent("OptimisarrSidecar/work", isDirectory: true)
+    }
+
+    public func execute(
+        _ assignment: Assignment,
+        pairing: StoredPairing,
+        progress: @escaping @Sendable (JobProgress) -> Void
+    ) async -> JobOutcome {
+        let scratch = scratchRoot.appendingPathComponent("lease-\(assignment.leaseId)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        do {
+            let outcome = try await run(assignment, pairing: pairing, scratch: scratch, progress: progress)
+            return outcome
+        } catch let error as SidecarError {
+            switch error {
+            case let .leaseLost(reason):
+                return .leaseLost(jobId: assignment.jobId, reason: reason)
+            case .credentialRejected:
+                return .leaseLost(jobId: assignment.jobId, reason: "This worker's credential was rejected.")
+            default:
+                return await release(assignment, pairing: pairing, reason: Self.describe(error))
+            }
+        } catch is CancellationError {
+            return await release(assignment, pairing: pairing, reason: "The job was cancelled on this machine.")
+        } catch {
+            return await release(assignment, pairing: pairing, reason: error.localizedDescription)
+        }
+    }
+
+    private func run(
+        _ assignment: Assignment,
+        pairing: StoredPairing,
+        scratch: URL,
+        progress: @escaping @Sendable (JobProgress) -> Void
+    ) async throws -> JobOutcome {
+        guard let ffmpeg else {
+            return await release(assignment, pairing: pairing, reason: "This build has no ffmpeg to run.")
+        }
+
+        let command: AssignmentCommand
+        do {
+            command = try AssignmentCommand.validate(
+                assignment.arguments, outputExtension: assignment.outputExtension)
+        } catch let error as AssignmentCommandError {
+            return await release(assignment, pairing: pairing, reason: "The server's command was refused: \(error).")
+        }
+
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        let source = scratch.appendingPathComponent("source", isDirectory: false)
+        let candidate = scratch.appendingPathComponent("candidate.\(assignment.outputExtension)", isDirectory: false)
+
+        progress(.fetchingSource)
+        let declaredSourceHash = try await client.fetchSource(
+            serverAddress: pairing.serverAddress, credential: pairing.credential,
+            leaseId: assignment.leaseId, to: source)
+        let actualSourceHash = try Self.sha256(of: source)
+        guard actualSourceHash.caseInsensitiveCompare(declaredSourceHash) == .orderedSame else {
+            return await release(assignment, pairing: pairing,
+                reason: "The source did not arrive intact (hash mismatch), so it was not encoded.")
+        }
+
+        let arguments = command.materialise(input: source, output: candidate)
+        let encode = try await withThrowingTaskGroup(of: (Int32, String)?.self) { group in
+            group.addTask {
+                let result = try await runner.run(ffmpeg, arguments) { seconds in
+                    progress(.encoding(encodedSeconds: seconds))
+                }
+                return result
+            }
+            group.addTask {
+                // Renew at half the window the server states, so one missed renewal does not
+                // cost the lease. A lost lease throws, which cancels the encode below.
+                let interval = max(5, Double(assignment.renewWithinSeconds) / 2)
+                while true {
+                    try await sleep(interval)
+                    try await client.renew(
+                        serverAddress: pairing.serverAddress, credential: pairing.credential,
+                        leaseId: assignment.leaseId)
+                }
+            }
+            // The encode finishes first in every healthy run; the renewal loop only ever ends by
+            // throwing. Either way the other task is cancelled before returning.
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? nil
+        }
+
+        guard let encode, encode.0 == 0 else {
+            let detail = encode?.1.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return await release(assignment, pairing: pairing,
+                reason: "ffmpeg exited with code \(encode?.0 ?? -1)." + (detail.isEmpty ? "" : " \(detail)"))
+        }
+
+        progress(.delivering)
+        let candidateHash = try Self.sha256(of: candidate)
+        let receipt = try await client.deliver(
+            serverAddress: pairing.serverAddress, credential: pairing.credential,
+            leaseId: assignment.leaseId, file: candidate,
+            sourceSha256: declaredSourceHash, candidateSha256: candidateHash)
+        return .delivered(jobId: receipt.jobId, bytes: receipt.bytes)
+    }
+
+    /// Hands the job back. Best effort: if the release itself fails the lease lapses on its own
+    /// and the server reclaims the job then, so nothing is stranded either way.
+    private func release(_ assignment: Assignment, pairing: StoredPairing, reason: String) async -> JobOutcome {
+        try? await client.release(
+            serverAddress: pairing.serverAddress, credential: pairing.credential,
+            leaseId: assignment.leaseId)
+        return .released(jobId: assignment.jobId, reason: reason)
+    }
+
+    /// Streams the file through SHA-256 so a multi-gigabyte source is never held in memory.
+    static func sha256(of file: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: file)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while let chunk = try handle.read(upToCount: 1 << 20), !chunk.isEmpty {
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func describe(_ error: SidecarError) -> String {
+        switch error {
+        case let .unreachable(description): return "The server could not be reached: \(description)"
+        case let .unexpectedResponse(status): return "The server replied unexpectedly (HTTP \(status))."
+        case let .remoteWorkersDisabled(reason): return reason
+        case let .transferFailed(reason): return reason
+        case let .deliveryRefused(reason): return reason
+        default: return "\(error)"
+        }
+    }
+}

--- a/sidecars/macos/Sources/SidecarCore/SidecarClient.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarClient.swift
@@ -26,6 +26,23 @@ public enum SidecarError: Error, Equatable, Sendable {
 
     /// The server could not be reached at all.
     case unreachable(description: String)
+
+    /// The lease this job runs under is no longer this worker's: it lapsed, was released, or the
+    /// job moved on without it. Whatever was being done for it is finished with.
+    case leaseLost(reason: String)
+
+    /// A source or candidate transfer did not complete.
+    case transferFailed(reason: String)
+
+    /// The server declined the delivered candidate; the reason is its own sentence.
+    case deliveryRefused(reason: String)
+}
+
+/// The server's acknowledgement of a delivered candidate: accepted for verification, not yet judged.
+public struct DeliveryReceipt: Sendable, Equatable {
+    public let jobId: Int
+    public let bytes: Int64
+    public let candidateSha256: String
 }
 
 /// The result of a successful pairing. The credential is returned exactly once and is not
@@ -43,9 +60,13 @@ public struct HeartbeatResult: Sendable, Equatable {
     public let heartbeatInterval: TimeInterval
 }
 
-/// Performs HTTP so the client can be tested without a network.
+/// Performs HTTP so the client can be tested without a network. Bodies that may be gigabytes —
+/// a source coming down, a candidate going up — stream to and from files rather than through
+/// memory, hence the two file-shaped calls beside the ordinary one.
 public protocol HTTPTransport: Sendable {
     func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse)
+    func download(_ request: URLRequest, to destination: URL) async throws -> HTTPURLResponse
+    func upload(_ request: URLRequest, fromFile file: URL) async throws -> (Data, HTTPURLResponse)
 }
 
 public struct URLSessionTransport: HTTPTransport {
@@ -57,6 +78,29 @@ public struct URLSessionTransport: HTTPTransport {
 
     public func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw SidecarError.unexpectedResponse(status: 0)
+        }
+        return (data, http)
+    }
+
+    public func download(_ request: URLRequest, to destination: URL) async throws -> HTTPURLResponse {
+        let (temporary, response) = try await session.download(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            try? FileManager.default.removeItem(at: temporary)
+            throw SidecarError.unexpectedResponse(status: 0)
+        }
+        if http.statusCode == 200 {
+            try? FileManager.default.removeItem(at: destination)
+            try FileManager.default.moveItem(at: temporary, to: destination)
+        } else {
+            try? FileManager.default.removeItem(at: temporary)
+        }
+        return http
+    }
+
+    public func upload(_ request: URLRequest, fromFile file: URL) async throws -> (Data, HTTPURLResponse) {
+        let (data, response) = try await session.upload(for: request, fromFile: file)
         guard let http = response as? HTTPURLResponse else {
             throw SidecarError.unexpectedResponse(status: 0)
         }
@@ -177,6 +221,148 @@ public struct SidecarClient: Sendable {
         case let status:
             throw SidecarError.unexpectedResponse(status: status)
         }
+    }
+
+    /// Asks for work. `nil` is the ordinary answer most of the time: nothing this worker can run
+    /// is queued, and that is not an error.
+    public func claim(serverAddress: String, credential: String) async throws -> Assignment? {
+        var request = try authorised(serverAddress, "/api/workers/claim", credential: credential, method: "POST")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data("{}".utf8)
+
+        let (data, response) = try await perform(request)
+        switch response.statusCode {
+        case 200:
+            guard
+                let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let assignment = Assignment(json: body)
+            else {
+                throw SidecarError.unexpectedResponse(status: 200)
+            }
+            return assignment
+        case 204:
+            return nil
+        case 401:
+            throw SidecarError.credentialRejected
+        case 403:
+            throw SidecarError.remoteWorkersDisabled(reason: Self.message(data) ?? "Remote workers are turned off.")
+        case let status:
+            throw SidecarError.unexpectedResponse(status: status)
+        }
+    }
+
+    /// Extends the claim. Throws `leaseLost` when the server no longer recognises it as ours,
+    /// which is the signal to stop the work being done under it.
+    public func renew(serverAddress: String, credential: String, leaseId: String) async throws {
+        let request = try authorised(
+            serverAddress, "/api/workers/leases/\(leaseId)/renew", credential: credential, method: "POST")
+        let (data, response) = try await perform(request)
+        try Self.checkLease(response.statusCode, data)
+    }
+
+    /// Hands the job back so the server can reassign it. Tolerant of a lease already gone.
+    public func release(serverAddress: String, credential: String, leaseId: String) async throws {
+        let request = try authorised(
+            serverAddress, "/api/workers/leases/\(leaseId)/release", credential: credential, method: "POST")
+        let (data, response) = try await perform(request)
+        try Self.checkLease(response.statusCode, data)
+    }
+
+    /// Fetches the source for a lease to a file and returns the hash the server declared for it,
+    /// so the caller can prove the transfer arrived intact before encoding a byte of it.
+    public func fetchSource(
+        serverAddress: String, credential: String, leaseId: String, to destination: URL
+    ) async throws -> String {
+        let request = try authorised(
+            serverAddress, "/api/workers/leases/\(leaseId)/source", credential: credential, method: "GET")
+        let response: HTTPURLResponse
+        do {
+            response = try await transport.download(request, to: destination)
+        } catch let error as SidecarError {
+            throw error
+        } catch {
+            throw SidecarError.transferFailed(reason: "The source transfer failed: \(error.localizedDescription)")
+        }
+
+        switch response.statusCode {
+        case 200:
+            guard let hash = response.value(forHTTPHeaderField: "X-Optimisarr-Source-Sha256"), !hash.isEmpty else {
+                throw SidecarError.unexpectedResponse(status: 200)
+            }
+            return hash
+        case 401:
+            throw SidecarError.credentialRejected
+        case 403, 404, 409:
+            throw SidecarError.leaseLost(reason: "The source is no longer available for this lease.")
+        case let status:
+            throw SidecarError.unexpectedResponse(status: status)
+        }
+    }
+
+    /// Delivers the candidate, declaring both hashes so the server can bind the file to the
+    /// exact source it was encoded from and refuse anything it cannot.
+    public func deliver(
+        serverAddress: String, credential: String, leaseId: String,
+        file: URL, sourceSha256: String, candidateSha256: String
+    ) async throws -> DeliveryReceipt {
+        var request = try authorised(
+            serverAddress, "/api/workers/leases/\(leaseId)/result", credential: credential, method: "POST")
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.setValue(sourceSha256, forHTTPHeaderField: "X-Optimisarr-Source-Sha256")
+        request.setValue(candidateSha256, forHTTPHeaderField: "X-Optimisarr-Candidate-Sha256")
+
+        let data: Data
+        let response: HTTPURLResponse
+        do {
+            (data, response) = try await transport.upload(request, fromFile: file)
+        } catch let error as SidecarError {
+            throw error
+        } catch {
+            throw SidecarError.transferFailed(reason: "The candidate upload failed: \(error.localizedDescription)")
+        }
+
+        switch response.statusCode {
+        case 202:
+            guard
+                let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let jobId = (body["jobId"] as? NSNumber)?.intValue,
+                let bytes = (body["bytes"] as? NSNumber)?.int64Value,
+                let hash = body["candidateSha256"] as? String
+            else {
+                throw SidecarError.unexpectedResponse(status: 202)
+            }
+            return DeliveryReceipt(jobId: jobId, bytes: bytes, candidateSha256: hash)
+        case 401:
+            throw SidecarError.credentialRejected
+        case 403, 404:
+            throw SidecarError.leaseLost(reason: Self.message(data) ?? "That lease is no longer this worker's.")
+        case 400, 409:
+            throw SidecarError.deliveryRefused(reason: Self.message(data) ?? "The server declined the candidate.")
+        case let status:
+            throw SidecarError.unexpectedResponse(status: status)
+        }
+    }
+
+    private static func checkLease(_ status: Int, _ data: Data) throws {
+        switch status {
+        case 200, 204:
+            return
+        case 401:
+            throw SidecarError.credentialRejected
+        case 403, 404, 409:
+            throw SidecarError.leaseLost(reason: message(data) ?? "That lease is no longer this worker's.")
+        case let status:
+            throw SidecarError.unexpectedResponse(status: status)
+        }
+    }
+
+    private func authorised(
+        _ serverAddress: String, _ path: String, credential: String, method: String
+    ) throws -> URLRequest {
+        var request = URLRequest(url: try Self.endpoint(serverAddress, path))
+        request.httpMethod = method
+        request.setValue("Bearer \(credential)", forHTTPHeaderField: "Authorization")
+        return request
     }
 
     private func perform(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {

--- a/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
@@ -11,6 +11,9 @@ public enum SidecarStatus: Equatable, Sendable {
     /// Paired and checking in successfully.
     case connected(workerId: Int, lastCheckIn: Date)
 
+    /// Paired and running a job the server handed over.
+    case working(jobId: Int, progress: JobProgress)
+
     /// Paired, but the last check-in did not get through. The credential is still believed good,
     /// so this recovers on its own — distinct from `revoked`, which never will.
     case unreachable(reason: String)
@@ -37,20 +40,26 @@ public final class SidecarSession: ObservableObject {
     @Published public private(set) var status: SidecarStatus = .unpaired
     @Published public private(set) var serverAddress: String = ""
 
+    /// How the last job ended, kept so the menu can say what this machine last did for the server.
+    @Published public private(set) var lastOutcome: JobOutcome?
+
     private let client: SidecarClient
     private let store: CredentialStore
     private let prober: CapabilityProber?
+    private let executor: WorkExecutor?
     private var capabilities: SidecarCapabilities
     private let sleep: @Sendable (TimeInterval) async throws -> Void
 
     private var pairing: StoredPairing?
     private var heartbeatTask: Task<Void, Never>?
+    private var jobTask: Task<Void, Never>?
 
     public init(
         client: SidecarClient = SidecarClient(),
         store: CredentialStore = KeychainCredentialStore(),
         capabilities: SidecarCapabilities = .provenToday(name: Host.current().localizedName ?? "Mac"),
         prober: CapabilityProber? = CapabilityProber(),
+        executor: WorkExecutor? = JobRunner(),
         sleep: @escaping @Sendable (TimeInterval) async throws -> Void = { seconds in
             try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
         }
@@ -59,6 +68,7 @@ public final class SidecarSession: ObservableObject {
         self.store = store
         self.capabilities = capabilities
         self.prober = prober
+        self.executor = executor
         self.sleep = sleep
     }
 
@@ -109,6 +119,10 @@ public final class SidecarSession: ObservableObject {
     public func unpair() {
         heartbeatTask?.cancel()
         heartbeatTask = nil
+        // A job in flight is stopped too: cancelling the task terminates ffmpeg and the runner
+        // hands the lease back, so the server can reassign rather than wait for it to lapse.
+        jobTask?.cancel()
+        jobTask = nil
         try? store.clear()
         pairing = nil
         status = .unpaired
@@ -137,7 +151,10 @@ public final class SidecarSession: ObservableObject {
                     maxConcurrency: capabilities.maxConcurrency)
 
                 interval = beat.heartbeatInterval
-                status = .connected(workerId: beat.workerId, lastCheckIn: Date())
+                if jobTask == nil {
+                    status = .connected(workerId: beat.workerId, lastCheckIn: Date())
+                    await claimIfIdle(pairing: pairing, workerId: beat.workerId)
+                }
             } catch SidecarError.credentialRejected {
                 // Terminal. Retrying cannot help, and holding a dead secret on disk serves no
                 // purpose, so drop it and tell the operator plainly.
@@ -159,6 +176,48 @@ public final class SidecarSession: ObservableObject {
         }
     }
 
+    /// Asks for work once per healthy check-in while idle. One job at a time: the capabilities
+    /// advertised one slot, and the server's matcher holds it to that.
+    private func claimIfIdle(pairing: StoredPairing, workerId: Int) async {
+        guard let executor, capabilities.maxConcurrency > 0 else { return }
+
+        let assignment: Assignment?
+        do {
+            assignment = try await client.claim(
+                serverAddress: pairing.serverAddress, credential: pairing.credential)
+        } catch {
+            // A failed claim is not a failed check-in. The next beat asks again; a credential
+            // problem surfaces through the heartbeat, which is the path that handles it.
+            return
+        }
+        guard let assignment else { return }
+
+        status = .working(jobId: assignment.jobId, progress: .fetchingSource)
+        let jobId = assignment.jobId
+        // The task holds the session for the job's duration, which is intended: a job is stopped
+        // by cancelling this task (see unpair), never by the session quietly going away under it.
+        jobTask = Task { [weak self] in
+            guard let self else { return }
+            let outcome = await executor.execute(assignment, pairing: pairing) { progress in
+                Task { @MainActor in self.report(jobId: jobId, progress: progress) }
+            }
+            self.finish(outcome, workerId: workerId)
+        }
+    }
+
+    private func report(jobId: Int, progress: JobProgress) {
+        guard jobTask != nil else { return }
+        status = .working(jobId: jobId, progress: progress)
+    }
+
+    private func finish(_ outcome: JobOutcome, workerId: Int) {
+        lastOutcome = outcome
+        jobTask = nil
+        if pairing != nil {
+            status = .connected(workerId: workerId, lastCheckIn: Date())
+        }
+    }
+
     static func describe(_ error: SidecarError) -> SidecarStatus {
         switch error {
         case .invalidServerAddress:
@@ -175,6 +234,10 @@ public final class SidecarSession: ObservableObject {
             return .pairingFailed(reason: "The server replied unexpectedly (HTTP \(status)).")
         case let .unreachable(description):
             return .pairingFailed(reason: description)
+        case let .leaseLost(reason), let .transferFailed(reason), let .deliveryRefused(reason):
+            // Job-time errors never reach pairing or check-in, but the mapping stays total so a
+            // new case cannot be forgotten silently.
+            return .unreachable(reason: reason)
         }
     }
 }
@@ -196,6 +259,7 @@ extension SidecarStatus {
         case .unpaired: return "Not paired"
         case .pairing: return "Pairing…"
         case .connected: return "Connected"
+        case let .working(jobId, _): return "Encoding job #\(jobId)"
         case .unreachable: return "Server unreachable"
         case .revoked: return "Access revoked"
         case .disabledOnServer: return "Turned off on the server"

--- a/sidecars/macos/Sources/SidecarCore/WorkerProtocol.swift
+++ b/sidecars/macos/Sources/SidecarCore/WorkerProtocol.swift
@@ -76,3 +76,94 @@ public struct SidecarCapabilities: Sendable, Equatable {
         SidecarCapabilities(name: name)
     }
 }
+
+/// What the server will hold this worker's quality evidence to. Carried so a measurement can be
+/// taken under the same model and thresholds the server judges by; a score under any other
+/// policy is evidence about something else.
+public struct QualityRequirement: Sendable, Equatable {
+    public let measure: Bool
+    public let model: String
+    public let frameSubsample: Int
+    public let clipVmaf: Bool
+    public let minimumHarmonicMean: Double
+    public let minimumMinimum: Double
+
+    public init(
+        measure: Bool, model: String, frameSubsample: Int, clipVmaf: Bool,
+        minimumHarmonicMean: Double, minimumMinimum: Double
+    ) {
+        self.measure = measure
+        self.model = model
+        self.frameSubsample = frameSubsample
+        self.clipVmaf = clipVmaf
+        self.minimumHarmonicMean = minimumHarmonicMean
+        self.minimumMinimum = minimumMinimum
+    }
+
+    init?(json: [String: Any]) {
+        guard
+            let measure = json["measure"] as? Bool,
+            let model = json["model"] as? String,
+            let frameSubsample = (json["frameSubsample"] as? NSNumber)?.intValue,
+            let clipVmaf = json["clipVmaf"] as? Bool,
+            let harmonic = (json["minimumHarmonicMean"] as? NSNumber)?.doubleValue,
+            let minimum = (json["minimumMinimum"] as? NSNumber)?.doubleValue
+        else { return nil }
+        self.init(
+            measure: measure, model: model, frameSubsample: frameSubsample, clipVmaf: clipVmaf,
+            minimumHarmonicMean: harmonic, minimumMinimum: minimum)
+    }
+}
+
+/// One job the server has handed this worker, mirroring the server's `AssignmentDto`.
+///
+/// The argument array is the exact FFmpeg command the server would have run itself, with two
+/// tokens standing in for paths. Nothing here is a path on any machine: the source is fetched by
+/// lease, and this worker decides where its own scratch lives. That division is what lets the
+/// command be validated rather than trusted — see `AssignmentCommand`.
+public struct Assignment: Sendable, Equatable {
+    public static let inputPlaceholder = "{{input}}"
+    public static let outputPlaceholder = "{{output}}"
+
+    public let leaseId: String
+    public let jobId: Int
+    public let sourceBytes: Int64
+    public let videoEncoder: String
+    public let renewWithinSeconds: Int
+    public let arguments: [String]
+    public let outputExtension: String
+    public let quality: QualityRequirement
+
+    public init(
+        leaseId: String, jobId: Int, sourceBytes: Int64, videoEncoder: String,
+        renewWithinSeconds: Int, arguments: [String], outputExtension: String,
+        quality: QualityRequirement
+    ) {
+        self.leaseId = leaseId
+        self.jobId = jobId
+        self.sourceBytes = sourceBytes
+        self.videoEncoder = videoEncoder
+        self.renewWithinSeconds = renewWithinSeconds
+        self.arguments = arguments
+        self.outputExtension = outputExtension
+        self.quality = quality
+    }
+
+    init?(json: [String: Any]) {
+        guard
+            let leaseId = json["leaseId"] as? String,
+            let jobId = (json["jobId"] as? NSNumber)?.intValue,
+            let sourceBytes = (json["sourceBytes"] as? NSNumber)?.int64Value,
+            let encoder = json["videoEncoder"] as? String,
+            let renew = (json["renewWithinSeconds"] as? NSNumber)?.intValue,
+            let arguments = json["arguments"] as? [String],
+            let outputExtension = json["outputExtension"] as? String,
+            let qualityJson = json["quality"] as? [String: Any],
+            let quality = QualityRequirement(json: qualityJson)
+        else { return nil }
+        self.init(
+            leaseId: leaseId, jobId: jobId, sourceBytes: sourceBytes, videoEncoder: encoder,
+            renewWithinSeconds: renew, arguments: arguments, outputExtension: outputExtension,
+            quality: quality)
+    }
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/SidecarClientTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/SidecarClientTests.swift
@@ -22,6 +22,16 @@ final class StubTransport: HTTPTransport, @unchecked Sendable {
         return (body, response)
     }
 
+    func download(_ request: URLRequest, to destination: URL) async throws -> HTTPURLResponse {
+        lastRequest = request
+        try body.write(to: destination)
+        return HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    }
+
+    func upload(_ request: URLRequest, fromFile file: URL) async throws -> (Data, HTTPURLResponse) {
+        try await send(request)
+    }
+
     var sentJSON: [String: Any] {
         guard
             let body = lastRequest?.httpBody,

--- a/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
@@ -28,6 +28,16 @@ final class ScriptedTransport: HTTPTransport, @unchecked Sendable {
             url: request.url!, statusCode: reply.status, httpVersion: nil, headerFields: nil)!
         return (data, response)
     }
+
+    func download(_ request: URLRequest, to destination: URL) async throws -> HTTPURLResponse {
+        let (data, response) = try await send(request)
+        try data.write(to: destination)
+        return response
+    }
+
+    func upload(_ request: URLRequest, fromFile file: URL) async throws -> (Data, HTTPURLResponse) {
+        try await send(request)
+    }
 }
 
 @MainActor

--- a/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
@@ -1,0 +1,473 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import SidecarCore
+
+// MARK: - The command contract
+
+/// The shape the server's builder produces for a worker: software decode, placeholders for both
+/// paths, the container extension on the output token.
+private let serverCommand: [String] = [
+    "-y", "-progress", "pipe:1", "-nostats",
+    "-fflags", "+genpts",
+    "-i", Assignment.inputPlaceholder,
+    "-map", "0", "-map", "-0:d",
+    "-map_metadata", "0",
+    "-metadata", "comment=optimisarr:0.2.11",
+    "-c", "copy",
+    "-filter:v:0", "crop=1920:800:0:140,scale=1280:534:flags=lanczos,fps=fps=29.97",
+    "-c:v:0", "hevc_videotoolbox",
+    "-q:v", "60",
+    "-c:a", "copy",
+    "-c:s", "mov_text",
+    "\(Assignment.outputPlaceholder).mp4",
+]
+
+@Suite("Assignment command contract")
+struct AssignmentCommandTests {
+    @Test("a command shaped like the server's is accepted and both tokens are substituted")
+    func acceptsServerShape() throws {
+        let command = try AssignmentCommand.validate(serverCommand, outputExtension: "mp4")
+
+        let materialised = command.materialise(
+            input: URL(fileURLWithPath: "/scratch/lease/source"),
+            output: URL(fileURLWithPath: "/scratch/lease/candidate.mp4"))
+
+        #expect(materialised[materialised.firstIndex(of: "-i")! + 1] == "/scratch/lease/source")
+        #expect(materialised.last == "/scratch/lease/candidate.mp4")
+        #expect(!materialised.contains { $0.contains("{{") })
+    }
+
+    @Test("an option the server's builder never emits is refused by name")
+    func refusesUnknownOption() {
+        var tampered = serverCommand
+        tampered.insert(contentsOf: ["-passlogfile", "log"], at: 4)
+
+        #expect(throws: AssignmentCommandError.unknownOption("-passlogfile")) {
+            try AssignmentCommand.validate(tampered, outputExtension: "mp4")
+        }
+    }
+
+    @Test("the input must be the placeholder, never a path on this machine")
+    func refusesRealInput() {
+        var tampered = serverCommand
+        tampered[tampered.firstIndex(of: "-i")! + 1] = "/Users/someone/Documents/private.mov"
+
+        #expect(throws: AssignmentCommandError.inputMustBePlaceholder("/Users/someone/Documents/private.mov")) {
+            try AssignmentCommand.validate(tampered, outputExtension: "mp4")
+        }
+    }
+
+    @Test("a value that looks like a path is refused even under an allowed option")
+    func refusesPathLikeValue() {
+        var tampered = serverCommand
+        tampered[tampered.firstIndex(of: "-progress")! + 1] = "/tmp/anywhere"
+
+        #expect(throws: AssignmentCommandError.pathLikeValue("/tmp/anywhere")) {
+            try AssignmentCommand.validate(tampered, outputExtension: "mp4")
+        }
+    }
+
+    @Test("the output token must be last and carry the promised extension")
+    func refusesOutputDrift() {
+        #expect(throws: AssignmentCommandError.outputMustBeLast(expected: "{{output}}.mkv")) {
+            try AssignmentCommand.validate(serverCommand, outputExtension: "mkv")
+        }
+
+        var reordered = serverCommand
+        reordered.append("-y")
+        #expect(throws: AssignmentCommandError.outputMustBeLast(expected: "{{output}}.mp4")) {
+            try AssignmentCommand.validate(reordered, outputExtension: "mp4")
+        }
+    }
+
+    @Test("a second input is refused however it is spelt")
+    func refusesSecondInput() {
+        var tampered = serverCommand
+        tampered.insert(contentsOf: ["-i", Assignment.inputPlaceholder], at: 4)
+
+        #expect(throws: AssignmentCommandError.exactlyOneInputRequired(2)) {
+            try AssignmentCommand.validate(tampered, outputExtension: "mp4")
+        }
+    }
+
+    @Test("progress lines yield encoded seconds and nothing else does")
+    func progressLines() {
+        #expect(FfmpegProgressLine.encodedSeconds("out_time_us=1500000") == 1.5)
+        #expect(FfmpegProgressLine.encodedSeconds("out_time_ms=1500000") == 1.5)
+        #expect(FfmpegProgressLine.encodedSeconds("frame=42") == nil)
+        #expect(FfmpegProgressLine.encodedSeconds("out_time_us=-1") == nil)
+    }
+}
+
+// MARK: - A stand-in server
+
+/// Answers the worker routes the way Optimisarr does, and records what it was sent, so the whole
+/// claim-fetch-encode-deliver flow can be walked without a server or an ffmpeg.
+final class FakeWorkerServer: HTTPTransport, @unchecked Sendable {
+    let sourceBytes: Data
+    var renewStatus = 200
+    var deliverStatus = 202
+    var claimJSON: [String: Any]?
+
+    private let lock = NSLock()
+    private(set) var deliveredFile: Data?
+    private(set) var deliveredHeaders: [String: String] = [:]
+    private(set) var released = false
+    private(set) var renewals = 0
+
+    init(sourceBytes: Data, claimJSON: [String: Any]? = nil) {
+        self.sourceBytes = sourceBytes
+        self.claimJSON = claimJSON
+    }
+
+    var sourceSha256: String {
+        SHA256.hash(data: sourceBytes).map { String(format: "%02x", $0) }.joined()
+    }
+
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let path = request.url!.path
+        return try lock.withLock {
+            if path.hasSuffix("/claim") {
+                guard let claimJSON else { return (Data(), response(request, 204)) }
+                return (try JSONSerialization.data(withJSONObject: claimJSON), response(request, 200))
+            }
+            if path.hasSuffix("/renew") {
+                renewals += 1
+                let body = renewStatus == 200 ? Data() : Data(#"{"error":"That lease has expired."}"#.utf8)
+                return (body, response(request, renewStatus))
+            }
+            if path.hasSuffix("/release") {
+                released = true
+                return (Data(), response(request, 204))
+            }
+            return (Data(), response(request, 404))
+        }
+    }
+
+    func download(_ request: URLRequest, to destination: URL) async throws -> HTTPURLResponse {
+        try sourceBytes.write(to: destination)
+        return response(request, 200, headers: ["X-Optimisarr-Source-Sha256": sourceSha256])
+    }
+
+    func upload(_ request: URLRequest, fromFile file: URL) async throws -> (Data, HTTPURLResponse) {
+        let delivered = try Data(contentsOf: file)
+        return lock.withLock {
+            deliveredFile = delivered
+            deliveredHeaders = request.allHTTPHeaderFields ?? [:]
+            let body = deliverStatus == 202
+                ? Data(#"{"jobId":12,"bytes":\#(delivered.count),"candidateSha256":"x"}"#.utf8)
+                : Data(#"{"error":"The uploaded candidate does not match the hash the worker declared."}"#.utf8)
+            return (body, response(request, deliverStatus))
+        }
+    }
+
+    private func response(_ request: URLRequest, _ status: Int, headers: [String: String] = [:]) -> HTTPURLResponse {
+        HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: headers)!
+    }
+}
+
+/// Stands in for ffmpeg: writes the candidate the command names, or fails, without encoding.
+struct FakeTranscodeRunner: TranscodeRunner, @unchecked Sendable {
+    var exitCode: Int32 = 0
+    var candidate = Data("candidate bytes".utf8)
+    var delay: TimeInterval = 0
+
+    func run(
+        _ executable: URL, _ arguments: [String], progress: @escaping @Sendable (Double) -> Void
+    ) async throws -> (exitCode: Int32, stderr: String) {
+        if delay > 0 { try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000)) }
+        progress(12.5)
+        if exitCode == 0 {
+            try candidate.write(to: URL(fileURLWithPath: arguments.last!))
+        }
+        return (exitCode, exitCode == 0 ? "" : "Error while opening encoder")
+    }
+}
+
+private func assignment(renewWithinSeconds: Int = 30) -> Assignment {
+    Assignment(
+        leaseId: "8b1e2c3d-0000-4000-8000-000000000001", jobId: 12, sourceBytes: 4_096,
+        videoEncoder: "hevc_videotoolbox", renewWithinSeconds: renewWithinSeconds,
+        arguments: serverCommand, outputExtension: "mp4",
+        quality: QualityRequirement(
+            measure: true, model: "vmaf_v0.6.1", frameSubsample: 1, clipVmaf: false,
+            minimumHarmonicMean: 93, minimumMinimum: 80))
+}
+
+private let pairing = StoredPairing(serverAddress: "localhost:8787", credential: "secret", workerId: 3)
+
+private func scratch() -> URL {
+    FileManager.default.temporaryDirectory.appendingPathComponent("optimisarr-worktest-\(UUID().uuidString)")
+}
+
+@Suite("Job runner")
+struct JobRunnerTests {
+    @Test("a healthy job fetches, encodes, hashes and delivers, then leaves no scratch behind")
+    func deliversAndCleansUp() async throws {
+        let server = FakeWorkerServer(sourceBytes: Data(repeating: 7, count: 4_096))
+        let root = scratch()
+        let runner = JobRunner(
+            client: SidecarClient(transport: server),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: FakeTranscodeRunner(),
+            scratchRoot: root,
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        let outcome = await runner.execute(assignment(), pairing: pairing) { _ in }
+
+        #expect(outcome == .delivered(jobId: 12, bytes: 15))
+        #expect(server.deliveredFile == Data("candidate bytes".utf8))
+        // Both hashes travel with the candidate, so the server can bind it to this exact source.
+        #expect(server.deliveredHeaders["X-Optimisarr-Source-Sha256"] == server.sourceSha256)
+        let expectedCandidateHash = SHA256.hash(data: Data("candidate bytes".utf8))
+            .map { String(format: "%02x", $0) }.joined()
+        #expect(server.deliveredHeaders["X-Optimisarr-Candidate-Sha256"] == expectedCandidateHash)
+        #expect(server.released == false)
+        #expect(!FileManager.default.fileExists(atPath: root.appendingPathComponent("lease-\(assignment().leaseId)").path))
+    }
+
+    @Test("a source that arrives corrupt is never encoded and the job is handed back")
+    func corruptSourceIsReleased() async throws {
+        let server = FakeWorkerServer(sourceBytes: Data(repeating: 7, count: 4_096))
+        let lying = LyingHashServer(inner: server)
+        let runner = JobRunner(
+            client: SidecarClient(transport: lying),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: FakeTranscodeRunner(),
+            scratchRoot: scratch(),
+            sleep: { _ in })
+
+        let outcome = await runner.execute(assignment(), pairing: pairing) { _ in }
+
+        guard case let .released(jobId, reason) = outcome else {
+            Issue.record("expected a release, got \(outcome)")
+            return
+        }
+        #expect(jobId == 12)
+        #expect(reason.contains("hash mismatch"))
+        #expect(server.released)
+        #expect(server.deliveredFile == nil)
+    }
+
+    @Test("a failed encode hands the job back with ffmpeg's reason")
+    func failedEncodeIsReleased() async throws {
+        let server = FakeWorkerServer(sourceBytes: Data(repeating: 1, count: 64))
+        let runner = JobRunner(
+            client: SidecarClient(transport: server),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: FakeTranscodeRunner(exitCode: 1),
+            scratchRoot: scratch(),
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        let outcome = await runner.execute(assignment(), pairing: pairing) { _ in }
+
+        guard case let .released(_, reason) = outcome else {
+            Issue.record("expected a release, got \(outcome)")
+            return
+        }
+        #expect(reason.contains("Error while opening encoder"))
+        #expect(server.released)
+        #expect(server.deliveredFile == nil)
+    }
+
+    @Test("a command the contract refuses is handed back before any byte is fetched")
+    func refusedCommandIsReleased() async throws {
+        let server = FakeWorkerServer(sourceBytes: Data(repeating: 1, count: 64))
+        var tampered = assignment()
+        tampered = Assignment(
+            leaseId: tampered.leaseId, jobId: tampered.jobId, sourceBytes: tampered.sourceBytes,
+            videoEncoder: tampered.videoEncoder, renewWithinSeconds: tampered.renewWithinSeconds,
+            arguments: ["-i", "/etc/passwd", "{{output}}.mp4"], outputExtension: "mp4",
+            quality: tampered.quality)
+        let runner = JobRunner(
+            client: SidecarClient(transport: server),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: FakeTranscodeRunner(),
+            scratchRoot: scratch(),
+            sleep: { _ in })
+
+        let outcome = await runner.execute(tampered, pairing: pairing) { _ in }
+
+        guard case let .released(_, reason) = outcome else {
+            Issue.record("expected a release, got \(outcome)")
+            return
+        }
+        #expect(reason.contains("refused"))
+        #expect(server.released)
+    }
+
+    @Test("losing the lease mid-encode stops the work rather than finishing it for nobody")
+    func lostLeaseCancelsEncode() async throws {
+        let server = FakeWorkerServer(sourceBytes: Data(repeating: 1, count: 64))
+        server.renewStatus = 409
+        let runner = JobRunner(
+            client: SidecarClient(transport: server),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            // Long enough that the renewal, which fires almost at once, wins the race.
+            runner: FakeTranscodeRunner(delay: 5),
+            scratchRoot: scratch(),
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        let started = Date()
+        let outcome = await runner.execute(assignment(renewWithinSeconds: 10), pairing: pairing) { _ in }
+
+        guard case .leaseLost = outcome else {
+            Issue.record("expected the lease to be lost, got \(outcome)")
+            return
+        }
+        #expect(Date().timeIntervalSince(started) < 4)
+        #expect(server.deliveredFile == nil)
+    }
+}
+
+/// Wraps a server so the declared source hash is wrong, standing in for a transfer that was
+/// truncated or corrupted on the way.
+final class LyingHashServer: HTTPTransport, @unchecked Sendable {
+    let inner: FakeWorkerServer
+    init(inner: FakeWorkerServer) { self.inner = inner }
+
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) { try await inner.send(request) }
+
+    func download(_ request: URLRequest, to destination: URL) async throws -> HTTPURLResponse {
+        _ = try await inner.download(request, to: destination)
+        return HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: nil,
+            headerFields: ["X-Optimisarr-Source-Sha256": String(repeating: "0", count: 64)])!
+    }
+
+    func upload(_ request: URLRequest, fromFile file: URL) async throws -> (Data, HTTPURLResponse) {
+        try await inner.upload(request, fromFile: file)
+    }
+}
+
+// MARK: - The session's loop
+
+/// Records the assignment it was handed and answers with a fixed outcome.
+final class RecordingExecutor: WorkExecutor, @unchecked Sendable {
+    private(set) var executed: [Assignment] = []
+    let outcome: JobOutcome
+    init(outcome: JobOutcome) { self.outcome = outcome }
+
+    func execute(
+        _ assignment: Assignment, pairing: StoredPairing,
+        progress: @escaping @Sendable (JobProgress) -> Void
+    ) async -> JobOutcome {
+        executed.append(assignment)
+        progress(.encoding(encodedSeconds: 3))
+        return outcome
+    }
+}
+
+/// Answers heartbeats forever and hands out one assignment on the first claim, so a session can be
+/// walked through pick-up, execution and return to idle without a scripted reply running out.
+final class RoutedTransport: HTTPTransport, @unchecked Sendable {
+    private let lock = NSLock()
+    private var assignment: [String: Any]?
+    private(set) var claims = 0
+    private(set) var heartbeats = 0
+
+    init(assignment: [String: Any]?) {
+        self.assignment = assignment
+    }
+
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let path = request.url!.path
+        return try lock.withLock {
+            if path.hasSuffix("/heartbeat") {
+                heartbeats += 1
+                let body = try JSONSerialization.data(withJSONObject: [
+                    "workerId": 4, "protocolVersion": 1, "heartbeatIntervalSeconds": 30,
+                ])
+                return (body, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+            }
+            if path.hasSuffix("/claim") {
+                claims += 1
+                guard let assignment else {
+                    return (Data(), HTTPURLResponse(url: request.url!, statusCode: 204, httpVersion: nil, headerFields: nil)!)
+                }
+                self.assignment = nil
+                return (try JSONSerialization.data(withJSONObject: assignment),
+                        HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+            }
+            return (Data(), HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+        }
+    }
+
+    func download(_ request: URLRequest, to destination: URL) async throws -> HTTPURLResponse {
+        HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!
+    }
+
+    func upload(_ request: URLRequest, fromFile file: URL) async throws -> (Data, HTTPURLResponse) {
+        try await send(request)
+    }
+}
+
+@MainActor
+@Suite("Session work loop")
+struct SessionWorkLoopTests {
+    private func assignmentJSON() -> [String: Any] {
+        [
+            "leaseId": "8b1e2c3d-0000-4000-8000-000000000001", "jobId": 12, "sourceBytes": 4_096,
+            "videoEncoder": "hevc_videotoolbox", "vmaf": "Cpu",
+            "expiresUtc": "2026-09-04T10:00:00+00:00", "renewWithinSeconds": 30,
+            "arguments": serverCommand, "outputExtension": "mp4",
+            "quality": [
+                "measure": true, "model": "vmaf_v0.6.1", "frameSubsample": 1, "clipVmaf": false,
+                "minimumHarmonicMean": 93.0, "minimumMinimum": 80.0,
+            ],
+        ]
+    }
+
+    @Test("a claim that returns work runs it and the session reports the outcome")
+    func claimsAndRuns() async throws {
+        let executor = RecordingExecutor(outcome: .delivered(jobId: 12, bytes: 15))
+        let store = InMemoryCredentialStore()
+        try store.save(StoredPairing(serverAddress: "localhost:8787", credential: "c", workerId: 4))
+        let transport = RoutedTransport(assignment: assignmentJSON())
+        let session = SidecarSession(
+            client: SidecarClient(transport: transport),
+            store: store,
+            capabilities: SidecarCapabilities(name: "Test", videoEncoders: ["hevc_videotoolbox"], vmaf: .cpu, maxConcurrency: 1),
+            prober: nil,
+            executor: executor,
+            sleep: { _ in try await Task.sleep(nanoseconds: 5_000_000) })
+
+        session.restore()
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(executor.executed.map(\.jobId) == [12])
+        #expect(executor.executed.first?.arguments == serverCommand)
+        #expect(session.lastOutcome == .delivered(jobId: 12, bytes: 15))
+        if case .connected = session.status {} else {
+            Issue.record("expected the session back to connected, got \(session.status)")
+        }
+        // Idle again, so the loop keeps asking; the server simply has nothing more.
+        #expect(transport.claims >= 2)
+        session.unpair()
+    }
+
+    @Test("a worker advertising no slot never claims")
+    func drainedWorkerNeverClaims() async throws {
+        let executor = RecordingExecutor(outcome: .delivered(jobId: 12, bytes: 15))
+        let store = InMemoryCredentialStore()
+        try store.save(StoredPairing(serverAddress: "localhost:8787", credential: "c", workerId: 4))
+        let transport = RoutedTransport(assignment: assignmentJSON())
+        let session = SidecarSession(
+            client: SidecarClient(transport: transport),
+            store: store,
+            capabilities: .provenToday(name: "Test"),
+            prober: nil,
+            executor: executor,
+            sleep: { _ in try await Task.sleep(nanoseconds: 5_000_000) })
+
+        session.restore()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(executor.executed.isEmpty)
+        // Only heartbeats went out: a drained worker asking for work would be a wasted request.
+        #expect(transport.heartbeats > 0)
+        #expect(transport.claims == 0)
+        session.unpair()
+    }
+}


### PR DESCRIPTION
Piece 3 of the four-piece sidecar plan in `docs/roadmap.md`, following #108 and #109. Swift only; no server change.

## Outcome

The Mac sidecar now does work. On each healthy check-in while idle, `SidecarSession` claims one job and `JobRunner` takes it from claim to delivery:

1. **Validate before fetching.** `AssignmentCommand` holds the server's array to an explicit contract: an allowlist of the options `FfmpegCommandBuilder` and `EncoderTuningPolicy` emit, `{{input}}` as the only input, `{{output}}.<ext>` last and matching the promised extension, and no other value containing a path separator or `~`. Anything else is refused whole and the job handed back naming the token.
2. **Fetch by lease and prove the bytes.** The source streams to the app's own scratch and is hashed; a mismatch against the server's declared hash means it is never encoded.
3. **Encode while renewing.** The bundled ffmpeg runs the materialised command; a sibling task renews the lease at half the stated window, and a lost lease cancels the encode (task group, first to finish wins, the other is cancelled). Progress is read from `-progress pipe:1`.
4. **Deliver with both hashes.** The candidate is hashed and uploaded with source and candidate hashes, which #109's server side then verifies exactly like a local encode.

Also: `.working` status with stage in the menu, last-outcome line, `unpair` cancels a running job, scratch removed on every exit path, transfers stream to and from files.

## Excluded

- Range-resumed downloads (a dropped transfer restarts).
- VMAF measurement on the worker and evidence upload; the server re-measures until then.
- Hardware decode on the worker, launch-at-login, sleep/wake, drain controls (piece 4), signing and notarisation.
- Real-hardware acceptance evidence. The live test suite exists but a full loop against a real server with a real encode has not yet been run; I will do that against dev once this and the server pieces are deployed.

## Verification

- `swift build` clean under Swift 6 strict concurrency; `swift test`: 57 tests in 13 suites passed. New: the command contract (accepts the server shape; refuses an unknown option, a real input path, a path-like value, output drift, a second input), progress parsing, and the job runner walked end to end against a stand-in server: delivers with both hashes and cleans scratch; corrupt source released; failed encode released with ffmpeg's reason; refused command released before any fetch; lost lease cancels the encode within the window. Session tests: claims and runs, reports the outcome, returns to idle; a drained worker never claims.
- `scripts/check_docs.py` clean. Backend and frontend untouched.

## Safety

The worker never touches an original: it reads a copy fetched by lease and writes only under its own scratch. The new trust boundary is the command itself, and it is enforced on the worker as an allowlist rather than trusted from the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
