### PR TITLE
Let an operator drain a remote worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@
   per-title VMAF libraries still run here whatever the choice says, and the editor says that too.
   New `workPlacement` on the library API and in config backups (an older backup restores as
   *Here or on a worker*); migration `AddLibraryWorkPlacement`.
+- **A remote worker can be drained.** `POST /api/workers/{id}/drain` asks a worker to finish what
+  it holds and take no more: its leases still renew and deliver, the claim route offers it nothing,
+  the local dispatcher stops counting it as a worker a *Prefer a worker* library could wait for,
+  and its heartbeat response says `draining` so the sidecar can show it. `DELETE
+  /api/workers/{id}/drain` resumes it, and refuses a revoked worker with `409` because only
+  pairing again brings one back. `GET /api/workers` gains `drainRequestedAt` and `heldLeases`, the
+  jobs a drain is waiting on. Migration `AddWorkerDrain`.
 
 ## 0.2.12 — 2026-09-10
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -562,7 +562,8 @@ different numbers on purpose: declaring a worker offline on one missed beat woul
 flap on a single dropped packet. The control plane stamps the last-seen time from its own clock, so
 a sidecar with a wrong clock cannot claim to be alive, and the heartbeat response carries the
 interval so a sidecar paces itself from the server rather than hard-coding a value that could drift
-out of step with the threshold.
+out of step with the threshold. The response also says whether the worker is `draining`, so a
+sidecar learns of a drain on its next check-in rather than at the end of its job.
 
 | Method | Endpoint | Purpose |
 |---|---|---|
@@ -573,6 +574,8 @@ out of step with the threshold.
 | `POST` | `/api/workers/heartbeat` | A paired sidecar checks in and reports free scratch space and current concurrency. Open route; authenticated by the worker credential as `Authorization: Bearer`, not the admin token. `401` when the credential is absent, unknown, or revoked. |
 | `GET` | `/api/workers` | List paired workers with an `online` flag the server computes from its own liveness rule. Never returns credential fingerprints. |
 | `DELETE` | `/api/workers/{id}` | Revoke a worker. Clears its credential and drains it; keeps the record. |
+| `POST` | `/api/workers/{id}/drain` | Ask a worker to finish what it holds and take no more. Its leases still renew and deliver; only new claims are refused. Idempotent; returns the worker row with `drainRequestedAt` set and `heldLeases`, the jobs the drain is waiting on. |
+| `DELETE` | `/api/workers/{id}/drain` | Resume a drained worker. `409 worker.revoked` for a revoked worker, which can only come back by pairing again. |
 | `POST` | `/api/workers/claim` | Ask for work. Returns one assignment, or `204` when nothing matches the worker's proved capabilities — the ordinary answer, not an error. Worker credential. |
 | `POST` | `/api/workers/leases/{leaseId}/renew` | Extend a claim. `403` if the lease belongs to another worker, `409` once it has lapsed. |
 | `POST` | `/api/workers/leases/{leaseId}/release` | Give a job back. It returns to the queue immediately. |

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -460,6 +460,9 @@
       },
       "HeartbeatResponse": {
         "properties": {
+          "draining": {
+            "type": "boolean"
+          },
           "heartbeatIntervalSeconds": {
             "format": "int32",
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -493,7 +496,8 @@
           "workerId",
           "protocolVersion",
           "serverTimeUtc",
-          "heartbeatIntervalSeconds"
+          "heartbeatIntervalSeconds",
+          "draining"
         ],
         "type": "object"
       },
@@ -2286,6 +2290,13 @@
           "architecture": {
             "type": "string"
           },
+          "drainRequestedAt": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "freeScratchBytes": {
             "format": "int64",
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -2299,6 +2310,14 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "heldLeases": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
           },
           "id": {
             "format": "int32",
@@ -2375,7 +2394,9 @@
           "pairedAt",
           "lastSeenAt",
           "revokedAt",
-          "online"
+          "online",
+          "drainRequestedAt",
+          "heldLeases"
         ],
         "type": "object"
       }
@@ -5182,6 +5203,104 @@
           },
           "401": {
             "description": "Admin token required when OPTIMISARR_ADMIN_TOKEN is set on the server."
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      }
+    },
+    "/api/workers/{id}/drain": {
+      "delete": {
+        "operationId": "ResumeWorker",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkerDto"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Admin token required when OPTIMISARR_ADMIN_TOKEN is set on the server."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Conflict"
+          }
+        },
+        "tags": [
+          "Workers"
+        ]
+      },
+      "post": {
+        "operationId": "DrainWorker",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkerDto"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Admin token required when OPTIMISARR_ADMIN_TOKEN is set on the server."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Not Found"
           }
         },
         "tags": [

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -583,9 +583,12 @@ the replacement workflow is trustworthy.
      minutes), or *Only on workers* — as one filter over the shared queue that the local dispatcher
      and a worker's claim both read from `WorkPlacementPolicy`, so a job keeps its priority and
      age wherever it is allowed to run. While remote workers are off every placement runs on the
-     server, which is what keeps a library from stalling on a feature not in use. **Still to
-     build:** drain controls, and an "on a worker" placement for adaptive libraries once selection
-     can hand the final encode over.
+     server, which is what keeps a library from stalling on a feature not in use. **Landed the same
+     day: drain controls on the server.** `POST`/`DELETE /api/workers/{id}/drain` is a claim
+     refusal and nothing more — held leases renew and deliver, the heartbeat answers `draining`,
+     and a draining worker no longer counts as one a *Prefer a worker* library could wait for.
+     **Still to build:** the Workers tab controls for drain and resume, and an "on a worker"
+     placement for adaptive libraries once selection can hand the final encode over.
    - **The next four pieces, in dependency order (recorded 2026-09-01).** Everything below waits on
      the first, and the first two are server work of similar size to a normal feature slice.
 

--- a/sidecars/macos/Sources/SidecarCore/SidecarClient.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarClient.swift
@@ -58,6 +58,9 @@ public struct HeartbeatResult: Sendable, Equatable {
     public let workerId: Int
     public let protocolVersion: Int
     public let heartbeatInterval: TimeInterval
+    /// The operator asked this machine to finish what it holds and take no more. Absent from an
+    /// older server's response, which reads as not draining.
+    public let draining: Bool
 }
 
 /// Performs HTTP so the client can be tested without a network. Bodies that may be gigabytes —
@@ -210,7 +213,8 @@ public struct SidecarClient: Sendable {
                 // Guarded rather than trusted outright: a zero or negative interval from a
                 // malformed response would otherwise become a tight polling loop against the
                 // server.
-                heartbeatInterval: TimeInterval(max(5, seconds))
+                heartbeatInterval: TimeInterval(max(5, seconds)),
+                draining: body["draining"] as? Bool ?? false
             )
         case 401:
             // Unknown or revoked. Either way this credential is finished and the app must stop

--- a/sidecars/macos/Tests/SidecarCoreTests/SidecarClientTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/SidecarClientTests.swift
@@ -158,6 +158,8 @@ struct HeartbeatTests {
 
         #expect(transport.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer secret")
         #expect(result.heartbeatInterval == 30)
+        // An older server says nothing about draining, which reads as not draining.
+        #expect(result.draining == false)
     }
 
     @Test("a revoked credential is reported distinctly so the app can stop using it")

--- a/src/Optimisarr.Api/Endpoints/WorkerEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerEndpoints.cs
@@ -21,7 +21,11 @@ internal sealed record WorkerDto(
     DateTimeOffset PairedAt,
     DateTimeOffset? LastSeenAt,
     DateTimeOffset? RevokedAt,
-    bool Online);
+    bool Online,
+    /// <summary>When an operator asked this worker to stop taking work; null while it takes work.</summary>
+    DateTimeOffset? DrainRequestedAt,
+    /// <summary>Leases this worker holds right now: the jobs a drain is waiting on.</summary>
+    int HeldLeases);
 
 /// <summary>The PIN an operator reads off the screen and types into a sidecar.</summary>
 internal sealed record PairingCodeDto(string Code, DateTimeOffset ExpiresUtc, int AttemptsRemaining);
@@ -66,7 +70,9 @@ internal sealed record HeartbeatResponse(
     int WorkerId,
     int ProtocolVersion,
     DateTimeOffset ServerTimeUtc,
-    int HeartbeatIntervalSeconds);
+    int HeartbeatIntervalSeconds,
+    /// <summary>True while an operator has asked the worker to finish what it holds and take no more.</summary>
+    bool Draining);
 
 internal static class WorkerEndpoints
 {
@@ -225,7 +231,8 @@ internal static class WorkerEndpoints
                 worker.Id,
                 worker.ProtocolVersion,
                 worker.LastSeenAt.Value,
-                (int)WorkerLiveness.HeartbeatInterval.TotalSeconds));
+                (int)WorkerLiveness.HeartbeatInterval.TotalSeconds,
+                worker.DrainRequestedAt is not null));
         })
         .WithName("WorkerHeartbeat")
         .Produces<HeartbeatResponse>()
@@ -240,11 +247,63 @@ internal static class WorkerEndpoints
                 .OrderBy(worker => worker.Id)
                 .ToListAsync(cancellationToken);
 
+            var held = await HeldLeasesByWorkerAsync(db, cancellationToken);
             var now = DateTimeOffset.UtcNow;
-            return Results.Ok(workers.Select(w => ToDto(w, now)).ToList());
+            return Results.Ok(workers.Select(w => ToDto(w, now, held.GetValueOrDefault(w.Id))).ToList());
         })
         .WithName("ListWorkers")
         .Produces<IReadOnlyList<WorkerDto>>();
+
+        // Draining is a claim refusal and nothing more: the worker keeps what it holds, finishes
+        // and delivers it, and is offered nothing new until resumed. Idempotent both ways, so an
+        // operator clicking twice, or a retried request, cannot flip the state back.
+        app.MapPost("/api/workers/{id:int}/drain", async (
+            int id,
+            OptimisarrDbContext db,
+            CancellationToken cancellationToken) =>
+        {
+            var worker = await db.Workers.FirstOrDefaultAsync(w => w.Id == id, cancellationToken);
+            if (worker is null)
+            {
+                return ApiErrors.NotFound("worker.notFound", $"No worker with id {id}.", new { id });
+            }
+
+            worker.DrainRequestedAt ??= DateTimeOffset.UtcNow;
+            await db.SaveChangesAsync(cancellationToken);
+            return await WorkerRowAsync(worker, db, cancellationToken);
+        })
+        .WithName("DrainWorker")
+        .Produces<WorkerDto>()
+        .Produces<ApiError>(StatusCodes.Status404NotFound);
+
+        app.MapDelete("/api/workers/{id:int}/drain", async (
+            int id,
+            OptimisarrDbContext db,
+            CancellationToken cancellationToken) =>
+        {
+            var worker = await db.Workers.FirstOrDefaultAsync(w => w.Id == id, cancellationToken);
+            if (worker is null)
+            {
+                return ApiErrors.NotFound("worker.notFound", $"No worker with id {id}.", new { id });
+            }
+
+            // A revoked worker cannot authenticate, so "resume" would promise work it can never
+            // claim. Re-pairing is the only way back, and this says so.
+            if (worker.RevokedAt is not null)
+            {
+                return Results.Json(
+                    new ApiError("worker.revoked", "A revoked worker cannot resume; pair it again."),
+                    statusCode: StatusCodes.Status409Conflict);
+            }
+
+            worker.DrainRequestedAt = null;
+            await db.SaveChangesAsync(cancellationToken);
+            return await WorkerRowAsync(worker, db, cancellationToken);
+        })
+        .WithName("ResumeWorker")
+        .Produces<WorkerDto>()
+        .Produces<ApiError>(StatusCodes.Status404NotFound)
+        .Produces<ApiError>(StatusCodes.Status409Conflict);
 
         // Revocation clears the fingerprint rather than deleting the row, so the pairing stays in
         // the audit trail while the credential stops matching anything at all.
@@ -278,7 +337,27 @@ internal static class WorkerEndpoints
         _ => "That pairing code is not correct."
     };
 
-    private static WorkerDto ToDto(Worker worker, DateTimeOffset nowUtc) => new(
+    private static async Task<IResult> WorkerRowAsync(
+        Worker worker,
+        OptimisarrDbContext db,
+        CancellationToken cancellationToken)
+    {
+        var held = await db.JobLeases
+            .CountAsync(lease => lease.WorkerId == worker.Id && lease.State == LeaseState.Held, cancellationToken);
+        return Results.Ok(ToDto(worker, DateTimeOffset.UtcNow, held));
+    }
+
+    private static async Task<Dictionary<int, int>> HeldLeasesByWorkerAsync(
+        OptimisarrDbContext db,
+        CancellationToken cancellationToken) =>
+        await db.JobLeases
+            .AsNoTracking()
+            .Where(lease => lease.State == LeaseState.Held)
+            .GroupBy(lease => lease.WorkerId)
+            .Select(group => new { WorkerId = group.Key, Count = group.Count() })
+            .ToDictionaryAsync(group => group.WorkerId, group => group.Count, cancellationToken);
+
+    private static WorkerDto ToDto(Worker worker, DateTimeOffset nowUtc, int heldLeases) => new(
         worker.Id,
         worker.Name,
         worker.OperatingSystem,
@@ -294,7 +373,9 @@ internal static class WorkerEndpoints
         worker.RevokedAt,
         // Revoked workers are never "online" whatever their last heartbeat said, so the UI cannot
         // show a green light next to a worker that can no longer authenticate.
-        worker.RevokedAt is null && WorkerLiveness.IsOnline(worker.LastSeenAt, nowUtc));
+        worker.RevokedAt is null && WorkerLiveness.IsOnline(worker.LastSeenAt, nowUtc),
+        worker.DrainRequestedAt,
+        heldLeases);
 
     /// <summary>
     /// Accepts a capability name, case-insensitively. An absent value means the worker claims no

--- a/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
@@ -84,6 +84,13 @@ internal static class WorkerLeaseEndpoints
                 return Results.NoContent();
             }
 
+            // An operator asked this worker to finish what it holds and take no more. Its renewals
+            // and deliveries are untouched; only new offers stop.
+            if (worker.DrainRequestedAt is not null)
+            {
+                return Results.NoContent();
+            }
+
             var held = await db.JobLeases
                 .CountAsync(lease => lease.WorkerId == worker.Id && lease.State == LeaseState.Held, cancellationToken);
             if (held >= worker.MaxConcurrency)

--- a/src/Optimisarr.Api/Queue/QueueDispatcher.cs
+++ b/src/Optimisarr.Api/Queue/QueueDispatcher.cs
@@ -454,6 +454,7 @@ public sealed class QueueDispatcher(
                     .AsNoTracking()
                     .AnyAsync(
                         worker => worker.RevokedAt == null
+                            && worker.DrainRequestedAt == null
                             && worker.MaxConcurrency > 0
                             && worker.LastSeenAt != null
                             && worker.LastSeenAt > offlineBefore,

--- a/src/Optimisarr.Data/Migrations/20260910114550_AddWorkerDrain.Designer.cs
+++ b/src/Optimisarr.Data/Migrations/20260910114550_AddWorkerDrain.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Optimisarr.Data;
 
@@ -10,9 +11,11 @@ using Optimisarr.Data;
 namespace Optimisarr.Data.Migrations
 {
     [DbContext(typeof(OptimisarrDbContext))]
-    partial class OptimisarrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260910114550_AddWorkerDrain")]
+    partial class AddWorkerDrain
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/src/Optimisarr.Data/Migrations/20260910114550_AddWorkerDrain.cs
+++ b/src/Optimisarr.Data/Migrations/20260910114550_AddWorkerDrain.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Optimisarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkerDrain : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "DrainRequestedAt",
+                table: "Workers",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DrainRequestedAt",
+                table: "Workers");
+        }
+    }
+}

--- a/src/Optimisarr.Data/Worker.cs
+++ b/src/Optimisarr.Data/Worker.cs
@@ -54,6 +54,14 @@ public sealed class Worker
 
     public DateTimeOffset? LastSeenAt { get; set; }
 
+    /// <summary>
+    /// Set when an operator asks the worker to stop taking new work. A draining worker keeps every
+    /// lease it holds, finishes and delivers them, and is simply offered nothing more until this
+    /// is cleared. Distinct from the worker reporting zero concurrency itself, which is the
+    /// sidecar's own choice and changes with every heartbeat.
+    /// </summary>
+    public DateTimeOffset? DrainRequestedAt { get; set; }
+
     /// <summary>Set when an operator revokes the worker. A revoked row is kept for the audit trail.</summary>
     public DateTimeOffset? RevokedAt { get; set; }
 }

--- a/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
+++ b/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
@@ -170,6 +170,88 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
         return job.Id;
     }
 
+    private async Task<int> WorkerIdNamed(string name)
+    {
+        using var scope = _api.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
+        return await db.Workers.Where(w => w.Name == name && w.RevokedAt == null)
+            .OrderByDescending(w => w.Id).Select(w => w.Id).FirstAsync();
+    }
+
+    [Fact]
+    public async Task A_draining_worker_is_offered_nothing_until_it_is_resumed()
+    {
+        // Drain is a claim refusal and nothing more. The queue is untouched, the worker keeps
+        // checking in, and resuming hands it the same job it was refused a moment earlier.
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Drainer");
+        var workerId = await WorkerIdNamed("Drainer");
+        var jobId = await QueueAJob();
+        var admin = Admin();
+
+        using var drained = await admin.PostAsync($"/api/workers/{workerId}/drain", null);
+        Assert.Equal(HttpStatusCode.OK, drained.StatusCode);
+        var drainedRow = await drained.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.NotEqual(JsonValueKind.Null, drainedRow.GetProperty("drainRequestedAt").ValueKind);
+
+        using var refused = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.NoContent, refused.StatusCode);
+        Assert.Equal(JobStatus.Queued, await StatusOf(jobId));
+
+        using var resumed = await admin.DeleteAsync($"/api/workers/{workerId}/drain");
+        Assert.Equal(HttpStatusCode.OK, resumed.StatusCode);
+        var resumedRow = await resumed.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(JsonValueKind.Null, resumedRow.GetProperty("drainRequestedAt").ValueKind);
+
+        using var offered = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.OK, offered.StatusCode);
+        Assert.Equal(JobStatus.Leased, await StatusOf(jobId));
+    }
+
+    [Fact]
+    public async Task Draining_keeps_the_lease_a_worker_already_holds()
+    {
+        // The whole point of drain over revoke: work in flight finishes. The lease still renews,
+        // the operator can see it is what the drain is waiting on, and the sidecar hears about
+        // the drain on its next check-in rather than at the end of the job.
+        await EnableRemoteWorkers();
+        var worker = await PairCapableWorker("Finisher");
+        var workerId = await WorkerIdNamed("Finisher");
+        await QueueAJob();
+        using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.OK, claim.StatusCode);
+        var leaseId = (await claim.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("leaseId").GetString()!;
+
+        using var drained = await Admin().PostAsync($"/api/workers/{workerId}/drain", null);
+        Assert.Equal(HttpStatusCode.OK, drained.StatusCode);
+        Assert.Equal(1, (await drained.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("heldLeases").GetInt32());
+
+        using var renewed = await worker.PostAsJsonAsync($"/api/workers/leases/{leaseId}/renew", new { });
+        Assert.Equal(HttpStatusCode.OK, renewed.StatusCode);
+
+        using var beat = await worker.PostAsJsonAsync("/api/workers/heartbeat", new
+        {
+            freeScratchBytes = 500L * 1024 * 1024 * 1024,
+            maxConcurrency = 1,
+        });
+        Assert.Equal(HttpStatusCode.OK, beat.StatusCode);
+        Assert.True((await beat.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("draining").GetBoolean());
+    }
+
+    [Fact]
+    public async Task A_revoked_worker_cannot_be_resumed()
+    {
+        await EnableRemoteWorkers();
+        await PairCapableWorker("Gone");
+        var workerId = await WorkerIdNamed("Gone");
+        var admin = Admin();
+        (await admin.DeleteAsync($"/api/workers/{workerId}")).EnsureSuccessStatusCode();
+
+        using var resumed = await admin.DeleteAsync($"/api/workers/{workerId}/drain");
+
+        Assert.Equal(HttpStatusCode.Conflict, resumed.StatusCode);
+    }
+
     private async Task<JobStatus> StatusOf(int jobId)
     {
         using var scope = _api.Services.CreateScope();

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -741,6 +741,10 @@ export type Worker = {
   revokedAt: string | null
   /** Computed by the server from its own liveness rule, so the UI never invents a second one. */
   online: boolean
+  /** When an operator asked the worker to finish what it holds and take no more; null while it takes work. */
+  drainRequestedAt: string | null
+  /** Leases the worker holds right now: what a drain is waiting on. */
+  heldLeases: number
 }
 
 export type WorkerPairingCode = {
@@ -1095,6 +1099,8 @@ export const api = {
 
   workers: () => request<Worker[]>('/api/workers'),
   revokeWorker: (id: number) => request<void>(`/api/workers/${id}`, { method: 'DELETE' }),
+  drainWorker: (id: number) => request<Worker>(`/api/workers/${id}/drain`, { method: 'POST' }),
+  resumeWorker: (id: number) => request<Worker>(`/api/workers/${id}/drain`, { method: 'DELETE' }),
   issueWorkerPairingCode: () =>
     request<WorkerPairingCode>('/api/workers/pairing-code', { method: 'POST' }),
   /** Null when no code is currently on screen — the ordinary resting state, not an error. */


### PR DESCRIPTION
Second slice of the sidecar allocation work (#123 merged first): an operator can drain a remote worker. Server side and API contract only; the Workers tab controls wait for the mockup verdict.

## What changes

- `Worker.DrainRequestedAt` (migration `AddWorkerDrain`). Null means taking work.
- `POST /api/workers/{id}/drain` asks a worker to finish what it holds and take no more; `DELETE /api/workers/{id}/drain` resumes it. Both idempotent; resume answers `409 worker.revoked` for a revoked worker, since only pairing again brings one back. Both return the worker row.
- Drain is a claim refusal and nothing more: `/api/workers/claim` answers `204` to a draining worker, while renew, source fetch and result delivery are untouched.
- The heartbeat response gains `draining`, and the macOS sidecar client parses it (absent from an older server reads as false).
- `GET /api/workers` gains `drainRequestedAt` and `heldLeases`, the jobs a drain is waiting on.
- The local dispatcher no longer counts a draining worker as one a *Prefer a worker* library could wait for.

## Verification

- `dotnet test`: 1879 passed. New: draining worker refused until resumed (and then handed the same job), a drain keeps and renews an existing lease and the heartbeat reports it, a revoked worker cannot be resumed.
- `swift test --filter SidecarClientTests`: 14 passed.
- `check_openapi.py --update`, `check_release_metadata.py`, `check_docs.py`, `npm run check`, `npm run build` clean.
- Docs: CHANGELOG, `docs/api.md` (routes and heartbeat field), roadmap item 9.
