### PR TITLE
Synchronise the 0.2.12 release metadata into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.12 — 2026-09-10
+
 ### Fixed
 
 - **A corrupt hardware decode is now re-encoded with software decode instead of being retried at

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Shared metadata for all projects. Version drives the /api/health response and the
        "optimisarr=<version>" marker stamped into optimised files. -->
   <PropertyGroup>
-    <Version>0.2.11</Version>
+    <Version>0.2.12</Version>
     <Product>Optimisarr</Product>
     <Authors>Optimisarr contributors</Authors>
     <Copyright>Copyright (C) 2026 Optimisarr contributors</Copyright>

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2372,7 +2372,7 @@
   "info": {
     "description": "HTTP API for Optimisarr \u2014 safe, verified FFmpeg transcoding for self-hosted media libraries. This contract is still pre-1.0 and may change between releases.",
     "title": "Optimisarr API",
-    "version": "0.2.11.0"
+    "version": "0.2.12.0"
   },
   "openapi": "3.1.1",
   "paths": {


### PR DESCRIPTION
Step 4 of the release flow in docs/development/releasing.md: application version 0.2.12, dated changelog heading, and OpenAPI version synchronised from main after tag v0.2.12, with a fresh `## Unreleased` section above. `check_release_metadata.py` is consistent in development context. No code change.