### PR TITLE
Disbelieve a progress clock that has run past its own end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,26 +16,11 @@
   also now reads the exact frame count mkvmerge writes into Matroska files (`NUMBER_OF_FRAMES`),
   which the rate-derived estimate was standing in for.
 
-### Changed
-
-- **The Libraries page is calmer, and every control lives in one place.** Each library is now a
-  card that leads with the number that matters (how many files) and a plain-words status: "All
-  already optimal" in muted text, or "12 ready to optimise" in cyan when something is actually
-  waiting — the only time the summary lights up. The four badges that were identical on every
-  library (preset, schedule, auto-replace, "access ok") are gone; preset and schedule read as a
-  short icon list under the path, and access is only mentioned when it is a problem. Scan is the
-  one button on the card; Enqueue, Configure and Delete sit in a keyboard-operable "more actions"
-  menu, so the destructive action no longer sits at equal weight to the primary one. Cards go two
-  to a row and stack on a phone. "Skipped" now explains itself on hover and points at Configure ›
-  Candidates for the per-file reason.
-
-### Fixed
 
 - **A TV library's type badge read "Tv".** The API serialises the media type as `Tv` while the
   label lookup only knew `TV`, so the raw enum name leaked into the badge (and the end-to-end mock
   sent `TV`, which hid it). The lookup now accepts both and the mock sends what the API sends.
 
-### Fixed
 
 - **A transcode could sit at "100% · ~2s left" until the container was restarted
   ([#95](https://github.com/Jellman86/optimisarr/issues/95)).** The status was still Transcoding,
@@ -76,6 +61,24 @@
   fall on; verified at 97 on the same encode. A variable-frame-rate source is no longer capped,
   since it has no "every second frame" that means the same thing to both sides. Found on the first
   real hardware run of the cap; no released build carried it.
+
+
+- **The weekly secret scan now acknowledges three reviewed historical documentation examples.**
+  Exact Gitleaks fingerprints suppress only the known placeholder authorization headers; new or
+  changed findings continue to fail the scan.
+
+### Changed
+
+- **The Libraries page is calmer, and every control lives in one place.** Each library is now a
+  card that leads with the number that matters (how many files) and a plain-words status: "All
+  already optimal" in muted text, or "12 ready to optimise" in cyan when something is actually
+  waiting — the only time the summary lights up. The four badges that were identical on every
+  library (preset, schedule, auto-replace, "access ok") are gone; preset and schedule read as a
+  short icon list under the path, and access is only mentioned when it is a problem. Scan is the
+  one button on the card; Enqueue, Configure and Delete sit in a keyboard-operable "more actions"
+  menu, so the destructive action no longer sits at equal weight to the primary one. Cards go two
+  to a row and stack on a phone. "Skipped" now explains itself on hover and points at Configure ›
+  Candidates for the per-file reason.
 
 ### Added
 
@@ -257,12 +260,6 @@
   worker checks in every 30 seconds using the credential it was given at pairing, and is shown as
   offline after two minutes of silence rather than on a single missed check-in, so a brief network
   blip does not make the status flicker. Revoking a worker stops its check-ins immediately.
-
-### Fixed
-
-- **The weekly secret scan now acknowledges three reviewed historical documentation examples.**
-  Exact Gitleaks fingerprints suppress only the known placeholder authorization headers; new or
-  changed findings continue to fail the scan.
 
 ## 0.2.11 — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Fixed
+
+- **The progress bar could reach 100% with minutes still to run
+  ([#95](https://github.com/Jellman86/optimisarr/issues/95)).** The reporter's diagnostics showed
+  the encode alive and busy the whole time: ffmpeg at 280% CPU, and the job finishing on its own.
+  The bar had believed the wrong clock. Progress is read from two clocks, encoded time and encoded
+  frames, and took the more advanced one; a frame count derived from a nominal rate came up short,
+  so the frame clock passed 100% while the time clock, still inside its range, said 94%. A clock
+  that has run past its own end has proven its expectation wrong, so it is now disbelieved in
+  favour of the other; only when both have overrun does the bar stop at 99% and drop the
+  seconds-left estimate rather than print "~2s" from a figure it can no longer trust. The probe
+  also now reads the exact frame count mkvmerge writes into Matroska files (`NUMBER_OF_FRAMES`),
+  which the rate-derived estimate was standing in for.
+
 ### Changed
 
 - **The Libraries page is calmer, and every control lives in one place.** Each library is now a

--- a/src/Optimisarr.Api/Queue/QueueDispatcher.cs
+++ b/src/Optimisarr.Api/Queue/QueueDispatcher.cs
@@ -2036,16 +2036,18 @@ public sealed class QueueDispatcher(
             // The final block is worth reporting even when it carries nothing measurable (a source
             // with neither a duration nor a frame count): "finishing" is a fact about the process,
             // not a reading of the bar.
-            var measured = FfmpegProgressCalculator.Calculate(durationSeconds, expectedFrameCount, sample);
-            if (measured is not { } measuredProgress)
+            var reading = FfmpegProgressCalculator.Measure(durationSeconds, expectedFrameCount, sample);
+            var estimateExhausted = reading?.EstimateExhausted ?? false;
+            if (reading is not { } measuredReading)
             {
                 if (!sample.IsFinal)
                 {
                     continue;
                 }
 
-                measuredProgress = lastObserved;
+                measuredReading = new FfmpegProgressReading(lastObserved, EstimateExhausted: false);
             }
+            var measuredProgress = measuredReading.Progress;
 
             // Some inputs contain discontinuous timestamps. Never let one make the visible or
             // persisted bar move backwards.
@@ -2075,10 +2077,12 @@ public sealed class QueueDispatcher(
                 }
             }
 
-            // Once FFmpeg has written its final block there is nothing left to estimate: the
-            // output is complete and only the exit remains, so the UI is told "finishing" rather
-            // than shown a seconds-left figure computed from a bar that can no longer move.
-            var eta = !sample.IsFinal && sample.Speed is { } speed && durationSeconds is > 0
+            // Two cases have nothing left to estimate. After FFmpeg's final block the output is
+            // complete and only the exit remains, so the UI is told "finishing". When every clock
+            // has run past its expected end the encode is still going but the expectation was
+            // wrong, so a seconds-left figure would be computed from a bar that can no longer
+            // move; speed and fps stay, the estimate goes.
+            var eta = !sample.IsFinal && !estimateExhausted && sample.Speed is { } speed && durationSeconds is > 0
                 ? FfmpegProgressParser.EstimateRemainingSeconds(
                     durationSeconds.Value,
                     measuredProgress * durationSeconds.Value,

--- a/src/Optimisarr.Core/Library/MediaProbeService.cs
+++ b/src/Optimisarr.Core/Library/MediaProbeService.cs
@@ -244,6 +244,11 @@ public sealed class MediaProbeService : IMediaProbeService
                         {
                             frameCount = frames;
                         }
+                        // Matroska never fills nb_frames, but files written by mkvmerge carry the
+                        // muxer's own count as a statistics tag, which is exact where a count
+                        // derived from a nominal frame rate can be off by enough to run the
+                        // progress bar past its end.
+                        frameCount ??= ReadMatroskaFrameCount(stream);
                         isHdr = IsHdrVideoStream(stream);
                         isDolbyVision = IsDolbyVisionStream(stream);
                         colorPrimaries = ReadString(stream, "color_primaries");
@@ -591,6 +596,29 @@ public sealed class MediaProbeService : IMediaProbeService
 
     // Containers tag streams with ISO 639 codes in any case; normalise to lower case so
     // language comparisons are stable. A blank tag means the language is unknown.
+    // The tag is NUMBER_OF_FRAMES, often with a language suffix (NUMBER_OF_FRAMES-eng), and is
+    // a string like every ffprobe tag. The first parseable one wins.
+    private static int? ReadMatroskaFrameCount(JsonElement stream)
+    {
+        if (!stream.TryGetProperty("tags", out var tags) || tags.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        foreach (var tag in tags.EnumerateObject())
+        {
+            if (tag.Name.StartsWith("NUMBER_OF_FRAMES", StringComparison.OrdinalIgnoreCase)
+                && tag.Value.ValueKind == JsonValueKind.String
+                && int.TryParse(tag.Value.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var frames)
+                && frames > 0)
+            {
+                return frames;
+            }
+        }
+
+        return null;
+    }
+
     private static string? ReadLanguageTag(JsonElement stream)
     {
         if (!stream.TryGetProperty("tags", out var tags) || tags.ValueKind != JsonValueKind.Object)

--- a/src/Optimisarr.Core/Queue/FfmpegProgressParser.cs
+++ b/src/Optimisarr.Core/Queue/FfmpegProgressParser.cs
@@ -72,13 +72,32 @@ public static partial class FfmpegProgressParser
 }
 
 /// <summary>
+/// A progress reading and whether the estimate behind it can still be trusted. The estimate is
+/// exhausted once every informative clock has run past its expected end: the encode is plainly
+/// still going, but nothing left can say how far.
+/// </summary>
+public sealed record FfmpegProgressReading(double Progress, bool EstimateExhausted);
+
+/// <summary>
 /// Calculates media progress from both clocks FFmpeg exposes. Copied streams can pin
-/// <c>out_time</c> at zero while video frames continue to encode, so the furthest valid clock is
-/// authoritative. Values remain below one until the process itself reports completion.
+/// <c>out_time</c> at zero while video frames continue to encode, so a clock at zero says
+/// nothing. A clock that has run past its expected end has proven its expectation wrong (a short
+/// container duration, a frame count derived from a nominal rate), so it says nothing either; the
+/// other clock, still inside its range, is the truthful one. A real encode was seen sitting at
+/// "100% · ~2s left" for the last six percent of an episode because the wrong clock was believed.
+/// Values remain below one until the process itself reports completion.
 /// </summary>
 public static class FfmpegProgressCalculator
 {
+    private const double Ceiling = 0.999;
+
     public static double? Calculate(
+        double? durationSeconds,
+        int? expectedFrameCount,
+        FfmpegProgressSample sample) =>
+        Measure(durationSeconds, expectedFrameCount, sample)?.Progress;
+
+    public static FfmpegProgressReading? Measure(
         double? durationSeconds,
         int? expectedFrameCount,
         FfmpegProgressSample sample)
@@ -95,10 +114,19 @@ public static class FfmpegProgressCalculator
             return null;
         }
 
-        return Math.Clamp(
-            Math.Max(timestampProgress ?? 0, frameProgress ?? 0),
-            0,
-            0.999);
+        var informative = new[] { timestampProgress, frameProgress }
+            .Where(clock => clock is > 0)
+            .Select(clock => clock!.Value)
+            .ToArray();
+        if (informative.Length == 0)
+        {
+            return new FfmpegProgressReading(0, EstimateExhausted: false);
+        }
+
+        var inRange = informative.Where(clock => clock <= 1).ToArray();
+        return inRange.Length > 0
+            ? new FfmpegProgressReading(Math.Min(inRange.Max(), Ceiling), EstimateExhausted: false)
+            : new FfmpegProgressReading(Ceiling, EstimateExhausted: true);
     }
 
     public static int? ExpectedFramesForWindow(

--- a/tests/Optimisarr.Tests/FfmpegProgressParserTests.cs
+++ b/tests/Optimisarr.Tests/FfmpegProgressParserTests.cs
@@ -115,6 +115,53 @@ public sealed class FfmpegProgressParserTests
     }
 
     [Fact]
+    public void A_clock_that_has_run_past_its_end_is_disbelieved_in_favour_of_the_other()
+    {
+        // The reporter's encode (#95): the frame count was derived from a nominal rate and came up
+        // short, so frames said 104% while the timestamp clock, still inside its range, said 94%.
+        // Believing the larger clock showed "100% · ~2s left" for the last six percent.
+        var sample = new FfmpegProgressSample(ElapsedSeconds: 2_430, Frame: 62_400, Fps: 30, Speed: 1.24);
+
+        var reading = FfmpegProgressCalculator.Measure(
+            durationSeconds: 2_580,
+            expectedFrameCount: 60_000,
+            sample);
+
+        Assert.Equal(2_430.0 / 2_580.0, reading!.Progress, precision: 6);
+        Assert.False(reading.EstimateExhausted);
+    }
+
+    [Fact]
+    public void The_estimate_is_exhausted_only_when_every_informative_clock_has_overrun()
+    {
+        var sample = new FfmpegProgressSample(ElapsedSeconds: 2_700, Frame: 62_400, Fps: 30, Speed: 1.24);
+
+        var reading = FfmpegProgressCalculator.Measure(
+            durationSeconds: 2_580,
+            expectedFrameCount: 60_000,
+            sample);
+
+        Assert.Equal(0.999, reading!.Progress);
+        Assert.True(reading.EstimateExhausted);
+    }
+
+    [Fact]
+    public void A_pinned_clock_at_zero_does_not_count_as_a_truthful_reading()
+    {
+        // Copied streams pin out_time at zero. That must neither be believed as "0%" nor stop an
+        // overrun frame clock from being recognised as exhausted.
+        var sample = new FfmpegProgressSample(ElapsedSeconds: 0, Frame: 1_600, Fps: 80, Speed: null);
+
+        var reading = FfmpegProgressCalculator.Measure(
+            durationSeconds: 60,
+            expectedFrameCount: 1_500,
+            sample);
+
+        Assert.Equal(0.999, reading!.Progress);
+        Assert.True(reading.EstimateExhausted);
+    }
+
+    [Fact]
     public void Protocol_parser_marks_only_the_end_block_as_final()
     {
         var parser = new FfmpegProgressProtocolParser();

--- a/tests/Optimisarr.Tests/MediaProbeParseTests.cs
+++ b/tests/Optimisarr.Tests/MediaProbeParseTests.cs
@@ -468,6 +468,43 @@ public sealed class MediaProbeParseTests
     }
 
     [Fact]
+    public void Parse_takes_the_frame_count_from_the_matroska_statistics_tag_when_nb_frames_is_absent()
+    {
+        // mkvmerge writes the muxer's exact count as a language-suffixed tag; Matroska never fills
+        // nb_frames. A count derived from the nominal rate instead can overrun the progress bar.
+        const string json = """
+        {
+          "streams": [{
+            "codec_type": "video", "codec_name": "h264", "width": 1920, "height": 1080,
+            "r_frame_rate": "24000/1001", "avg_frame_rate": "24000/1001",
+            "tags": { "NUMBER_OF_FRAMES-eng": "61873", "language": "eng" }
+          }],
+          "format": { "format_name": "matroska,webm", "duration": "2580.5" }
+        }
+        """;
+
+        var result = MediaProbeService.Parse(json, ".mkv");
+
+        Assert.Equal(61_873, result.FrameCount);
+    }
+
+    [Fact]
+    public void Parse_prefers_nb_frames_over_the_matroska_tag_when_both_are_present()
+    {
+        const string json = """
+        {
+          "streams": [{
+            "codec_type": "video", "codec_name": "h264", "width": 1920, "height": 1080,
+            "nb_frames": "100", "tags": { "NUMBER_OF_FRAMES": "200" }
+          }],
+          "format": { "format_name": "matroska,webm" }
+        }
+        """;
+
+        Assert.Equal(100, MediaProbeService.Parse(json, ".mkv").FrameCount);
+    }
+
+    [Fact]
     public void Parse_classifies_a_still_image_as_image()
     {
         const string json = """


### PR DESCRIPTION
Follow-up to #115, from the reporter's diagnostics on #95: ffmpeg was alive at 280% CPU and the job finished on its own. Not a hang; the bar believed the wrong clock.

## Change
- `FfmpegProgressCalculator.Measure` returns a reading plus `EstimateExhausted`. A clock past 1.0 has proven its expectation wrong and is ignored in favour of the other in-range clock; a clock at 0 (copied streams pin `out_time`) is not a reading. Only when every informative clock has overrun does progress hold at 0.999 and the estimate count as exhausted.
- The dispatcher sends no ETA while the estimate is exhausted; fps and speed still broadcast. Combined with #115's 99% floor, the last stretch reads "99% · 30 fps · 1.24×" instead of "100% · ~2s left".
- `MediaProbeService` reads mkvmerge's `NUMBER_OF_FRAMES[-lang]` statistics tag when `nb_frames` is absent, so Matroska sources get an exact expected frame count instead of one derived from the nominal rate.

## Evidence
- `dotnet build -warnaserror`: 0 warnings. `dotnet test`: 1835 passed, 5 new (three calculator cases modelled on the reporter's numbers, two probe cases).
- No frontend change.
