### PR TITLE
Hide the remote-worker groundwork behind a preview flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,9 @@
   also now reads the exact frame count mkvmerge writes into Matroska files (`NUMBER_OF_FRAMES`),
   which the rate-derived estimate was standing in for.
 
-
 - **A TV library's type badge read "Tv".** The API serialises the media type as `Tv` while the
   label lookup only knew `TV`, so the raw enum name leaked into the badge (and the end-to-end mock
   sent `TV`, which hid it). The lookup now accepts both and the mock sends what the API sends.
-
 
 - **A transcode could sit at "100% · ~2s left" until the container was restarted
   ([#95](https://github.com/Jellman86/optimisarr/issues/95)).** The status was still Transcoding,
@@ -49,21 +47,6 @@
   not paused — and discards the output, so the retry and exclusion policies see it like any other
   failure. A paused encode is never counted; SIGSTOP silences it on purpose.
 
-- **A delivered candidate larger than 30 MB was refused.** The result route inherited Kestrel's
-  default request body cap, meant for form posts, so the first real delivery from a Mac sidecar
-  failed with "request body too large" and the worker handed the job back. The route now lifts the
-  cap; it already streams the body to disk in bounded chunks, so no memory is at stake. Found by
-  the live work-loop test on real hardware.
-
-- **A delivered candidate was named after the source rather than its own container.** A worker
-  told to produce MP4 from an MKV source had its candidate stored as `.mkv`, and the replacement
-  takes the final extension from that name. The container the assignment promised is now recorded
-  on the lease when it is granted (migration `AddLeaseOutputExtension`) and the candidate is named
-  from it; a lease with no recorded container cannot be delivered against. The same live run also
-  found that looking up the delivering worker ordered leases by a date in SQLite, which SQLite
-  cannot do; the ordering now happens in memory and a test asks the real database. Both found on
-  the first real delivery.
-
 - **A frame-rate-capped encode could fail its own quality check.** The cap thinned frames with
   FFmpeg's `fps` filter, which picks each output slot by nearest timestamp. On an exact 2:1 every
   odd source frame sits precisely on the rounding boundary, so which neighbour is kept depends on
@@ -75,7 +58,6 @@
   fall on; verified at 97 on the same encode. A variable-frame-rate source is no longer capped,
   since it has no "every second frame" that means the same thing to both sides. Found on the first
   real hardware run of the cap; no released build carried it.
-
 
 - **The weekly secret scan now acknowledges three reviewed historical documentation examples.**
   Exact Gitleaks fingerprints suppress only the known placeholder authorization headers; new or
@@ -108,51 +90,120 @@
   for bitrate-driven modes rather than the constant-quality mode used here. The library form's
   support note now says so.
 
-- **The macOS sidecar now does work.** On each healthy check-in while idle it claims a job, and
-  runs it end to end: the server's command is validated against an explicit contract before a byte
-  is fetched (known options only, the only input and output are the two placeholder tokens, no value
-  that looks like a path — anything else is refused whole and the job handed back with the token
-  named); the source is fetched by lease into the app's own scratch and hashed, and a transfer that
-  does not match the server's hash is never encoded; the bundled ffmpeg runs while the lease is
-  renewed, and losing the lease stops the encode; the candidate is hashed and delivered with both
-  hashes for the server to verify exactly as it would a local encode. The menu shows the job and
-  stage, and how the last job ended. Scratch is removed on every exit path; forgetting the pairing
-  cancels a running job. One job at a time. VMAF is not yet measured on the Mac; the server measures
-  it itself for now.
+- **Groundwork for remote transcoding workers, hidden in this release.** A remote worker cannot
+  yet do a job for you: the macOS sidecar has done one end-to-end encode on a developer's
+  machine, and worker-side quality measurement, drain controls, credential binding, resumable
+  transfers, signing, and the Windows sidecar are still to build. Everything below therefore sits
+  behind `OPTIMISARR_EXPERIMENTAL_REMOTE_WORKERS=true`: without it the **Remote workers** switch
+  and the **Workers** tab do not appear, the setting cannot be turned on, and every worker route
+  answers 403 `workers.unavailable`, whatever an older database may have stored. The pieces that
+  landed, kept here so the record is complete:
+  - **A delivered candidate larger than 30 MB was refused.** The result route inherited Kestrel's
+    default request body cap, meant for form posts, so the first real delivery from a Mac sidecar
+    failed with "request body too large" and the worker handed the job back. The route now lifts the
+    cap; it already streams the body to disk in bounded chunks, so no memory is at stake. Found by
+    the live work-loop test on real hardware.
 
-- **A candidate delivered by a remote worker is now verified and can earn replacement.** Before
-  this, a delivered candidate was set to Verifying, where nothing picked it up, and the next
-  restart's recovery sweep deleted it as an interrupted encode. Delivery now lands the job in a new
-  **Delivered, awaiting verification** status. The dispatcher picks such jobs up ahead of starting
-  new encodes, under the same concurrency cap and activity policy, rebuilds the encode contract for
-  the worker that produced the candidate, and runs every local gate against it — decode, duration,
-  tail, streams, size, resolution, frame rate, and the VMAF comparison — through exactly the path a
-  local encode takes. A candidate that passes becomes ready to replace or is auto-replaced as the
-  library asks; one that fails is retried at higher quality or failed, as before. Restart recovery
-  now tells a delivered candidate mid-verification from an interrupted local encode and keeps it.
-  The queue shows **Encoding remotely** and the new status by name, both count as active, and
-  clearing or cancelling treats a delivered candidate as pending work. A result arriving for a job
-  the operator has cancelled is refused rather than quietly reviving it. VMAF is re-measured here
-  for now; accepting a worker's own measurement is wired in with the sidecar's work loop.
+  - **A delivered candidate was named after the source rather than its own container.** A worker
+    told to produce MP4 from an MKV source had its candidate stored as `.mkv`, and the replacement
+    takes the final extension from that name. The container the assignment promised is now recorded
+    on the lease when it is granted (migration `AddLeaseOutputExtension`) and the candidate is named
+    from it; a lease with no recorded container cannot be delivered against. The same live run also
+    found that looking up the delivering worker ordered leases by a date in SQLite, which SQLite
+    cannot do; the ordering now happens in memory and a test asks the real database. Both found on
+    the first real delivery.
 
-- **A remote worker can now be handed an executable assignment.** Until now every claim returned
-  nothing: the assignment named no encoder and carried no encode policy, so no sidecar could be
-  offered work (the characterisation test that pinned this now asserts the opposite). A claim now
-  runs the same preparation as local dispatch — fresh probes, crop detection, the picture, audio
-  and track contract, verification policy — with the encoder chosen from what the worker proved,
-  in the same preference order this machine uses for its own hardware, and hands over the exact
-  FFmpeg argument array this machine would have run. Two tokens stand in for paths, `{{input}}`
-  and `{{output}}` with the container extension attached, so no path on the server is ever sent
-  and a worker substitutes only its own scratch. The assignment also states the VMAF requirement
-  (whether to measure, which model, frame subsample, clip mode, thresholds) so evidence can be bound
-  to the policy this machine will judge by. Not offered, each with a reason in the debug log:
-  remux, audio and image jobs, and jobs from adaptive-VMAF libraries whose per-title quality has
-  not yet been chosen, because that selection runs on this machine's encoder and a quality chosen
-  for one encoder means nothing on another. The VideoToolbox encoder family is now understood
-  end to end — selection, quality, preset, tuning and the command builder — so a Mac that proves
-  `hevc_videotoolbox` receives `-q:v` on Apple's scale rather than a CRF it would reject. That
-  quality line is a straight mapping and still owes calibration on real hardware; the VMAF gate,
-  not the mapping, is what guarantees a result.
+  - **The macOS sidecar now does work.** On each healthy check-in while idle it claims a job, and
+    runs it end to end: the server's command is validated against an explicit contract before a byte
+    is fetched (known options only, the only input and output are the two placeholder tokens, no value
+    that looks like a path — anything else is refused whole and the job handed back with the token
+    named); the source is fetched by lease into the app's own scratch and hashed, and a transfer that
+    does not match the server's hash is never encoded; the bundled ffmpeg runs while the lease is
+    renewed, and losing the lease stops the encode; the candidate is hashed and delivered with both
+    hashes for the server to verify exactly as it would a local encode. The menu shows the job and
+    stage, and how the last job ended. Scratch is removed on every exit path; forgetting the pairing
+    cancels a running job. One job at a time. VMAF is not yet measured on the Mac; the server measures
+    it itself for now.
+
+  - **A candidate delivered by a remote worker is now verified and can earn replacement.** Before
+    this, a delivered candidate was set to Verifying, where nothing picked it up, and the next
+    restart's recovery sweep deleted it as an interrupted encode. Delivery now lands the job in a new
+    **Delivered, awaiting verification** status. The dispatcher picks such jobs up ahead of starting
+    new encodes, under the same concurrency cap and activity policy, rebuilds the encode contract for
+    the worker that produced the candidate, and runs every local gate against it — decode, duration,
+    tail, streams, size, resolution, frame rate, and the VMAF comparison — through exactly the path a
+    local encode takes. A candidate that passes becomes ready to replace or is auto-replaced as the
+    library asks; one that fails is retried at higher quality or failed, as before. Restart recovery
+    now tells a delivered candidate mid-verification from an interrupted local encode and keeps it.
+    The queue shows **Encoding remotely** and the new status by name, both count as active, and
+    clearing or cancelling treats a delivered candidate as pending work. A result arriving for a job
+    the operator has cancelled is refused rather than quietly reviving it. VMAF is re-measured here
+    for now; accepting a worker's own measurement is wired in with the sidecar's work loop.
+
+  - **A remote worker can now be handed an executable assignment.** Until now every claim returned
+    nothing: the assignment named no encoder and carried no encode policy, so no sidecar could be
+    offered work (the characterisation test that pinned this now asserts the opposite). A claim now
+    runs the same preparation as local dispatch — fresh probes, crop detection, the picture, audio
+    and track contract, verification policy — with the encoder chosen from what the worker proved,
+    in the same preference order this machine uses for its own hardware, and hands over the exact
+    FFmpeg argument array this machine would have run. Two tokens stand in for paths, `{{input}}`
+    and `{{output}}` with the container extension attached, so no path on the server is ever sent
+    and a worker substitutes only its own scratch. The assignment also states the VMAF requirement
+    (whether to measure, which model, frame subsample, clip mode, thresholds) so evidence can be bound
+    to the policy this machine will judge by. Not offered, each with a reason in the debug log:
+    remux, audio and image jobs, and jobs from adaptive-VMAF libraries whose per-title quality has
+    not yet been chosen, because that selection runs on this machine's encoder and a quality chosen
+    for one encoder means nothing on another. The VideoToolbox encoder family is now understood
+    end to end — selection, quality, preset, tuning and the command builder — so a Mac that proves
+    `hevc_videotoolbox` receives `-q:v` on Apple's scale rather than a CRF it would reject. That
+    quality line is a straight mapping and still owes calibration on real hardware; the VMAF gate,
+    not the mapping, is what guarantees a result.
+
+  - **The macOS sidecar now knows what its Mac can actually do.** It bundles its own ffmpeg, built
+    from pinned source rather than downloaded — no prebuilt Apple Silicon build met the requirement,
+    and a worker that cannot measure quality cannot do the job at all. It then proves its hardware
+    instead of assuming it: each VideoToolbox encoder is confirmed with a real throwaway encode, and
+    hardware decode by encoding a clip and decoding it back, because every Apple build lists
+    VideoToolbox whether or not a given machine can open it. Capabilities are probed at pairing, so
+    what the server records is what the machine could do just then. A Mac that proves nothing reports
+    nothing and is never offered work. **It still transcodes nothing** — no work is requested, because
+    the server cannot yet finish a job returned by a worker.
+
+  - **Remote transcoding sidecars can now be paired with a PIN.** Settings gains a **Workers** tab.
+    Press Pair a sidecar, then type the code and the server address it shows into your sidecar app.
+    The code lasts five minutes, works once, and is destroyed after five wrong entries, so a code
+    short enough to retype stays safe. Paired workers are listed with their platform, encoders, and
+    status, and can be revoked; revoking ends a worker's access immediately and keeps the record.
+    Optimisarr remains the only thing that replaces, quarantines, moves, or deletes a file — a worker
+    never can. **No work reaches a sidecar yet**, so pairing has no effect on your library today; it
+    is there so a connection can be set up and tested while the rest is built. The entries below
+    describe the routes a worker will use once that is true — claiming, fetching a source, returning
+    a candidate — none of which can currently be exercised end to end.
+  - **Remote workers are off unless you turn them on.** Settings → General has a Remote workers
+    switch, off by default and off on upgrade. While it is off there is no Workers tab and no sidecar
+    can pair or check in, so a normal single-container install is unchanged and never has to think
+    about it. Turning it back off stops check-ins immediately but keeps what is already paired, so
+    nothing is lost and turning it on again restores it.
+  - **A remote worker can now return the file it encoded.** The upload is checksummed on arrival and
+    refused if it does not match, if it was encoded from a different source, or if the worker no
+    longer holds the job. An accepted file waits for verification and cannot replace anything until
+    every check Optimisarr runs on its own transcodes has passed against it too.
+  - **A remote worker can now download the file it has been given.** Transfers resume where they left
+    off if the connection drops, and come with a checksum so the worker can confirm it received the
+    file intact. A worker can only ever fetch the exact original it was assigned, and only while it
+    still holds the job.
+  - **The route for a worker to claim a job now exists, but no job can be offered through it yet.**
+    A paired sidecar can ask for work, and Optimisarr will only ever hand out a job where the worker
+    has proved it has the encoder, VMAF support, scratch space and spare concurrency that job needs.
+    A claimed job leaves the queue so this machine will not also run it, and comes straight back if
+    the worker gives it up or goes silent. In practice nothing is handed out: the offer names the
+    encoder recorded on the job, and that is only written when *this* machine transcodes, so a queued
+    job has none and the request is correctly refused as incomplete. Remote transcoding therefore has
+    no effect on your library in this release.
+  - **Paired sidecars now report in, and the Workers list shows whether each one is reachable.** A
+    worker checks in every 30 seconds using the credential it was given at pairing, and is shown as
+    offline after two minutes of silence rather than on a single missed check-in, so a brief network
+    blip does not make the status flicker. Revoking a worker stops its check-ins immediately.
 
 - **A library can now cap frame rate on re-encode.** Advanced options gain **Cap frame rate at**,
   with 60 and 30 fps stops, beside the resolution controls; this completes the framerate ask in
@@ -199,16 +250,6 @@
   window cannot be honoured. It reaches x264/x265 only — NVENC reads a cap but never a floor, and
   passing it one would look applied while doing nothing. Nothing is set by default.
 
-- **The macOS sidecar now knows what its Mac can actually do.** It bundles its own ffmpeg, built
-  from pinned source rather than downloaded — no prebuilt Apple Silicon build met the requirement,
-  and a worker that cannot measure quality cannot do the job at all. It then proves its hardware
-  instead of assuming it: each VideoToolbox encoder is confirmed with a real throwaway encode, and
-  hardware decode by encoding a clip and decoding it back, because every Apple build lists
-  VideoToolbox whether or not a given machine can open it. Capabilities are probed at pairing, so
-  what the server records is what the machine could do just then. A Mac that proves nothing reports
-  nothing and is never offered work. **It still transcodes nothing** — no work is requested, because
-  the server cannot yet finish a job returned by a worker.
-
 - **Video re-encodes can now be fine-tuned per library.** Advanced options gain a **Fine-tune the
   encoder** group with three settings: a **content tune** for animation or film grain, a **maximum
   bitrate** ceiling on top of the quality target, and **stronger adaptive quantisation** to spend
@@ -238,42 +279,6 @@
   count is captured by every scan and read again immediately before any replacement, so a file
   linked after it was queued is still caught. Off by default and off on upgrade, so an existing
   installation's candidates are unchanged.
-
-- **Remote transcoding sidecars can now be paired with a PIN.** Settings gains a **Workers** tab.
-  Press Pair a sidecar, then type the code and the server address it shows into your sidecar app.
-  The code lasts five minutes, works once, and is destroyed after five wrong entries, so a code
-  short enough to retype stays safe. Paired workers are listed with their platform, encoders, and
-  status, and can be revoked; revoking ends a worker's access immediately and keeps the record.
-  Optimisarr remains the only thing that replaces, quarantines, moves, or deletes a file — a worker
-  never can. **No work reaches a sidecar yet**, so pairing has no effect on your library today; it
-  is there so a connection can be set up and tested while the rest is built. The entries below
-  describe the routes a worker will use once that is true — claiming, fetching a source, returning
-  a candidate — none of which can currently be exercised end to end.
-- **Remote workers are off unless you turn them on.** Settings → General has a Remote workers
-  switch, off by default and off on upgrade. While it is off there is no Workers tab and no sidecar
-  can pair or check in, so a normal single-container install is unchanged and never has to think
-  about it. Turning it back off stops check-ins immediately but keeps what is already paired, so
-  nothing is lost and turning it on again restores it.
-- **A remote worker can now return the file it encoded.** The upload is checksummed on arrival and
-  refused if it does not match, if it was encoded from a different source, or if the worker no
-  longer holds the job. An accepted file waits for verification and cannot replace anything until
-  every check Optimisarr runs on its own transcodes has passed against it too.
-- **A remote worker can now download the file it has been given.** Transfers resume where they left
-  off if the connection drops, and come with a checksum so the worker can confirm it received the
-  file intact. A worker can only ever fetch the exact original it was assigned, and only while it
-  still holds the job.
-- **The route for a worker to claim a job now exists, but no job can be offered through it yet.**
-  A paired sidecar can ask for work, and Optimisarr will only ever hand out a job where the worker
-  has proved it has the encoder, VMAF support, scratch space and spare concurrency that job needs.
-  A claimed job leaves the queue so this machine will not also run it, and comes straight back if
-  the worker gives it up or goes silent. In practice nothing is handed out: the offer names the
-  encoder recorded on the job, and that is only written when *this* machine transcodes, so a queued
-  job has none and the request is correctly refused as incomplete. Remote transcoding therefore has
-  no effect on your library in this release.
-- **Paired sidecars now report in, and the Workers list shows whether each one is reachable.** A
-  worker checks in every 30 seconds using the credential it was given at pairing, and is shown as
-  offline after two minutes of silence rather than on a single missed check-in, so a brief network
-  blip does not make the status flicker. Revoking a worker stops its check-ins immediately.
 
 ## 0.2.11 — 2026-08-13
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -537,6 +537,10 @@ The credential is returned exactly once, in the pairing response. Optimisarr sto
 fingerprint and cannot reproduce it. Revoking clears the fingerprint, which ends the worker's access
 outright because an absent fingerprint matches nothing; the row is kept for the audit trail.
 
+Remote workers are a preview: the whole surface exists only when the container starts with
+`OPTIMISARR_EXPERIMENTAL_REMOTE_WORKERS=true`; without it every route below answers `403` with code
+`workers.unavailable`, and `PUT /api/settings` refuses `remoteWorkersEnabled: true` with `400`.
+
 Remote workers are opt-in. While the `workers.remoteEnabled` setting is off — the default, and the
 value any upgrade inherits — `POST /api/workers/pairing-code`, `POST /api/workers/pair`, and
 `POST /api/workers/heartbeat` all answer `403 workers.disabled`. `GET /api/workers` and

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2063,6 +2063,10 @@
               "string"
             ]
           },
+          "remoteWorkersAvailable": {
+            "default": false,
+            "type": "boolean"
+          },
           "remoteWorkersEnabled": {
             "default": false,
             "type": "boolean"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -454,7 +454,8 @@ the replacement workflow is trustworthy.
      is needed. All accelerated paths fall back to software, HDR stays on its established
      software colour pipeline, and `n_threads` remains bounded to the core count.
 
-9. **Optional Windows and macOS sidecars for distributed transcoding: started.** Keep one
+9. **Optional Windows and macOS sidecars for distributed transcoding: started; hidden behind
+   `OPTIMISARR_EXPERIMENTAL_REMOTE_WORKERS` since 2026-09-10 until the list below is done.** Keep one
    Optimisarr container as the control plane and safety authority, while trusted desktop sidecars
    contribute otherwise-idle CPU/GPU capacity. A sidecar may receive a read-only source, transcode
    it, run the assigned VMAF policy, and return the candidate plus evidence; it can never replace,

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -41,6 +41,20 @@ environment:
   OPTIMISARR_ADMIN_TOKEN: "change-this-long-random-token"
 ```
 
+## Remote workers are a preview, off and hidden
+
+Distributed transcoding through paired sidecars is groundwork in this release, not a feature you
+can rely on: worker-side quality measurement, drain controls, signing, and the Windows sidecar are
+still to build. The **Remote workers** switch and the **Workers** tab therefore exist only when the
+container starts with the preview flag, and every worker route answers 403 without it:
+
+```yaml
+environment:
+  OPTIMISARR_EXPERIMENTAL_REMOTE_WORKERS: "true"
+```
+
+Leave it unset unless you are following the sidecar work on `dev`.
+
 When the token is set, the web UI asks for it before loading operational data.
 API clients must send it as a bearer token:
 

--- a/src/Optimisarr.Api/Diagnostics/DiagnosticsQueries.cs
+++ b/src/Optimisarr.Api/Diagnostics/DiagnosticsQueries.cs
@@ -83,7 +83,7 @@ internal static class DiagnosticsQueries
             version,
             DateTimeOffset.UtcNow,
             environment,
-            SettingsDto.From(queue),
+            SettingsDto.From(queue, settings.RemoteWorkersAvailable),
             stats,
             toolChecks,
             hardwareCapability,

--- a/src/Optimisarr.Api/Endpoints/SettingsEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/SettingsEndpoints.cs
@@ -30,7 +30,7 @@ internal static class SettingsEndpoints
             CancellationToken cancellationToken) =>
         {
             var queue = await settings.GetQueueSettingsAsync(cancellationToken);
-            return Results.Ok(SettingsDto.From(queue));
+            return Results.Ok(SettingsDto.From(queue, settings.RemoteWorkersAvailable));
         })
         .WithName("GetSettings");
 
@@ -39,7 +39,7 @@ internal static class SettingsEndpoints
             SettingsStore settings,
             CancellationToken cancellationToken) =>
         {
-            if (!SettingsRequestParser.TryParse(request, out var parsed, out var error))
+            if (!SettingsRequestParser.TryParse(request, settings.RemoteWorkersAvailable, out var parsed, out var error))
             {
                 return ApiErrors.BadRequest(error!.Code, error.Message);
             }
@@ -47,7 +47,7 @@ internal static class SettingsEndpoints
             await settings.SetQueueSettingsAsync(parsed, cancellationToken);
 
             var queue = await settings.GetQueueSettingsAsync(cancellationToken);
-            return Results.Ok(SettingsDto.From(queue));
+            return Results.Ok(SettingsDto.From(queue, settings.RemoteWorkersAvailable));
         })
         .WithName("UpdateSettings");
 

--- a/src/Optimisarr.Api/Endpoints/SetupEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/SetupEndpoints.cs
@@ -151,7 +151,7 @@ internal static class SetupEndpoints
                     "Setup can be applied only from the final review step.");
             }
 
-            if (!SettingsRequestParser.TryParse(request.Settings, out var queueSettings, out var error))
+            if (!SettingsRequestParser.TryParse(request.Settings, settings.RemoteWorkersAvailable, out var queueSettings, out var error))
             {
                 return ApiErrors.BadRequest(error!.Code, error.Message);
             }

--- a/src/Optimisarr.Api/Library/SettingsRequestParser.cs
+++ b/src/Optimisarr.Api/Library/SettingsRequestParser.cs
@@ -1,3 +1,4 @@
+using Optimisarr.Api.Workers;
 using Optimisarr.Core.Queue;
 using Optimisarr.Core.Verification;
 
@@ -9,10 +10,19 @@ internal static class SettingsRequestParser
 {
     public static bool TryParse(
         SettingsDto request,
+        bool remoteWorkersAvailable,
         out QueueSettings settings,
         out SettingsRequestError? error)
     {
         settings = default!;
+        if (request.RemoteWorkersEnabled && !remoteWorkersAvailable)
+        {
+            return Fail(
+                "workers.unavailable",
+                "Remote workers are groundwork in this release, not a feature. "
+                + $"Set {RemoteWorkersFeature.EnvironmentVariable}=true to try the preview.",
+                out error);
+        }
 
         if (request.MaxConcurrentJobs < 1)
             return Fail("settings.maxConcurrentJobs.minimum", "Max concurrent jobs must be at least 1.", out error);

--- a/src/Optimisarr.Api/Library/SettingsStore.cs
+++ b/src/Optimisarr.Api/Library/SettingsStore.cs
@@ -1,3 +1,4 @@
+using Optimisarr.Api.Workers;
 using Microsoft.EntityFrameworkCore;
 using Optimisarr.Core.Queue;
 using Optimisarr.Core.Settings;
@@ -23,8 +24,14 @@ public sealed record QueueSettings(
     bool RemoteWorkersEnabled = false);
 
 /// <summary>Reads and writes well-known application settings in the database.</summary>
-public sealed class SettingsStore(OptimisarrDbContext db)
+public sealed class SettingsStore(OptimisarrDbContext db, RemoteWorkersFeature? remoteWorkers = null)
 {
+    /// <summary>
+    /// Whether this deployment offers remote workers at all. The stored switch decides whether an
+    /// operator has turned them on; this decides whether the switch exists.
+    /// </summary>
+    public bool RemoteWorkersAvailable => remoteWorkers?.Available ?? false;
+
     private static readonly string[] LegacyVerificationSettingKeys =
     [
         "verification.qualityGateEnabled",

--- a/src/Optimisarr.Api/Program.cs
+++ b/src/Optimisarr.Api/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.EntityFrameworkCore;
 using Optimisarr.Api;
 using Optimisarr.Api.Diagnostics;
+using Optimisarr.Api.Workers;
 using Optimisarr.Api.Endpoints;
 using Optimisarr.Api.Library;
 using Optimisarr.Api.Metrics;
@@ -67,6 +68,7 @@ builder.Services.AddSingleton(new ImageComparisonReferenceService(transcodeFfmpe
 builder.Services.AddSingleton(new ImageMarkerService(Environment.GetEnvironmentVariable("OPTIMISARR_EXIFTOOL")));
 builder.Services.AddSingleton(new ImageMetadataService(Environment.GetEnvironmentVariable("OPTIMISARR_EXIFTOOL")));
 builder.Services.AddSingleton<VerificationService>();
+builder.Services.AddSingleton(RemoteWorkersFeature.FromEnvironment());
 builder.Services.AddScoped<SettingsStore>();
 builder.Services.AddScoped<ConfigPortabilityService>();
 builder.Services.AddScoped<LibraryInventoryService>();
@@ -269,9 +271,10 @@ internal sealed record SettingsDto(
     bool ReplacementAllowCrossFilesystem,
     bool DryRunMode,
     int ReplacementQuarantineRetentionDays,
-    bool RemoteWorkersEnabled = false)
+    bool RemoteWorkersEnabled = false,
+    bool RemoteWorkersAvailable = false)
 {
-    public static SettingsDto From(QueueSettings settings) => new(
+    public static SettingsDto From(QueueSettings settings, bool remoteWorkersAvailable = false) => new(
         settings.MaxConcurrentJobs,
         settings.MinFreeDiskBytes,
         settings.CpuThreadLimit,
@@ -282,7 +285,8 @@ internal sealed record SettingsDto(
         settings.ReplacementAllowCrossFilesystem,
         settings.DryRunMode,
         settings.ReplacementQuarantineRetentionDays,
-        settings.RemoteWorkersEnabled);
+        settings.RemoteWorkersEnabled,
+        remoteWorkersAvailable);
 }
 
 internal sealed record QueueStatusDto(

--- a/src/Optimisarr.Api/Workers/RemoteWorkersFeature.cs
+++ b/src/Optimisarr.Api/Workers/RemoteWorkersFeature.cs
@@ -1,0 +1,28 @@
+namespace Optimisarr.Api.Workers;
+
+/// <summary>
+/// Remote transcoding workers are groundwork in this release, not a feature a user can rely on:
+/// the macOS sidecar has done one end-to-end encode on a developer's machine, and worker-side
+/// quality measurement, drain controls, credential binding, resumable transfers, signing, and the
+/// Windows sidecar are still to build. Until that list is done the whole surface stays out of
+/// sight unless an operator opts into the preview with an environment variable, so a default
+/// install never meets a switch that leads somewhere unfinished.
+/// </summary>
+public sealed record RemoteWorkersFeature(bool Available)
+{
+    public const string EnvironmentVariable = "OPTIMISARR_EXPERIMENTAL_REMOTE_WORKERS";
+
+    public static RemoteWorkersFeature FromEnvironment() =>
+        new(IsEnabled(Environment.GetEnvironmentVariable(EnvironmentVariable)));
+
+    /// <summary>Accepts the spellings people actually type into a compose file.</summary>
+    public static bool IsEnabled(string? value)
+    {
+        var trimmed = value?.Trim();
+        return trimmed is not null
+            && (trimmed == "1"
+                || trimmed.Equals("true", StringComparison.OrdinalIgnoreCase)
+                || trimmed.Equals("yes", StringComparison.OrdinalIgnoreCase)
+                || trimmed.Equals("on", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Optimisarr.Api/Workers/WorkerGate.cs
+++ b/src/Optimisarr.Api/Workers/WorkerGate.cs
@@ -16,6 +16,15 @@ internal static class WorkerGate
         SettingsStore settings,
         CancellationToken cancellationToken)
     {
+        if (!settings.RemoteWorkersAvailable)
+        {
+            return Results.Json(
+                new ApiError("workers.unavailable",
+                    "Remote workers are groundwork in this release, not a feature. "
+                    + $"Set {RemoteWorkersFeature.EnvironmentVariable}=true to try the preview."),
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
         var queue = await settings.GetQueueSettingsAsync(cancellationToken);
         if (queue.RemoteWorkersEnabled)
         {

--- a/tests/Optimisarr.Tests/AdminTokenAuthEndpointTests.cs
+++ b/tests/Optimisarr.Tests/AdminTokenAuthEndpointTests.cs
@@ -1,3 +1,4 @@
+using Optimisarr.Api.Workers;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -926,6 +927,8 @@ public sealed class AdminTokenAuthEndpointTests
             Directory.CreateDirectory(LibraryDirectory);
             Environment.SetEnvironmentVariable(AdminTokenAuth.EnvironmentVariable, Token);
             Environment.SetEnvironmentVariable("OPTIMISARR_CONFIG_DIR", _configDir);
+            // The worker tests exercise the preview; the availability tests turn it off per host.
+            Environment.SetEnvironmentVariable(RemoteWorkersFeature.EnvironmentVariable, "true");
         }
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/tests/Optimisarr.Tests/RemoteWorkersAvailabilityTests.cs
+++ b/tests/Optimisarr.Tests/RemoteWorkersAvailabilityTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Optimisarr.Api.Workers;
+
+namespace Optimisarr.Tests;
+
+/// <summary>
+/// Remote workers are groundwork in this release. Without the experimental flag the switch must not
+/// exist, the setting must not be acceptable, and every worker route must refuse, whatever an older
+/// database may have stored. With the flag, the opt-in behaves as it always did.
+/// </summary>
+[Collection(TokenedApiCollection.Name)]
+public sealed class RemoteWorkersAvailabilityTests
+{
+    private readonly AdminTokenAuthEndpointTests.TokenedApi _api;
+
+    public RemoteWorkersAvailabilityTests(AdminTokenAuthEndpointTests.TokenedApi api) => _api = api;
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("1", true)]
+    [InlineData("yes", true)]
+    [InlineData(" on ", true)]
+    [InlineData("false", false)]
+    [InlineData("0", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void The_flag_accepts_the_spellings_people_type(string? value, bool expected) =>
+        Assert.Equal(expected, RemoteWorkersFeature.IsEnabled(value));
+
+    private WebApplicationFactory<Program> WithoutThePreview() =>
+        _api.WithWebHostBuilder(builder => builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<RemoteWorkersFeature>();
+            services.AddSingleton(new RemoteWorkersFeature(Available: false));
+        }));
+
+    private static HttpClient Admin(WebApplicationFactory<Program> host)
+    {
+        var client = host.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", AdminTokenAuthEndpointTests.TokenedApi.Token);
+        return client;
+    }
+
+    [Fact]
+    public async Task Without_the_flag_settings_say_workers_are_not_available()
+    {
+        using var host = WithoutThePreview();
+        var settings = await (await Admin(host).GetAsync("/api/settings")).Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.False(settings.GetProperty("remoteWorkersAvailable").GetBoolean());
+    }
+
+    [Fact]
+    public async Task With_the_flag_settings_say_workers_are_available()
+    {
+        var settings = await (await Admin(_api).GetAsync("/api/settings")).Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.True(settings.GetProperty("remoteWorkersAvailable").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Without_the_flag_the_switch_cannot_be_turned_on()
+    {
+        using var host = WithoutThePreview();
+        var admin = Admin(host);
+        var current = await (await admin.GetAsync("/api/settings")).Content.ReadFromJsonAsync<JsonElement>();
+        using var doc = JsonDocument.Parse(current.GetRawText());
+        var payload = new Dictionary<string, object?>();
+        foreach (var property in doc.RootElement.EnumerateObject())
+        {
+            payload[property.Name] = JsonSerializer.Deserialize<object?>(property.Value.GetRawText());
+        }
+        payload["remoteWorkersEnabled"] = true;
+
+        using var saved = await admin.PutAsJsonAsync("/api/settings", payload);
+
+        Assert.Equal(HttpStatusCode.BadRequest, saved.StatusCode);
+        var error = await saved.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("workers.unavailable", error.GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public async Task Without_the_flag_every_worker_route_refuses()
+    {
+        using var host = WithoutThePreview();
+        var admin = Admin(host);
+
+        using var pairing = await admin.PostAsync("/api/workers/pairing-code", null);
+        Assert.Equal(HttpStatusCode.Forbidden, pairing.StatusCode);
+        var error = await pairing.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("workers.unavailable", error.GetProperty("code").GetString());
+    }
+}

--- a/tests/Optimisarr.Tests/SettingsRequestParserTests.cs
+++ b/tests/Optimisarr.Tests/SettingsRequestParserTests.cs
@@ -12,7 +12,7 @@ public sealed class SettingsRequestParserTests
     {
         var request = ValidRequest() with { HdrToneMapMode = null };
 
-        var parsed = SettingsRequestParser.TryParse(request, out var settings, out var error);
+        var parsed = SettingsRequestParser.TryParse(request, remoteWorkersAvailable: true, out var settings, out var error);
 
         Assert.True(parsed);
         Assert.Null(error);
@@ -26,7 +26,7 @@ public sealed class SettingsRequestParserTests
     {
         var request = ValidRequest() with { HdrToneMapMode = value };
 
-        var parsed = SettingsRequestParser.TryParse(request, out _, out var error);
+        var parsed = SettingsRequestParser.TryParse(request, remoteWorkersAvailable: true, out _, out var error);
 
         Assert.False(parsed);
         Assert.Equal("settings.hdrToneMapMode.invalid", error?.Code);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -334,6 +334,9 @@ export type Settings = {
   replacementQuarantineRetentionDays: number
   /** Opt-in. Off by default: one container stays the complete, uncomplicated way to run this. */
   remoteWorkersEnabled: boolean
+  /** Groundwork only in this release: the switch and the Workers tab exist only when the server
+   * was started with OPTIMISARR_EXPERIMENTAL_REMOTE_WORKERS=true. */
+  remoteWorkersAvailable: boolean
 }
 
 export type TimedCleanupPreview = {

--- a/web/src/lib/pages/Settings.svelte
+++ b/web/src/lib/pages/Settings.svelte
@@ -405,6 +405,7 @@
     replacementAllowCrossFilesystem: false,
     dryRunMode: false,
     remoteWorkersEnabled: false,
+    remoteWorkersAvailable: false,
     replacementQuarantineRetentionDays: 0,
   })
 
@@ -413,9 +414,11 @@
     { key: 'connections', label: i18n.m.settings.tab_connections },
     { key: 'notifications', label: i18n.m.settings.tab_notifications },
     { key: 'tools', label: i18n.m.settings.tab_tools },
-    // Only once opted in: a default single-container install should not have to wonder what a
-    // remote worker is.
-    ...(settings.remoteWorkersEnabled ? [{ key: 'workers' as TabKey, label: i18n.m.settings.tab_workers }] : []),
+    // Only once opted in, and only where the server offers the preview at all: a default
+    // single-container install should not have to wonder what a remote worker is.
+    ...(settings.remoteWorkersAvailable && settings.remoteWorkersEnabled
+      ? [{ key: 'workers' as TabKey, label: i18n.m.settings.tab_workers }]
+      : []),
     { key: 'backup', label: i18n.m.settings.tab_backup },
   ])
 
@@ -732,13 +735,16 @@
         hint={i18n.m.settings.dry_run_hint}
       />
     </div>
-    <div class="mt-5 max-w-2xl border-t border-slate-200 pt-5 dark:border-slate-800">
-      <Toggle
-        bind:checked={settings.remoteWorkersEnabled}
-        label={i18n.m.settings.remote_workers}
-        hint={i18n.m.settings.remote_workers_hint}
-      />
-    </div>
+    {#if settings.remoteWorkersAvailable}
+      <!-- Groundwork, not a feature: the server shows this only under the experimental flag. -->
+      <div class="mt-5 max-w-2xl border-t border-slate-200 pt-5 dark:border-slate-800">
+        <Toggle
+          bind:checked={settings.remoteWorkersEnabled}
+          label={i18n.m.settings.remote_workers}
+          hint={i18n.m.settings.remote_workers_hint}
+        />
+      </div>
+    {/if}
     <div class="mt-5 max-w-2xl border-t border-slate-200 pt-5 dark:border-slate-800">
       <Toggle
         bind:checked={settings.replacementAllowCrossFilesystem}


### PR DESCRIPTION
## Outcome
Remote workers are groundwork, not a feature: one end-to-end encode on a developer's Mac, with worker-side VMAF, drain controls, credential binding, resumable transfers, signing and the Windows sidecar still to build (roadmap item 9). Yet the **Remote workers** switch and the **Workers** tab were reachable on every install, and the changelog read as finished work. Ahead of 0.2.12, the surface is hidden unless the container starts with `OPTIMISARR_EXPERIMENTAL_REMOTE_WORKERS=true`.

- `RemoteWorkersFeature` is read once from the environment and registered as a singleton; `SettingsStore.RemoteWorkersAvailable` carries it to the gate, the settings response (`remoteWorkersAvailable`), the request parser and the page.
- Without the flag: the switch and the tab do not render; `PUT /api/settings` with `remoteWorkersEnabled: true` is a 400 `workers.unavailable`; every worker route answers 403 `workers.unavailable` regardless of what an older database stored.
- With the flag: the opt-in behaves exactly as before (all existing worker tests run with it on).
- Changelog: the twelve worker entries move under one lead bullet that says what they are and that they are hidden. Docs: configuration guide section, API note, roadmap item 9 stamped.

## Verification
`dotnet build -warnaserror` clean; `dotnet test` 1854 passed (new: flag spellings, settings say unavailable, switch refused, worker route refused, and available under the flag); `check_openapi.py --update` then `--check` clean; `check_docs.py` passed; web `npm run check` (svelte-check, locales, setup tests) and `npm run build` clean. Playwright e2e left to CI; its fixtures omit the new field, which reads as unavailable and hides the switch, matching their `remoteWorkersEnabled: false`.

## Risk
None to media or data. An operator who had turned remote workers on from a dev build sees the switch and tab disappear until they set the flag; the stored setting is untouched.