### PR TITLE
Re-encode with software decode when a hardware decode comes out corrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Fixed
 
+- **A corrupt hardware decode is now re-encoded with software decode instead of being retried at
+  a higher quality and then excluded.** On two different Intel hosts, QSV decoded certain H.264 MKV
+  sources into broken frames (159 of 959 in one window, all scoring zero) while the same hevc_qsv
+  encoder fed by software decode scored 96. The verification gates rejected every such output, so
+  no original was ever touched, but the rejection looked like a weak encode: the job spent a second
+  full encode on the higher-quality retry, failed again the same way, and the file was auto-excluded
+  for good. On one install that had happened to 265 MKV files while MP4 sources never failed once.
+  A hardware-decoded output that fails with decoder corruption's signature — decode errors, or any
+  frame below the catastrophic VMAF floor — is now re-encoded once with software decode feeding the
+  same encoder, and that second result is what the gates judge. The report's context records the
+  retry and why. A weak but intact encode, whose worst frame stays above the floor, keeps the
+  higher-quality retry as before. Files auto-excluded by the old behaviour are not re-queued
+  automatically; un-exclude them and they will be tried again the new way.
+
 - **The progress bar could reach 100% with minutes still to run
   ([#95](https://github.com/Jellman86/optimisarr/issues/95)).** The reporter's diagnostics showed
   the encode alive and busy the whole time: ffmpeg at 280% CPU, and the job finishing on its own.

--- a/src/Optimisarr.Api/Queue/QueueDispatcher.cs
+++ b/src/Optimisarr.Api/Queue/QueueDispatcher.cs
@@ -864,18 +864,64 @@ public sealed class QueueDispatcher(
                     }
                 }
 
-                await VerifyAndFinishAsync(jobId, spec.OutputPath, preparedWork, cancellationToken);
+                var disposition = await VerifyAndFinishAsync(
+                    jobId,
+                    spec.OutputPath,
+                    preparedWork,
+                    cancellationToken,
+                    softwareDecodeRetryAvailable: preparedWork.UsedHardwareDecode
+                        && preparedWork.SoftwareFallbackArguments is not null);
+                if (disposition == VerificationDisposition.RetryWithSoftwareDecode)
+                {
+                    // One more encode, with the universal software decoder feeding the same encoder.
+                    // The retried work cannot fall back again, so this cannot loop.
+                    DeleteWorkOutput(spec.OutputPath);
+                    arguments = preparedWork.SoftwareFallbackArguments!;
+                    var retriedWork = preparedWork with
+                    {
+                        Arguments = arguments,
+                        SoftwareFallbackArguments = null,
+                        UsedHardwareDecode = false,
+                        UsedHardwareToneMap = false,
+                        SoftwareDecodeRetryReason = HardwareDecodeFallback.SoftwareDecodeRetryReason
+                    };
+                    await WithJobAsync(jobId, job =>
+                    {
+                        job.Status = JobStatus.Transcoding;
+                        job.Progress = 0;
+                        job.VerificationPassed = null;
+                        job.VerifiedAt = null;
+                        job.OutputSizeBytes = null;
+                        job.UpdatedAt = DateTimeOffset.UtcNow;
+                    }, cancellationToken);
+                    await BeginTranscodeAsync(
+                        jobId,
+                        spec.OutputPath,
+                        arguments,
+                        preparedWork.VideoEncoder,
+                        preparedWork.VideoQuality,
+                        cancellationToken);
+                    await NotifyAsync();
+                    run = await RunFfmpegAsync(
+                        jobId,
+                        arguments,
+                        progressDuration,
+                        expectedFrameCount,
+                        hardwareEncoder,
+                        cancellationToken);
+                    if (run.ExitCode == 0)
+                    {
+                        await VerifyAndFinishAsync(jobId, spec.OutputPath, retriedWork, cancellationToken);
+                    }
+                    else
+                    {
+                        await FailFromFfmpegRunAsync(jobId, spec.OutputPath, run);
+                    }
+                }
             }
             else
             {
-                DeleteWorkOutput(spec.OutputPath);
-                // Translate known ffmpeg failures into a clear, actionable reason; fall back to the
-                // raw stderr tail for anything unrecognised.
-                var error = FfmpegErrorInterpreter.Explain(run.Error)
-                    ?? run.Error
-                    ?? $"ffmpeg exited with code {run.ExitCode}";
-                await CompleteAsync(jobId, JobStatus.Failed, error: error, processLog: run.Log);
-                await NotifyJobFailedAsync(jobId, error);
+                await FailFromFfmpegRunAsync(jobId, spec.OutputPath, run);
             }
         }
         catch (JobNoLongerEligibleException ex)
@@ -948,7 +994,10 @@ public sealed class QueueDispatcher(
         bool UsedHardwareToneMap = false,
         // The inventory's picture size, when it has one. A remote assignment names the VMAF
         // model from it so the worker's evidence can be held to the model this machine would use.
-        PictureSize? SourcePicture = null)
+        PictureSize? SourcePicture = null,
+        // Why this work is a second encode of the same job, when it is one; carried into the
+        // verification report's context so the record explains itself.
+        string? SoftwareDecodeRetryReason = null)
     {
         public void Deconstruct(out TranscodeSpec spec, out IReadOnlyList<string> arguments)
         {
@@ -2131,6 +2180,18 @@ public sealed class QueueDispatcher(
             log.ToLog());
     }
 
+    // Translate known ffmpeg failures into a clear, actionable reason; fall back to the raw
+    // stderr tail for anything unrecognised. The partial output is never left behind.
+    private async Task FailFromFfmpegRunAsync(int jobId, string outputPath, FfmpegRun run)
+    {
+        DeleteWorkOutput(outputPath);
+        var error = FfmpegErrorInterpreter.Explain(run.Error)
+            ?? run.Error
+            ?? $"ffmpeg exited with code {run.ExitCode}";
+        await CompleteAsync(jobId, JobStatus.Failed, error: error, processLog: run.Log);
+        await NotifyJobFailedAsync(jobId, error);
+    }
+
     private async Task BeginTranscodeAsync(
         int jobId,
         string outputPath,
@@ -2293,7 +2354,24 @@ public sealed class QueueDispatcher(
     // check plus duration/stream/size comparison against the original. A failed
     // report leaves the job Failed with the output retained for inspection — the
     // original is never touched either way.
-    private async Task VerifyAndFinishAsync(int jobId, string outputPath, JobWork work, CancellationToken cancellationToken)
+    private enum VerificationDisposition
+    {
+        /// <summary>The job reached a terminal state, a queued retry, or replacement.</summary>
+        Finished,
+
+        /// <summary>
+        /// The hardware-decoded output failed the way a corrupt decode fails. The report is saved;
+        /// the caller owns the software re-encode because only it holds the fallback command.
+        /// </summary>
+        RetryWithSoftwareDecode
+    }
+
+    private async Task<VerificationDisposition> VerifyAndFinishAsync(
+        int jobId,
+        string outputPath,
+        JobWork work,
+        CancellationToken cancellationToken,
+        bool softwareDecodeRetryAvailable = false)
     {
         await WithJobAsync(jobId, job =>
         {
@@ -2367,7 +2445,8 @@ public sealed class QueueDispatcher(
                     outcome.VmafSampling,
                     policy.MinimumVmafHarmonicMean,
                     policy.MinimumVmafMin,
-                    policy.MinimumVmafCatastrophicMin)
+                    policy.MinimumVmafCatastrophicMin,
+                    work.SoftwareDecodeRetryReason)
             }
         };
         var reportJson = JsonSerializer.Serialize(outcome.Report, ReportJsonOptions);
@@ -2386,13 +2465,31 @@ public sealed class QueueDispatcher(
 
         if (!outcome.Report.Passed)
         {
+            // Asked before the higher-quality retry: a corrupt decode fails at every quality, so
+            // re-encoding it at a higher one would only spend a second encode on the same rubbish.
+            if (softwareDecodeRetryAvailable
+                && !work.IsDisposable
+                && HardwareDecodeFallback.ShouldRetryAfterVerification(
+                    outcome.Report,
+                    policy.MinimumVmafCatastrophicMin))
+            {
+                logger.LogWarning(
+                    "Job {JobId}: the hardware-decoded output failed verification with the signature of "
+                    + "decoder corruption ({Failures}); re-encoding with software decode",
+                    jobId,
+                    string.Join("; ", outcome.Report.Checks
+                        .Where(check => check.Outcome == CheckOutcome.Failed)
+                        .Select(check => check.Name)));
+                return VerificationDisposition.RetryWithSoftwareDecode;
+            }
+
             if (!work.IsDisposable && VmafRetryPolicy.ShouldRetry(
                     outcome.Report,
                     work.VideoQuality?.RetryCount ?? 0,
                     work.VideoQuality?.Effective))
             {
                 await QueueHigherQualityRetryAsync(jobId, outputPath);
-                return;
+                return VerificationDisposition.Finished;
             }
 
             var failed = outcome.Report.Checks
@@ -2412,16 +2509,17 @@ public sealed class QueueDispatcher(
                     work.VideoQuality?.RetryCount ?? 0,
                     work.VideoQuality?.Effective));
             await NotifyJobFailedAsync(jobId, summary);
-            return;
+            return VerificationDisposition.Finished;
         }
 
         if (work.IsDisposable)
         {
             await CompleteAsync(jobId, JobStatus.Completed, progress: 1.0);
-            return;
+            return VerificationDisposition.Finished;
         }
 
         await FinishSuccessfulJobAsync(jobId, outputPath, work, settings.DryRunMode);
+        return VerificationDisposition.Finished;
     }
 
     internal static VerificationClip? BuildVerificationClip(

--- a/src/Optimisarr.Core/Queue/HardwareDecodeFallback.cs
+++ b/src/Optimisarr.Core/Queue/HardwareDecodeFallback.cs
@@ -1,3 +1,5 @@
+using Optimisarr.Core.Verification;
+
 namespace Optimisarr.Core.Queue;
 
 /// <summary>
@@ -29,6 +31,47 @@ public static class HardwareDecodeFallback
     /// True when <paramref name="ffmpegStderr"/> looks like a hardware decode/hwaccel setup
     /// failure that a software-decode retry could recover from.
     /// </summary>
+    public const string DecodeHealthCheckName = "Decode health";
+    private const string VmafCheckName = "Perceptual quality (VMAF)";
+
+    /// <summary>
+    /// The context note carried by the second verification, so the report says why the encode
+    /// was repeated rather than leaving two encodes and one result to be reconciled by hand.
+    /// </summary>
+    public const string SoftwareDecodeRetryReason =
+        "Re-encoded with software decode: the hardware-decoded output failed verification with the "
+        + "signature of decoder corruption (frames scoring near zero, or decode errors), which the "
+        + "encoder cannot fix at any quality.";
+
+    /// <summary>
+    /// True when a hardware-decoded output failed verification in the way a corrupt decode fails,
+    /// not the way a merely weak encode fails: the output has decode errors, or single frames score
+    /// below the catastrophic floor. Intel QSV was observed to decode certain H.264 streams into
+    /// broken frames on two different hosts while software decode of the same stream was clean; a
+    /// higher-quality retry of a corrupt decode only wastes a second encode, so this is asked first.
+    /// A weak encode whose worst frame is still above the floor keeps the higher-quality retry.
+    /// </summary>
+    public static bool ShouldRetryAfterVerification(VerificationReport report, double catastrophicFloor)
+    {
+        if (report.Passed)
+        {
+            return false;
+        }
+
+        var failed = report.Checks
+            .Where(check => check.Outcome == CheckOutcome.Failed)
+            .Select(check => check.Name)
+            .ToHashSet(StringComparer.Ordinal);
+        if (failed.Contains(DecodeHealthCheckName))
+        {
+            return true;
+        }
+
+        return failed.Contains(VmafCheckName)
+            && report.Vmaf is { Measured: true, Scores.VmafMin: { } lowestFrame }
+            && lowestFrame < catastrophicFloor;
+    }
+
     public static bool ShouldRetryInSoftware(string? ffmpegStderr)
     {
         if (string.IsNullOrWhiteSpace(ffmpegStderr))

--- a/src/Optimisarr.Core/Verification/VerificationReport.cs
+++ b/src/Optimisarr.Core/Verification/VerificationReport.cs
@@ -19,7 +19,10 @@ public sealed record VerificationContext(
     string? VmafSampling,
     double MinimumVmafHarmonicMean,
     double MinimumVmafFifthPercentile,
-    double MinimumVmafCatastrophicMin);
+    double MinimumVmafCatastrophicMin,
+    // Set when this report judges a second encode made with software decode after the first,
+    // hardware-decoded one failed with the signature of decoder corruption. Null otherwise.
+    string? DecodeRetry = null);
 
 /// <summary>
 /// Structured VMAF evidence retained independently of the pass/fail checks. Measure-only callers

--- a/tests/Optimisarr.Tests/HardwareDecodeFallbackTests.cs
+++ b/tests/Optimisarr.Tests/HardwareDecodeFallbackTests.cs
@@ -1,9 +1,91 @@
 using Optimisarr.Core.Queue;
+using Optimisarr.Core.Verification;
 
 namespace Optimisarr.Tests;
 
 public sealed class HardwareDecodeFallbackTests
 {
+    // --- After verification: the corruption signature ------------------------------------------
+    //
+    // Intel QSV decoded an H.264 MKV into broken frames on two hosts; the same encoder fed by
+    // software decode scored 96. The gates rejected every corrupt output, so nothing was harmed,
+    // but each cost a full encode, then a higher-quality retry, then a permanent auto-exclusion.
+
+    private const double Floor = 40;
+
+    private static VerificationReport Report(
+        double? lowestFrame,
+        bool measured = true,
+        params (string Name, CheckOutcome Outcome)[] checks) =>
+        new(
+            checks.Select(check => new VerificationCheck(check.Name, check.Outcome, "")).ToList(),
+            Vmaf: new VmafEvidence(
+                measured,
+                null,
+                measured
+                    ? new QualityScores(VmafMean: 58, VmafHarmonicMean: 6, VmafMin: lowestFrame, PsnrYMean: null, SsimMean: null)
+                    : null));
+
+    [Fact]
+    public void Frames_scoring_below_the_catastrophic_floor_are_read_as_a_corrupt_decode()
+    {
+        // The observed shape: 159 of 959 frames at zero, harmonic mean in single digits.
+        var report = Report(lowestFrame: 0, checks: [("Perceptual quality (VMAF)", CheckOutcome.Failed)]);
+
+        Assert.True(HardwareDecodeFallback.ShouldRetryAfterVerification(report, Floor));
+    }
+
+    [Fact]
+    public void Decode_errors_in_the_output_are_read_as_a_corrupt_decode_whatever_else_failed()
+    {
+        var report = Report(
+            lowestFrame: 0,
+            checks:
+            [
+                ("Decode health", CheckOutcome.Failed),
+                ("Size saving", CheckOutcome.Failed),
+                ("Perceptual quality (VMAF)", CheckOutcome.Failed)
+            ]);
+
+        Assert.True(HardwareDecodeFallback.ShouldRetryAfterVerification(report, Floor));
+    }
+
+    [Fact]
+    public void A_weak_but_intact_encode_keeps_the_higher_quality_retry()
+    {
+        // Worst frame above the floor: the encoder simply did not spend enough. That is what the
+        // higher-quality retry is for, and a software re-encode would change nothing.
+        var report = Report(lowestFrame: 62, checks: [("Perceptual quality (VMAF)", CheckOutcome.Failed)]);
+
+        Assert.False(HardwareDecodeFallback.ShouldRetryAfterVerification(report, Floor));
+    }
+
+    [Fact]
+    public void A_size_saving_failure_alone_is_not_a_decode_problem()
+    {
+        var report = Report(lowestFrame: 91, checks: [("Size saving", CheckOutcome.Failed)]);
+
+        Assert.False(HardwareDecodeFallback.ShouldRetryAfterVerification(report, Floor));
+    }
+
+    [Fact]
+    public void An_unmeasured_vmaf_gives_no_grounds_to_retry()
+    {
+        var report = Report(lowestFrame: null, measured: false, checks: [("Perceptual quality (VMAF)", CheckOutcome.Failed)]);
+
+        Assert.False(HardwareDecodeFallback.ShouldRetryAfterVerification(report, Floor));
+    }
+
+    [Fact]
+    public void A_passing_report_never_retries()
+    {
+        var report = Report(lowestFrame: 0, checks: [("Perceptual quality (VMAF)", CheckOutcome.Passed)]);
+
+        Assert.False(HardwareDecodeFallback.ShouldRetryAfterVerification(report, Floor));
+    }
+
+    // --- Before verification: ffmpeg setup failures (unchanged) --------------------------------
+
     [Theory]
     [InlineData("[hevc_qsv @ 0x..] Failed setup for format qsv: hwaccel initialisation returned error")]
     [InlineData("Error while opening decoder for input stream")]


### PR DESCRIPTION
## Outcome
A hardware-decoded output that fails verification the way a corrupt decode fails is re-encoded once with software decode feeding the same encoder, and that second output is what the gates judge. Before, the same failure was read as a weak encode: a higher-quality retry (a second wasted full encode), the same failure, then permanent auto-exclusion.

## Evidence
- Live install: across 1,236 scored jobs, MP4 sources failed the quality gate 0 times in 1,052; MKV sources failed 108 of 183 (59%). 265 MKV files had been auto-excluded, 117 of them after the higher-quality retry failed identically.
- Reproduced on Riker (jellyfin-ffmpeg 7.1.4) and Quark (Frigate's ffmpeg 7.0.2), same source window, same encoder, same measurement:

| Decode path | VMAF mean | Frames near 0 |
|---|---|---|
| Software decode → hevc_qsv | 96.5 | 0 / 959 |
| QSV decode → hevc_qsv (Riker) | 58.8 | 159 / 959 |
| QSV decode → hevc_qsv (Quark) | 0.1 | 954 / 959 |

Identical bad frames at ICQ 20 and 24, so it is the decoder, not the quality setting. A lossless remux scored 97.8 through the windowed comparison, so the measurement path is sound.

## Change
- `HardwareDecodeFallback.ShouldRetryAfterVerification`: true when a hardware-decoded output fails with a Decode health failure, or a VMAF failure whose worst frame is below the catastrophic floor. A weak but intact encode (worst frame above the floor) is not a match and keeps the higher-quality retry.
- `VerifyAndFinishAsync` returns a disposition; the local transcode path re-encodes once with the existing `SoftwareFallbackArguments`, with `UsedHardwareDecode` cleared so it cannot loop. Delivered remote candidates never take this path.
- `VerificationContext.DecodeRetry` records the retry reason in the saved report.

## Not in this PR
- Files auto-excluded by the old behaviour are not re-queued. Un-excluding the 117 "VMAF failed the higher-quality retry" entries on the affected install will retry them the new way.
- Learning to prefer software decode after repeated corruption on a host, so the first encode is not wasted either. Worth a roadmap entry.

## Checks
`dotnet build -warnaserror` 0 warnings; `dotnet test` 1841 passed, 6 new. No frontend change.
