### PR TITLE
Fix what the first real sidecar delivery found: body cap, lease lookup, naming, decimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+### Fixed
+
+- **A delivered candidate larger than 30 MB was refused.** The result route inherited Kestrel's
+  default request body cap, meant for form posts, so the first real delivery from a Mac sidecar
+  failed with "request body too large" and the worker handed the job back. The route now lifts the
+  cap; it already streams the body to disk in bounded chunks, so no memory is at stake. Found by
+  the live work-loop test on real hardware.
+
+- **A delivered candidate was named after the source rather than its own container.** A worker
+  told to produce MP4 from an MKV source had its candidate stored as `.mkv`, and the replacement
+  takes the final extension from that name. The container the assignment promised is now recorded
+  on the lease when it is granted (migration `AddLeaseOutputExtension`) and the candidate is named
+  from it; a lease with no recorded container cannot be delivered against. The same live run also
+  found that looking up the delivering worker ordered leases by a date in SQLite, which SQLite
+  cannot do; the ordering now happens in memory and a test asks the real database. Both found on
+  the first real delivery.
+
+- **A frame-rate-capped encode could fail its own quality check.** The cap thinned frames with
+  FFmpeg's `fps` filter, which picks each output slot by nearest timestamp. On an exact 2:1 every
+  odd source frame sits precisely on the rounding boundary, so which neighbour is kept depends on
+  the stream's timebase and on whether timestamps were reset first — and the verification's
+  reference preparation resets them before thinning while the encode does not. The two kept
+  different frames for half the picture, and a 60 → 30 encode that scores VMAF 97 against the
+  right frames scored 48 against the wrong ones and was failed. Both sides now keep frames by
+  index, recovered from each frame's own time and the probed source rate, which has no boundary to
+  fall on; verified at 97 on the same encode. A variable-frame-rate source is no longer capped,
+  since it has no "every second frame" that means the same thing to both sides. Found on the first
+  real hardware run of the cap; no released build carried it.
+
 ### Added
 
 - **The macOS sidecar now does work.** On each healthy check-in while idle it claims a job, and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -659,9 +659,24 @@ the replacement workflow is trustworthy.
         input and output, and no path-like value; a refused command hands the job back naming the
         token. Losing the lease cancels the encode; forgetting the pairing cancels the job; scratch
         is removed on every exit path. **Left for later:** Range-resumed downloads (a dropped
-        transfer restarts today), VMAF measurement on the worker and the evidence upload that
-        `RemoteQualityEvidenceValidator` will judge (the server re-measures until then), and
-        real-hardware acceptance evidence for the whole loop.
+        transfer restarts today), and VMAF measurement on the worker with the evidence upload that
+        `RemoteQualityEvidenceValidator` will judge (the server re-measures until then).
+
+        **Real-hardware evidence (2026-09-04, Apple Silicon Mac, local server built from dev):**
+        `LiveWorkLoopTests` paired with proved capabilities, claimed a queued 1080p60 H.264 job,
+        received `hevc_videotoolbox` with the 30 fps cap applied, encoded with the bundled ffmpeg,
+        and delivered; the server verified the candidate through every gate including VMAF
+        (harmonic mean 97.74 against a floor of 93) and marked it ready to replace. The VMAF
+        retry also crossed the boundary: a first candidate failed the gate, was requeued at
+        higher quality, claimed again and delivered again. The run found four defects, all fixed
+        in the same change: Kestrel's 30 MB body cap refused the candidate; the delivering worker
+        was looked up by ordering a `DateTimeOffset` in SQLite; the candidate was named after the
+        source's extension rather than the contract's container (the replacement takes the final
+        extension from that name); and the frame-rate cap's `fps` filter and the verification's
+        reference preparation kept different frames on an exact 2:1, scoring 48 for a 97 encode —
+        both sides now thin by frame index. The worker-side allowlist also refused the new filter
+        for its escaped comma until taught to tell an escape from a Windows path, which is the
+        fail-closed behaviour it exists for.
 
      4. **Drain controls**, and then productionisation: launch-at-login, sleep/wake, App Nap,
         low-disk handling, cancel-on-quit. Developer ID signing and notarisation are unblocked — a
@@ -696,9 +711,12 @@ the replacement workflow is trustworthy.
      generic failure. A live test suite runs the real client against a running server, which is how
      this contract gets a second implementation holding it honest. It now claims work, fetches the
      source by lease, validates and runs the server's command with the bundled ffmpeg, renews the
-     lease throughout, and delivers the candidate with both hashes (see piece 3 above). **Still to
-     build:** VMAF on the worker, Range-resumed transfers, launch-at-login, sleep/wake and App Nap
-     handling, Developer ID signing and notarisation, and real-hardware acceptance evidence.
+     lease throughout, and delivers the candidate with both hashes (see piece 3 above), and has
+     done so end to end on real Apple Silicon hardware against a server built from `dev`, with the
+     candidate passing every server gate including VMAF. **Still to build:** VMAF on the worker,
+     Range-resumed transfers, launch-at-login, sleep/wake and App Nap handling, drain controls,
+     and Developer ID signing and notarisation. Neither platform is described as supported until
+     that list is done and the evidence is repeated on a release build.
    - **Operational UI and acceptance evidence.** The main app shows each worker's trustworthy name,
      platform, version, capabilities, health, load, active lease, transfer progress, and last error;
      worker removal immediately prevents new assignments. Automated contract and end-to-end tests

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -29,6 +29,16 @@ Scratch lives under `~/Library/Application Support/OptimisarrSidecar/work` and i
 exit path. One job at a time. Quality evidence (VMAF) is not yet measured here; the server measures
 it itself for now.
 
+This loop has run end to end on real hardware: `LiveWorkLoopTests` pairs with a running server,
+claims a queued job, encodes it with the bundled ffmpeg and delivers it, and the server's own
+verification — every gate, VMAF included — then judges the candidate. Run it against a server that
+has a job queued this Mac can take:
+
+```bash
+OPTIMISARR_LIVE_URL=localhost:8787 OPTIMISARR_LIVE_PIN="1234 5678" \
+OPTIMISARR_FFMPEG=$(pwd)/vendor/ffmpeg swift test --filter LiveWorkLoop
+```
+
 What it reports is real. It bundles its own ffmpeg, built from pinned source by
 [`scripts/build-ffmpeg.sh`](scripts/build-ffmpeg.sh), and probes this machine in two stages: parse
 `ffmpeg -encoders`, then confirm each VideoToolbox encoder with a real throwaway encode. Every Apple

--- a/sidecars/macos/Sources/SidecarCore/AssignmentCommand.swift
+++ b/sidecars/macos/Sources/SidecarCore/AssignmentCommand.swift
@@ -109,9 +109,28 @@ public struct AssignmentCommand: Sendable, Equatable {
         }
         // A filter chain, a metadata marker or a rate control value never needs a path
         // separator or a home shorthand; an argument that has one is trying to name a file.
-        if value.contains("/") || value.contains("\\") || value.hasPrefix("~") {
+        if value.contains("/") || value.hasPrefix("~") || Self.hasPathLikeBackslash(value) {
             throw AssignmentCommandError.pathLikeValue(value)
         }
+    }
+
+    /// A backslash is how a filtergraph escapes a comma, colon or quote inside one filter's
+    /// arguments — `select=not(mod(round(t*60)\,2))` — and how Windows separates path segments.
+    /// The first real capped encode was refused wholesale for the former, so the two are told
+    /// apart by what follows: an escape precedes one of the few characters filtergraphs escape,
+    /// a path segment precedes anything else.
+    static func hasPathLikeBackslash(_ value: String) -> Bool {
+        let escapable: Set<Character> = [",", ":", "'", "\\", "[", "]", ";"]
+        var previousWasBackslash = false
+        for character in value {
+            if previousWasBackslash {
+                if !escapable.contains(character) { return true }
+                previousWasBackslash = false
+                continue
+            }
+            previousWasBackslash = character == "\\"
+        }
+        return previousWasBackslash
     }
 
     private static func isPlainExtension(_ extension: String) -> Bool {

--- a/sidecars/macos/Tests/SidecarCoreTests/LiveWorkLoopTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/LiveWorkLoopTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import SidecarCore
+
+/// Runs one real job end to end against a real Optimisarr: pair with proved capabilities, claim,
+/// fetch the source, encode with the bundled ffmpeg, deliver the candidate.
+///
+/// Skipped unless `OPTIMISARR_LIVE_URL`, `OPTIMISARR_LIVE_PIN` and `OPTIMISARR_FFMPEG` are all
+/// set, and it expects the server to have a job queued that this Mac can take. This is the
+/// acceptance evidence the roadmap asks for: every stubbed test proves the loop behaves as I
+/// believe the contract works, and only this proves the belief against the other implementation.
+///
+///     OPTIMISARR_LIVE_URL=localhost:8787 OPTIMISARR_LIVE_PIN="1234 5678" \
+///     OPTIMISARR_FFMPEG=$(pwd)/vendor/ffmpeg swift test --filter LiveWorkLoop
+@Suite("Live work loop", .enabled(if: ProcessInfo.processInfo.environment["OPTIMISARR_LIVE_URL"] != nil
+    && ProcessInfo.processInfo.environment["OPTIMISARR_FFMPEG"] != nil))
+struct LiveWorkLoopTests {
+    private var serverAddress: String { ProcessInfo.processInfo.environment["OPTIMISARR_LIVE_URL"] ?? "" }
+    private var pin: String { ProcessInfo.processInfo.environment["OPTIMISARR_LIVE_PIN"] ?? "" }
+    private var ffmpeg: URL { URL(fileURLWithPath: ProcessInfo.processInfo.environment["OPTIMISARR_FFMPEG"] ?? "") }
+
+    @Test("claims a real job, encodes it with the bundled ffmpeg, and delivers the candidate")
+    func runsOneJob() async throws {
+        let client = SidecarClient()
+        let capabilities = await CapabilityProber(ffmpeg: ffmpeg).probe(name: "Live work loop", maxConcurrency: 1)
+        #expect(!capabilities.videoEncoders.isEmpty, "the bundled ffmpeg proved no encoder")
+
+        let paired = try await client.pair(serverAddress: serverAddress, pin: pin, capabilities: capabilities)
+        let pairing = StoredPairing(serverAddress: serverAddress, credential: paired.credential, workerId: paired.workerId)
+
+        // The server only offers work to a worker it has heard from.
+        _ = try await client.heartbeat(
+            serverAddress: serverAddress, credential: pairing.credential,
+            freeScratchBytes: capabilities.freeScratchBytes, maxConcurrency: capabilities.maxConcurrency)
+
+        let assignment = try await client.claim(serverAddress: serverAddress, credential: pairing.credential)
+        guard let assignment else {
+            Issue.record("the server offered no work; queue a job this Mac can take before running this")
+            return
+        }
+        print("Assignment: job #\(assignment.jobId), encoder \(assignment.videoEncoder), output .\(assignment.outputExtension)")
+        print("Command: \(assignment.arguments.joined(separator: " "))")
+        #expect(capabilities.videoEncoders.contains(assignment.videoEncoder))
+
+        let runner = JobRunner(client: client, ffmpeg: ffmpeg)
+        let outcome = await runner.execute(assignment, pairing: pairing) { progress in
+            print("Progress: \(progress)")
+        }
+        print("Outcome: \(outcome)")
+
+        guard case let .delivered(jobId, bytes) = outcome else {
+            Issue.record("expected delivery, got \(outcome)")
+            return
+        }
+        #expect(jobId == assignment.jobId)
+        #expect(bytes > 0)
+    }
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
@@ -81,6 +81,21 @@ struct AssignmentCommandTests {
         }
     }
 
+    @Test("a filtergraph's escaped comma is not mistaken for a Windows path")
+    func acceptsFiltergraphEscapes() throws {
+        // The frame-rate cap's select filter escapes its comma with a backslash. The first real
+        // capped encode was refused for it; a backslash before a path segment is still refused.
+        var capped = serverCommand
+        capped[capped.firstIndex(of: "-filter:v:0")! + 1] = #"crop=1920:800:0:140,select=not(mod(round(t*60)\,2))"#
+        _ = try AssignmentCommand.validate(capped, outputExtension: "mp4")
+
+        var windows = serverCommand
+        windows[windows.firstIndex(of: "-progress")! + 1] = #"C:\Users\someone\progress.txt"#
+        #expect(throws: AssignmentCommandError.pathLikeValue(#"C:\Users\someone\progress.txt"#)) {
+            try AssignmentCommand.validate(windows, outputExtension: "mp4")
+        }
+    }
+
     @Test("a second input is refused however it is spelt")
     func refusesSecondInput() {
         var tampered = serverCommand

--- a/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
@@ -187,6 +187,9 @@ internal static class WorkerLeaseEndpoints
                     AcquiredAt = lease.AcquiredUtc,
                     ExpiresAt = lease.ExpiresUtc,
                     State = lease.State,
+                    // Bound to the lease so delivery names the candidate by the contract, not by
+                    // the source; the replacement's final extension comes from that name.
+                    OutputExtension = assignment.OutputExtension,
                 });
 
                 // The exclusion that matters: off the queue, so this machine will not also run it.

--- a/src/Optimisarr.Api/Endpoints/WorkerResultEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerResultEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Optimisarr.Api.Library;
 using Optimisarr.Api.Queue;
@@ -107,13 +108,23 @@ internal static class WorkerResultEndpoints
                     "That candidate was encoded from a different source than this job's.");
             }
 
+            // The candidate takes the container extension the assignment promised, recorded on the
+            // lease when it was granted. The replacement names the final file from the candidate,
+            // so naming it after the source would place an MP4 under ".mkv". A lease with no
+            // recorded contract cannot be delivered against.
+            if (string.IsNullOrWhiteSpace(lease.OutputExtension))
+            {
+                return ApiErrors.Conflict("worker.result.contractMissing",
+                    "That lease records no output container, so its candidate cannot be named safely.");
+            }
+
             var workRoot = WorkPaths.Resolve(environment);
             var outputRoot = WorkOutputRoot.ForMediaFile(workRoot, job.MediaFileId);
             Directory.CreateDirectory(outputRoot);
 
             // Written under a temporary name and hashed on the way in, so a transfer that dies
             // part-way never leaves something that looks like a finished candidate.
-            var finalPath = RemoteCandidate.PathFor(outputRoot, job.Id, Path.GetExtension(job.MediaFile.Path));
+            var finalPath = RemoteCandidate.PathFor(outputRoot, job.Id, "." + lease.OutputExtension.TrimStart('.'));
             var stagingPath = finalPath + ".partial";
 
             long written;
@@ -155,6 +166,10 @@ internal static class WorkerResultEndpoints
             return Results.Accepted(value: new ResultAcceptedDto(job.Id, written, actualHash));
         })
         .WithName("DeliverResult")
+        // A candidate is a whole film. Kestrel's default 30 MB body cap exists for form posts, and
+        // the first real delivery from a Mac hit it; the body streams to disk in bounded chunks
+        // above, so lifting the cap here costs no memory. Found by the live work-loop test.
+        .WithMetadata(new DisableRequestSizeLimitAttribute())
         .Produces<ResultAcceptedDto>(StatusCodes.Status202Accepted)
         .Produces<ApiError>(StatusCodes.Status401Unauthorized);
     }

--- a/src/Optimisarr.Api/Queue/QueueDispatcher.cs
+++ b/src/Optimisarr.Api/Queue/QueueDispatcher.cs
@@ -559,6 +559,29 @@ public sealed class QueueDispatcher(
         }
     }
 
+    /// <summary>
+    /// The worker whose completed lease delivered this job's candidate — the latest one, should a
+    /// job ever have been delivered more than once. Ordered in memory: SQLite cannot ORDER BY a
+    /// DateTimeOffset, which the first live delivery proved by failing here. A job holds at most a
+    /// handful of leases, so loading them is cheap.
+    /// </summary>
+    internal static async Task<Worker?> DeliveringWorkerAsync(
+        OptimisarrDbContext db,
+        int jobId,
+        CancellationToken cancellationToken)
+    {
+        var completed = await db.JobLeases
+            .AsNoTracking()
+            .Include(lease => lease.Worker)
+            .Where(lease => lease.JobId == jobId && lease.State == LeaseState.Completed)
+            .ToListAsync(cancellationToken);
+
+        return completed
+            .OrderByDescending(lease => lease.AcquiredAt)
+            .Select(lease => lease.Worker)
+            .FirstOrDefault();
+    }
+
     // Single-writer claim for a delivered candidate: only transition if still waiting, so two
     // dispatch cycles can never verify the same candidate at once.
     private async Task<bool> TryClaimDeliveredAsync(int jobId, CancellationToken cancellationToken)
@@ -610,12 +633,7 @@ public sealed class QueueDispatcher(
                     .Where(job => job.Id == jobId)
                     .Select(job => job.WorkOutputPath)
                     .FirstOrDefaultAsync(cancellationToken);
-                deliveredBy = await db.JobLeases
-                    .AsNoTracking()
-                    .Where(lease => lease.JobId == jobId && lease.State == LeaseState.Completed)
-                    .OrderByDescending(lease => lease.AcquiredAt)
-                    .Select(lease => lease.Worker)
-                    .FirstOrDefaultAsync(cancellationToken);
+                deliveredBy = await DeliveringWorkerAsync(db, jobId, cancellationToken);
             }
 
             if (candidatePath is null || !File.Exists(candidatePath))
@@ -1280,7 +1298,7 @@ public sealed class QueueDispatcher(
             ExpectedWidth: spec.ExpectedSize?.Width,
             ExpectedHeight: spec.ExpectedSize?.Height,
             Crop: spec.CropTo,
-            TargetFrameRate: spec.TargetFrameRate,
+            FrameRate: spec.FrameRate,
             // The tracks the kept-languages rules remove on purpose; verification holds
             // the output to exactly this plan and judges fidelity against the kept tracks.
             RemovedAudioStreamIndexes: spec.RemoveAudioStreamIndexes,
@@ -1730,7 +1748,8 @@ public sealed class QueueDispatcher(
                 // A capped encode kept every other frame; decimating the reference the same way
                 // lines the judged frames up with the kept ones.
                 ReferenceFrameRate: work.Spec.TargetFrameRate ?? sourceProbe.VideoFrameRate,
-                ReferenceCrop: work.Spec.CropTo);
+                ReferenceCrop: work.Spec.CropTo,
+                ReferenceDecimation: work.Spec.FrameRate);
             var measurementProgress = new Progress<double>(progress =>
             {
                 var mapped = AdaptiveQualityProgress.Map(

--- a/src/Optimisarr.Api/Queue/VerificationService.cs
+++ b/src/Optimisarr.Api/Queue/VerificationService.cs
@@ -27,9 +27,9 @@ public sealed record OriginalSnapshot(
     // The crop the encode applied, so the quality reference is cropped identically. Null means
     // the full frame was encoded.
     Optimisarr.Core.Queue.CropRect? Crop = null,
-    // The rate the encode decimated to under a frame-rate cap, so the quality reference is
+    // How the encode thinned its frames under a frame-rate cap, so the quality reference is
     // decimated identically and the judged frames are the kept frames. Null keeps the source rate.
-    double? TargetFrameRate = null,
+    Optimisarr.Core.Queue.FrameRateDecimation? FrameRate = null,
     // Audio-relative indexes the kept-languages rule removed on purpose; verification expects
     // exactly those tracks gone and judges channel/sample-rate fidelity against the kept ones.
     IReadOnlyList<int>? RemovedAudioStreamIndexes = null,
@@ -284,7 +284,7 @@ public sealed class VerificationService(
                 OutputHeight: outputProbe.Height,
                 ExpectedWidth: reference.ExpectedWidth,
                 ExpectedHeight: reference.ExpectedHeight,
-                ExpectedFrameRate: reference.TargetFrameRate,
+                ExpectedFrameRate: reference.FrameRate?.TargetFps,
                 OutputFrameRate: outputProbe.VideoFrameRate,
                 ImageQualityMeasured: imageQualityResult?.Measured ?? false,
                 ImageQualityError: imageQualityResult?.Error,
@@ -449,8 +449,9 @@ public sealed class VerificationService(
             MeasureDurationSeconds: clipDurationSeconds,
             FrameSubsample: frameSubsample,
             Acceleration: acceleration,
-            ReferenceFrameRate: reference.TargetFrameRate ?? originalProbe.VideoFrameRate,
-            ReferenceCrop: reference.Crop);
+            ReferenceFrameRate: reference.FrameRate?.TargetFps ?? originalProbe.VideoFrameRate,
+            ReferenceCrop: reference.Crop,
+            ReferenceDecimation: reference.FrameRate);
         var result = await quality.MeasureAsync(
             qualityReferencePath,
             outputPath,

--- a/src/Optimisarr.Api/Workers/RemoteCandidate.cs
+++ b/src/Optimisarr.Api/Workers/RemoteCandidate.cs
@@ -10,8 +10,9 @@ internal static class RemoteCandidate
 {
     private const string Prefix = "remote-";
 
-    public static string PathFor(string outputRoot, int jobId, string sourceExtension) =>
-        Path.Combine(outputRoot, $"{Prefix}{jobId}{sourceExtension}");
+    /// <param name="extension">The contract's container extension, with its leading dot.</param>
+    public static string PathFor(string outputRoot, int jobId, string extension) =>
+        Path.Combine(outputRoot, $"{Prefix}{jobId}{extension}");
 
     public static bool IsDelivered(string? workOutputPath) =>
         workOutputPath is not null

--- a/src/Optimisarr.Core/Queue/FfmpegCommandBuilder.cs
+++ b/src/Optimisarr.Core/Queue/FfmpegCommandBuilder.cs
@@ -48,11 +48,14 @@ public sealed record TranscodeSpec(
     // The picture to keep when black bars are removed, in source coordinates, or null for none.
     // Applied before any downscale, so a downscale is computed from the cropped size.
     CropRect? CropTo = null,
-    // The exact rate a video re-encode is decimated to under a library's frame-rate cap, or null
-    // to keep the source cadence. Always a clean halving of the source (see FrameRatePlanner), and
-    // the same value the VMAF reference is decimated to so the judged frames are the kept frames.
-    double? TargetFrameRate = null)
+    // How a video re-encode thins its frames under a library's frame-rate cap, or null to keep
+    // the source cadence. Always a clean halving of the source (see FrameRatePlanner), and the
+    // same decimation the VMAF reference receives so the judged frames are the kept frames.
+    FrameRateDecimation? FrameRate = null)
 {
+    /// <summary>The rate a capped encode produces, or null when the source cadence is kept.</summary>
+    public double? TargetFrameRate => FrameRate?.TargetFps;
+
     /// <summary>
     /// The size this encode intends to produce, or null when it intends the source size. The
     /// verification gate holds the output to this. A downscale already accounts for any crop.
@@ -310,9 +313,9 @@ public static class FfmpegCommandBuilder
         }
         // Decimate after the geometry and before the tone-map, so the expensive colour work runs
         // only on the frames that survive.
-        if (spec.TargetFrameRate is { } targetFrameRate)
+        if (spec.FrameRate is { } decimation)
         {
-            filters.Add(FrameRatePlanner.Filter(targetFrameRate));
+            filters.Add(FrameRatePlanner.Filter(decimation));
         }
         if (spec.TonemapToSdr)
         {

--- a/src/Optimisarr.Core/Queue/FrameRatePlanner.cs
+++ b/src/Optimisarr.Core/Queue/FrameRatePlanner.cs
@@ -3,13 +3,26 @@ using System.Globalization;
 namespace Optimisarr.Core.Queue;
 
 /// <summary>
-/// Turns a library's frame-rate cap into an exact target rate for one source, or into nothing.
+/// How a capped encode thins its source: keep one frame in every <see cref="Divisor"/>, judged by
+/// each source frame's index. The same three numbers build the encode filter and the VMAF
+/// reference filter, so the frames judged are the frames kept.
+/// </summary>
+public sealed record FrameRateDecimation(double SourceFps, double TargetFps, int Divisor);
+
+/// <summary>
+/// Turns a library's frame-rate cap into an exact decimation for one source, or into nothing.
 ///
 /// The only conversion that is ever clean is dropping every other frame — an integer ratio. Any
 /// other ratio (30→25, 60→24) repeats or skips a frame every few and judders, which is a worse
 /// picture than either rate. So the plan halves the source rate until it sits under the cap and
-/// refuses anything that cannot be reached that way. The exact result is what both the encode and
-/// the VMAF reference are decimated to, so the frames being judged are the frames that were kept.
+/// refuses anything that cannot be reached that way.
+///
+/// Frames are chosen by index, not by nearest timestamp. FFmpeg's <c>fps</c> filter decides each
+/// output slot by rounding, and on an exact 2:1 the odd frames sit precisely on the rounding
+/// boundary, so which of two source frames it keeps depends on the stream's timebase and on
+/// whether timestamps were rebased first. The first real capped encode and its verification made
+/// different choices for half the frames and scored VMAF 48 for a 97 encode. An index has no
+/// boundary to fall on.
 /// </summary>
 public static class FrameRatePlanner
 {
@@ -20,13 +33,16 @@ public static class FrameRatePlanner
     public const double MinimumTargetFps = 20;
 
     /// <summary>
-    /// The rate to decimate <paramref name="sourceFps"/> to under <paramref name="capFps"/>, or
+    /// The decimation that brings <paramref name="sourceFps"/> under <paramref name="capFps"/>, or
     /// <c>null</c> when the source is already at or under the cap, when either value is unknown,
-    /// or when no clean halving reaches the cap without falling below cinema rate.
+    /// when no clean halving reaches the cap without falling below cinema rate, or when the source
+    /// is variable frame rate — an irregular stream has no "every second frame" that means the
+    /// same thing to the encode and to the reference.
     /// </summary>
-    public static double? Plan(double? sourceFps, int? capFps)
+    public static FrameRateDecimation? Plan(double? sourceFps, int? capFps, bool sourceIsVariableFrameRate = false)
     {
-        if (sourceFps is not { } source || capFps is not { } cap
+        if (sourceIsVariableFrameRate
+            || sourceFps is not { } source || capFps is not { } cap
             || !double.IsFinite(source) || source <= 0 || cap <= 0)
         {
             return null;
@@ -40,20 +56,26 @@ public static class FrameRatePlanner
         }
 
         var target = source;
+        var divisor = 1;
         while (target > cap * (1 + Tolerance))
         {
             target /= 2;
+            divisor *= 2;
         }
 
-        return target >= MinimumTargetFps ? target : null;
+        return target >= MinimumTargetFps ? new FrameRateDecimation(source, target, divisor) : null;
     }
 
     /// <summary>
-    /// The ffmpeg <c>fps</c> filter for an exact rate. The shortest round-trip form parses back to
-    /// the same double the VMAF reference timeline is built from, so both decimate identically.
+    /// The FFmpeg filter that keeps one source frame in every <see cref="FrameRateDecimation.Divisor"/>.
+    /// Each frame's index is recovered from its own timestamp, <c>round(t × source rate)</c>, so the
+    /// choice is the same whether the stream was seeked, rebased or rescaled first: container
+    /// timestamp jitter is well under half a frame, and the source rate is the probe's exact
+    /// rational, so the rounding is never near a boundary. Kept frames keep their own timestamps,
+    /// which are already regular at the target rate.
     /// </summary>
-    public static string Filter(double targetFps) =>
-        $"fps=fps={targetFps.ToString("R", CultureInfo.InvariantCulture)}";
+    public static string Filter(FrameRateDecimation decimation) =>
+        $"select=not(mod(round(t*{decimation.SourceFps.ToString("R", CultureInfo.InvariantCulture)})\\,{decimation.Divisor}))";
 
     /// <summary>
     /// How many frames survive a decimation from <paramref name="sourceFps"/> to

--- a/src/Optimisarr.Core/Queue/TranscodeSpecResolver.cs
+++ b/src/Optimisarr.Core/Queue/TranscodeSpecResolver.cs
@@ -142,9 +142,9 @@ public static class TranscodeSpecResolver
                     rules.VideoDownscaleHeight),
             CropTo: rules.TargetVideoCodec is null ? null : detectedCrop,
             // A copied stream keeps its cadence too; only a re-encode can drop frames.
-            TargetFrameRate: rules.TargetVideoCodec is null
+            FrameRate: rules.TargetVideoCodec is null
                 ? null
-                : FrameRatePlanner.Plan(sourceFrameRate, rules.MaxFrameRate));
+                : FrameRatePlanner.Plan(sourceFrameRate, rules.MaxFrameRate, sourceIsVariableFrameRate));
     }
 
     /// <summary>True for MP4-family containers, which cannot store image-based subtitles.</summary>

--- a/src/Optimisarr.Core/Verification/QualityScoreCommandBuilder.cs
+++ b/src/Optimisarr.Core/Verification/QualityScoreCommandBuilder.cs
@@ -48,7 +48,11 @@ public sealed record QualityMeasurementContext(
     // The crop the encode applied, so the reference is cropped identically before comparison. A
     // cropped output measured against an uncropped reference is comparing different pictures.
     // The comparison then happens at the cropped size.
-    Queue.CropRect? ReferenceCrop = null);
+    Queue.CropRect? ReferenceCrop = null,
+    // How a capped encode thinned its frames, so the reference is thinned by the same index rule
+    // before any timestamp handling. Decimating by nearest timestamp instead can keep different
+    // frames than the encode kept, and then the comparison is of neighbours, not of the same frame.
+    Queue.FrameRateDecimation? ReferenceDecimation = null);
 
 /// <summary>A complete, shell-free FFmpeg VMAF invocation and its selected measurement policy.</summary>
 public sealed record QualityScoreCommand(
@@ -111,9 +115,19 @@ public static class QualityScoreCommandBuilder
         // A crop is a software filter with no CUDA counterpart in the accelerated graph, so a
         // cropped comparison stays on the CPU path — the same choice HDR makes, for the same
         // reason: correctness over speed.
-        var acceleration = context.ReferenceIsHdr || context.ReferenceCrop is not null
+        // A decimated reference likewise: the frame selection must be reproduced exactly, and
+        // only the CPU graph carries it.
+        var acceleration = context.ReferenceIsHdr
+            || context.ReferenceCrop is not null
+            || context.ReferenceDecimation is not null
             ? VmafAcceleration.None
             : context.Acceleration;
+
+        // Thinning by frame index happens before anything touches timestamps, so the index each
+        // frame is judged by is the one the encode judged it by.
+        var referenceDecimation = context.ReferenceDecimation is { } decimation
+            ? $"{Queue.FrameRatePlanner.Filter(decimation)},"
+            : string.Empty;
 
         // With a crop, the picture being judged is the cropped one: both streams are brought to
         // its size, and the viewing model is chosen from it.
@@ -168,6 +182,7 @@ public static class QualityScoreCommandBuilder
                 distortedTimeline,
                 referenceTimeline)
             : BuildCpuFilter(
+                referenceDecimation,
                 normalise,
                 referencePreparation,
                 logPath,
@@ -223,6 +238,7 @@ public static class QualityScoreCommandBuilder
     }
 
     private static string BuildCpuFilter(
+        string referenceDecimation,
         string normalise,
         string referencePreparation,
         string logPath,
@@ -238,7 +254,7 @@ public static class QualityScoreCommandBuilder
             : string.Empty;
         return
             $"[0:v]{download}{distortedTimeline},{normalise}[dist];" +
-            $"[1:v]{download}{referenceTimeline},{referencePreparation}[ref];" +
+            $"[1:v]{download}{referenceDecimation}{referenceTimeline},{referencePreparation}[ref];" +
             "[dist][ref]libvmaf=" +
             $"model=version={model}:" +
             $"n_threads={threads}:n_subsample={frameSubsample}:" +

--- a/src/Optimisarr.Data/JobLease.cs
+++ b/src/Optimisarr.Data/JobLease.cs
@@ -31,6 +31,15 @@ public sealed class JobLease
 
     public LeaseState State { get; set; } = LeaseState.Held;
 
+    /// <summary>
+    /// The container extension the assignment told the worker to produce, recorded when the
+    /// lease is granted. The delivered candidate is named with it, because the replacement takes
+    /// its final extension from the candidate's name: a file named after the source but holding
+    /// the contract's container would be placed under the wrong extension. Null only for a lease
+    /// granted before this existed, and such a lease can no longer deliver.
+    /// </summary>
+    public string? OutputExtension { get; set; }
+
     /// <summary>Rebuilds the domain lease so every decision runs through one state machine.</summary>
     public WorkerLease ToDomain() =>
         new(Id, JobId, WorkerId, AcquiredAt, ExpiresAt, State);

--- a/src/Optimisarr.Data/Migrations/20260904175249_AddLeaseOutputExtension.Designer.cs
+++ b/src/Optimisarr.Data/Migrations/20260904175249_AddLeaseOutputExtension.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Optimisarr.Data;
 
@@ -10,9 +11,11 @@ using Optimisarr.Data;
 namespace Optimisarr.Data.Migrations
 {
     [DbContext(typeof(OptimisarrDbContext))]
-    partial class OptimisarrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904175249_AddLeaseOutputExtension")]
+    partial class AddLeaseOutputExtension
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/src/Optimisarr.Data/Migrations/20260904175249_AddLeaseOutputExtension.cs
+++ b/src/Optimisarr.Data/Migrations/20260904175249_AddLeaseOutputExtension.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Optimisarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLeaseOutputExtension : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OutputExtension",
+                table: "JobLeases",
+                type: "TEXT",
+                maxLength: 8,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OutputExtension",
+                table: "JobLeases");
+        }
+    }
+}

--- a/src/Optimisarr.Data/OptimisarrDbContext.cs
+++ b/src/Optimisarr.Data/OptimisarrDbContext.cs
@@ -185,6 +185,7 @@ public sealed class OptimisarrDbContext(DbContextOptions<OptimisarrDbContext> op
         {
             entity.HasKey(lease => lease.Id);
             entity.Property(lease => lease.State).HasConversion<string>().HasMaxLength(32);
+            entity.Property(lease => lease.OutputExtension).HasMaxLength(8);
 
             // Removing a job removes its leases; a lease without a job claims nothing.
             entity.HasOne(lease => lease.Job)

--- a/tests/Optimisarr.Tests/FfmpegCommandBuilderTests.cs
+++ b/tests/Optimisarr.Tests/FfmpegCommandBuilderTests.cs
@@ -291,13 +291,13 @@ public sealed class FfmpegCommandBuilderTests
         var args = FfmpegCommandBuilder.Build(Reencode(tonemap: true) with
         {
             DownscaleTo = new PictureSize(1280, 720),
-            TargetFrameRate = 30
+            FrameRate = new FrameRateDecimation(60, 30, 2)
         });
 
         var chain = args[IndexOf(args, "-filter:v:0") + 1];
-        Assert.Contains("fps=fps=30", chain);
-        Assert.True(chain.IndexOf("scale=", StringComparison.Ordinal) < chain.IndexOf("fps=fps=", StringComparison.Ordinal));
-        Assert.True(chain.IndexOf("fps=fps=", StringComparison.Ordinal) < chain.IndexOf("tonemap", StringComparison.Ordinal));
+        Assert.Contains(@"select=not(mod(round(t*60)\,2))", chain);
+        Assert.True(chain.IndexOf("scale=", StringComparison.Ordinal) < chain.IndexOf("select=", StringComparison.Ordinal));
+        Assert.True(chain.IndexOf("select=", StringComparison.Ordinal) < chain.IndexOf("tonemap", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -309,12 +309,12 @@ public sealed class FfmpegCommandBuilderTests
         var args = FfmpegCommandBuilder.Build(Reencode() with
         {
             SourceIsVariableFrameRate = true,
-            TargetFrameRate = 30
+            FrameRate = new FrameRateDecimation(60, 30, 2)
         });
 
         Assert.DoesNotContain("-fps_mode", args);
         Assert.DoesNotContain("-enc_time_base:v:0", args);
-        Assert.Contains("fps=fps=30", args[IndexOf(args, "-filter:v:0") + 1]);
+        Assert.Contains("select=", args[IndexOf(args, "-filter:v:0") + 1]);
     }
 
     [Fact]
@@ -329,7 +329,8 @@ public sealed class FfmpegCommandBuilderTests
     [Fact]
     public void A_frame_rate_target_on_a_remux_is_ignored()
     {
-        var args = FfmpegCommandBuilder.Build(Reencode(videoCodec: null) with { TargetFrameRate = 30 });
+        var args = FfmpegCommandBuilder.Build(
+            Reencode(videoCodec: null) with { FrameRate = new FrameRateDecimation(60, 30, 2) });
 
         Assert.DoesNotContain("-filter:v:0", args);
     }

--- a/tests/Optimisarr.Tests/FrameRatePlannerTests.cs
+++ b/tests/Optimisarr.Tests/FrameRatePlannerTests.cs
@@ -6,24 +6,26 @@ namespace Optimisarr.Tests;
 /// The framerate ask from #95, shaped as a cap rather than a target. The only conversion that is
 /// ever clean is dropping every other frame — an integer ratio. Anything else, 30→25 or 60→24,
 /// repeats a frame every few and judders. So the plan halves the source rate until it is under
-/// the cap and refuses everything else, and the exact result is what both the encode and the VMAF
-/// reference are decimated to, so they stay frame-aligned.
+/// the cap and refuses everything else, and the same decimation is what both the encode and the
+/// VMAF reference apply, so they stay frame-aligned.
 /// </summary>
 public sealed class FrameRatePlannerTests
 {
     [Theory]
-    [InlineData(60.0, 30, 30.0)]
-    [InlineData(59.94, 30, 29.97)]
-    [InlineData(50.0, 30, 25.0)]
-    [InlineData(120.0, 30, 30.0)]
-    [InlineData(120.0, 60, 60.0)]
-    [InlineData(48.0, 30, 24.0)]
-    public void The_source_rate_is_halved_until_it_is_under_the_cap(double source, int cap, double expected)
+    [InlineData(60.0, 30, 30.0, 2)]
+    [InlineData(59.94, 30, 29.97, 2)]
+    [InlineData(50.0, 30, 25.0, 2)]
+    [InlineData(120.0, 30, 30.0, 4)]
+    [InlineData(120.0, 60, 60.0, 2)]
+    [InlineData(48.0, 30, 24.0, 2)]
+    public void The_source_rate_is_halved_until_it_is_under_the_cap(double source, int cap, double expected, int divisor)
     {
-        var target = FrameRatePlanner.Plan(source, cap);
+        var plan = FrameRatePlanner.Plan(source, cap);
 
-        Assert.NotNull(target);
-        Assert.Equal(expected, target.Value, precision: 6);
+        Assert.NotNull(plan);
+        Assert.Equal(expected, plan.TargetFps, precision: 6);
+        Assert.Equal(divisor, plan.Divisor);
+        Assert.Equal(source, plan.SourceFps);
     }
 
     [Theory]
@@ -47,6 +49,14 @@ public sealed class FrameRatePlannerTests
     }
 
     [Fact]
+    public void A_variable_frame_rate_source_is_never_decimated()
+    {
+        // "Every second frame" of an irregular stream means nothing regular, and the encode and
+        // the reference could not be relied on to pick the same frames. Left at its own cadence.
+        Assert.Null(FrameRatePlanner.Plan(60.0, 30, sourceIsVariableFrameRate: true));
+    }
+
+    [Fact]
     public void Unknown_or_absurd_inputs_produce_no_target()
     {
         Assert.Null(FrameRatePlanner.Plan(null, 30));
@@ -57,12 +67,23 @@ public sealed class FrameRatePlannerTests
     }
 
     [Fact]
-    public void The_filter_states_the_exact_rate()
+    public void The_filter_keeps_frames_by_index_rather_than_by_nearest_timestamp()
     {
-        // The same value the VMAF reference is decimated to, so the two stay frame-aligned.
-        var filter = FrameRatePlanner.Filter(29.97);
+        // fps=30 on a 60 fps stream puts every odd frame exactly on its rounding boundary, and
+        // which neighbour it keeps then depends on the timebase and on whether timestamps were
+        // rebased first. The first real capped encode and its verification disagreed on half the
+        // frames that way. An index recovered from the frame's own time has no boundary to fall on.
+        var filter = FrameRatePlanner.Filter(new FrameRateDecimation(60, 30, 2));
 
-        Assert.StartsWith("fps=fps=29.97", filter);
+        Assert.Equal(@"select=not(mod(round(t*60)\,2))", filter);
+    }
+
+    [Fact]
+    public void The_filter_states_the_exact_source_rate_so_a_fractional_rate_still_rounds_cleanly()
+    {
+        var filter = FrameRatePlanner.Filter(new FrameRateDecimation(59.94, 29.97, 2));
+
+        Assert.StartsWith("select=not(mod(round(t*59.94)", filter);
     }
 
     [Fact]

--- a/tests/Optimisarr.Tests/QualityScoreCommandBuilderTests.cs
+++ b/tests/Optimisarr.Tests/QualityScoreCommandBuilderTests.cs
@@ -378,6 +378,43 @@ public sealed class QualityScoreCommandBuilderTests
     }
 
     [Fact]
+    public void A_capped_encode_has_its_reference_thinned_by_the_same_index_rule_before_anything_else()
+    {
+        // The reference must lose exactly the frames the encode lost. Thinning by frame index,
+        // ahead of any timestamp reset or cadence filter, is what makes the two choices identical;
+        // the first real capped encode scored VMAF 48 for a 97 picture when the reference was
+        // decimated by nearest timestamp after a reset instead. The candidate is already at the
+        // target rate and is not thinned.
+        var command = QualityScoreCommandBuilder.Build(
+            "/work/output.mp4", "/data/original.mkv", "/tmp/vmaf.json",
+            new QualityMeasurementContext(1920, 1080, ReferenceIsHdr: false, HdrConvertedToSdr: false,
+                ReferenceFrameRate: 30,
+                ReferenceDecimation: new Optimisarr.Core.Queue.FrameRateDecimation(60, 30, 2)),
+            threads: 4);
+
+        Assert.Contains(@"[1:v]select=not(mod(round(t*60)\,2)),settb=AVTB,setpts=PTS-STARTPTS,fps=fps=30", command.FilterGraph);
+        Assert.Contains("[0:v]settb=AVTB,setpts=PTS-STARTPTS,fps=fps=30", command.FilterGraph);
+        Assert.DoesNotContain("[0:v]select", command.FilterGraph);
+    }
+
+    [Fact]
+    public void A_decimated_reference_keeps_the_comparison_on_the_cpu_path()
+    {
+        // Same trade the crop and HDR make: the CPU graph is the one that reproduces the
+        // preparation exactly, and a wrong frame pairing is worse than a slower measurement.
+        var command = QualityScoreCommandBuilder.Build(
+            "/work/output.mp4", "/data/original.mkv", "/tmp/vmaf.json",
+            new QualityMeasurementContext(1920, 1080, ReferenceIsHdr: false, HdrConvertedToSdr: false,
+                Acceleration: VmafAcceleration.Cuda,
+                ReferenceFrameRate: 30,
+                ReferenceDecimation: new Optimisarr.Core.Queue.FrameRateDecimation(60, 30, 2)),
+            threads: 4);
+
+        Assert.DoesNotContain("libvmaf_cuda", command.FilterGraph);
+        Assert.Contains("select=not(mod(round(t*60)", command.FilterGraph);
+    }
+
+    [Fact]
     public void A_cropped_uhd_source_still_selects_the_4k_model_from_its_cropped_size()
     {
         // 3840x1600 is the common cropped cinema master; it is still a 4K viewing picture.

--- a/tests/Optimisarr.Tests/QueueDispatcherSafetyTests.cs
+++ b/tests/Optimisarr.Tests/QueueDispatcherSafetyTests.cs
@@ -32,7 +32,7 @@ public sealed class QueueDispatcherSafetyTests
     {
         // The expensive part — the encode — happened on another machine and is finished. Only this
         // machine's verdict was interrupted, so the candidate waits for verification to run again.
-        var delivered = RemoteCandidate.PathFor("/work/42", jobId: 7, sourceExtension: ".mkv");
+        var delivered = RemoteCandidate.PathFor("/work/42", jobId: 7, extension: ".mkv");
 
         Assert.Equal(
             QueueDispatcher.RecoveryAction.KeepDelivered,

--- a/tests/Optimisarr.Tests/TranscodeSpecResolverTests.cs
+++ b/tests/Optimisarr.Tests/TranscodeSpecResolverTests.cs
@@ -549,6 +549,22 @@ public sealed class TranscodeSpecResolverTests
     }
 
     [Fact]
+    public void A_variable_frame_rate_source_is_not_capped()
+    {
+        // The cap is a clean halving, and an irregular stream has no clean half. Its own
+        // cadence is kept, and the VFR handling stays in force.
+        var rules = Hevc with { MaxFrameRate = 30 };
+
+        var spec = TranscodeSpecResolver.Resolve(
+            rules, inputPath: "/data/films/Clip.mkv", relativePath: "Clip.mkv",
+            workRoot: "/work", sourceIsHdr: false, crf: 23, preset: "medium",
+            sourceIsVariableFrameRate: true, sourceFrameRate: 59.94);
+
+        Assert.Null(spec.FrameRate);
+        Assert.Null(spec.TargetFrameRate);
+    }
+
+    [Fact]
     public void An_unknown_source_rate_gets_no_target()
     {
         var rules = Hevc with { MaxFrameRate = 30 };

--- a/tests/Optimisarr.Tests/WorkerResultUploadTests.cs
+++ b/tests/Optimisarr.Tests/WorkerResultUploadTests.cs
@@ -4,8 +4,11 @@ using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Optimisarr.Api.Queue;
 using Optimisarr.Api.Workers;
 using Optimisarr.Data;
 
@@ -235,6 +238,21 @@ public sealed class WorkerResultUploadTests : IAsyncLifetime
     }
 
     [Fact]
+    public void The_delivery_route_lifts_kestrels_default_body_cap()
+    {
+        // A candidate is a whole film. The in-process test host does not enforce Kestrel's 30 MB
+        // default, so the first real delivery from a Mac was the first to hit it; this pins the
+        // route metadata Kestrel reads, so the cap cannot quietly return.
+        var deliver = Assert.Single(
+            _api.Services.GetRequiredService<EndpointDataSource>().Endpoints,
+            endpoint => endpoint.Metadata.GetMetadata<IEndpointNameMetadata>()?.EndpointName == "DeliverResult");
+
+        var limit = deliver.Metadata.GetMetadata<IRequestSizeLimitMetadata>();
+        Assert.NotNull(limit);
+        Assert.Null(limit.MaxRequestBodySize);
+    }
+
+    [Fact]
     public async Task An_accepted_candidate_lands_in_the_work_directory_and_never_over_the_original()
     {
         await EnableRemoteWorkers();
@@ -258,6 +276,16 @@ public sealed class WorkerResultUploadTests : IAsyncLifetime
         // leaves it alone rather than treating it as an interrupted local encode.
         Assert.Equal(JobStatus.AwaitingVerification, job.Status);
         Assert.True(RemoteCandidate.IsDelivered(job.WorkOutputPath));
+        // Named by the contract's container, not the source's: this library targets MP4 while the
+        // source is an MKV, and the replacement takes the final extension from this name. The
+        // first live delivery landed as remote-1.mkv holding an MP4, which is how this was found.
+        Assert.Equal(".mp4", Path.GetExtension(job.WorkOutputPath));
+
+        // Verification rebuilds the contract for the worker that delivered, found through its
+        // completed lease. Asked here, against SQLite, because the first live delivery failed on
+        // exactly this lookup: the database cannot order a DateTimeOffset.
+        var deliveredBy = await QueueDispatcher.DeliveringWorkerAsync(db, job.Id, CancellationToken.None);
+        Assert.Equal("Accepted", deliveredBy?.Name);
 
         // The original must be exactly as it was. A returned candidate is a proposal, not a
         // replacement, and nothing about delivering one may touch the source.


### PR DESCRIPTION
Follows #108, #109 and #110. This is the "real-hardware acceptance evidence" the roadmap asked for, and what it found.

## The run

On this Apple Silicon Mac, against a server built from `dev` with the bundled ffmpeg: a library with a 30 fps cap and a fixed quality, a 40 s 1080p60 H.264 source, remote workers on, queue paused so only the sidecar could take the job. `LiveWorkLoopTests` (new, skipped without `OPTIMISARR_LIVE_URL`/`PIN`/`FFMPEG`) paired with proved capabilities, claimed, received `hevc_videotoolbox` with `-q:v` and the cap applied, encoded, and delivered. The server then verified the candidate through every gate.

Final result with the VMAF gate on: harmonic mean **97.74** (floor 93), fifth percentile 96.89, lowest frame 95.55, and the job marked **ReadyToReplace**. The VMAF retry also crossed the boundary: a first candidate failed the gate, was requeued at higher quality, claimed and delivered again.

## What it found, all fixed here

1. **Kestrel's 30 MB body cap refused the candidate.** `DeliverResult` now carries `DisableRequestSizeLimit`; a test pins the route metadata. The body already streamed to disk in bounded chunks.
2. **The delivering-worker lookup ordered a `DateTimeOffset` in SQLite.** Now `DeliveringWorkerAsync`, ordered in memory, and the upload test asks the real database.
3. **The candidate was named after the source's extension, not the contract's container.** `ReplacementPlanner` takes the final extension from that name, so an MP4 would have been placed as `.mkv`. The promised container is recorded on the lease at claim (`JobLease.OutputExtension`, migration `AddLeaseOutputExtension`), the candidate is named from it, and a lease with no recorded container cannot deliver (409).
4. **The frame-rate cap and its verification kept different frames.** `fps=30` on a 60 fps stream decides each slot by nearest timestamp, and every odd frame sits exactly on the rounding boundary; the reference chain resets timestamps before thinning while the encode does not. Half the frames compared to a neighbour and a 97 encode scored 48. Both sides now thin by index, `select=not(mod(round(t*<source fps>)\,<divisor>))`, ahead of any timestamp handling; `FrameRateDecimation` carries source rate, target and divisor from the planner to the builder, the snapshot and `QualityMeasurementContext.ReferenceDecimation`. A VFR source is no longer capped. Reproduced by hand: server chain 48.47, index select 97.74.
5. **The worker's allowlist refused the new filter's escaped comma** as path-like and handed the job back — correct fail-closed behaviour, now taught to tell a filtergraph escape from a Windows path segment, with both cases tested.

## Verification

- `dotnet build -warnaserror`: 0 warnings. `dotnet test`: 1820 passed.
- `swift test`: 59 tests in 14 suites passed; `LiveWorkLoopTests` passed against the local server.
- `scripts/check_docs.py` clean. No OpenAPI change (the assignment contract is unchanged).

## Safety

Nothing here weakens a gate. The frame-rate change makes the quality comparison compare the same frames, which had been failing good encodes, not passing bad ones. The naming change prevents a wrong container extension reaching a replacement. Migration adds one nullable column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
