### PR TITLE
Hand the job back before the Mac sleeps or the sidecar quits, and start at login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@
   Otherwise the server measures VMAF itself and writes why on the worker's card. Every other gate
   is still repeated here, and a low score fails the candidate the ordinary way. New stage
   `Measuring`; migration `AddLeaseQualityEvidence`.
+- **The macOS sidecar survives a lid and a quit.** While a job runs it holds a system activity
+  assertion, so macOS neither naps the app nor idles the machine to sleep under an encode. When
+  the Mac sleeps anyway the job is handed back first and the server reassigns it at once, rather
+  than two minutes later when the lease lapses; check-ins resume on wake. Quitting the app
+  mid-job hands the job back before exiting. The menu gains **Start at login**, registered
+  through the system's login-item service.
 
 ## 0.2.12 — 2026-09-10
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -600,8 +600,10 @@ the replacement workflow is trustworthy.
      both hashes, and the server parses, pools and judges them with `RemoteQualityEvidenceValidator`
      at verification — accepted only when bound to the delivered hash and a policy at least as
      strict as now required, otherwise measured again here with the reason on the worker's card.
-     **Still to build:** an "on a worker" placement for adaptive libraries once selection can
-     hand the final encode over.
+     **Sidecar lifecycle, same day:** an activity assertion while a job runs (no App Nap, no
+     idle sleep), the job handed back before the Mac sleeps or the app quits, check-ins resumed on
+     wake, and a Start-at-login toggle via `SMAppService`. **Still to build:** an "on a worker"
+     placement for adaptive libraries once selection can hand the final encode over.
    - **The next four pieces, in dependency order (recorded 2026-09-01).** Everything below waits on
      the first, and the first two are server work of similar size to a normal feature slice.
 

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -34,6 +34,14 @@ server has verified it can finish a job that came back — asks for work. A job 
 Scratch lives under `~/Library/Application Support/OptimisarrSidecar/work` and is removed on every
 exit path. One job at a time.
 
+While a job runs the app holds a system activity assertion, so macOS neither naps it nor idles the
+machine to sleep under an encode. When the Mac does sleep — a closed lid, a chosen sleep — the job
+is handed back to the server first, so it is reassigned at once rather than after the lease lapses,
+and check-ins resume the moment the Mac wakes. Quitting the app mid-job hands the job back the same
+way before the app exits. **Start at login** in the menu registers the app as a login item through
+the system's own service, so it also appears under System Settings › General › Login Items; it needs
+the app to run from the built bundle rather than a bare build directory.
+
 This loop has run end to end on real hardware: `LiveWorkLoopTests` pairs with a running server,
 claims a queued job, encodes it with the bundled ffmpeg and delivers it, and the server's own
 verification — every gate, VMAF included — then judges the candidate. Run it against a server that

--- a/sidecars/macos/Sources/OptimisarrSidecar/LoginItem.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/LoginItem.swift
@@ -1,0 +1,19 @@
+import ServiceManagement
+
+/// Whether this app opens at login, through the system's own login-item service so it appears in
+/// System Settings › General › Login Items like any other app and can be switched off there too.
+/// Requires the app to run from a real bundle, which `make-app.sh` produces; from a bare build
+/// directory the service refuses and the toggle says so.
+enum LoginItem {
+    static var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    static func setEnabled(_ enabled: Bool) throws {
+        if enabled {
+            try SMAppService.mainApp.register()
+        } else {
+            try SMAppService.mainApp.unregister()
+        }
+    }
+}

--- a/sidecars/macos/Sources/OptimisarrSidecar/OptimisarrSidecarApp.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/OptimisarrSidecarApp.swift
@@ -62,7 +62,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Shown on first launch too, while nothing is paired. Someone who has just installed this has
     /// no reason to know it lives in the menu bar, and if the icon is hidden they would otherwise
     /// see nothing happen at all.
+    /// The sleep and wake hooks live here rather than in the session so SidecarCore stays free
+    /// of AppKit and its lifecycle can be tested by calling the same two methods directly.
+    private func observePowerEvents() {
+        let centre = NSWorkspace.shared.notificationCenter
+        centre.addObserver(forName: NSWorkspace.willSleepNotification, object: nil, queue: .main) { _ in
+            Task { @MainActor in await AppState.shared.session.systemWillSleep() }
+        }
+        centre.addObserver(forName: NSWorkspace.didWakeNotification, object: nil, queue: .main) { _ in
+            Task { @MainActor in AppState.shared.session.systemDidWake() }
+        }
+    }
+
+    /// Quitting mid-encode hands the job back first, so the server reassigns it now rather than
+    /// after the lease lapses. The reply is deferred only for as long as that one call takes.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        Task { @MainActor in
+            await AppState.shared.session.prepareToQuit()
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
+        observePowerEvents()
         // Deferred rather than run inline. Restoring reads the Keychain, and anything that touches
         // the Keychain can in principle block; doing it here on the launch path once left the app
         // running with no menu bar icon and no window at all, because it was stuck behind a modal

--- a/sidecars/macos/Sources/OptimisarrSidecar/SidecarMenu.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/SidecarMenu.swift
@@ -10,6 +10,8 @@ struct SidecarMenu: View {
 
     @State private var serverAddress = ""
     @State private var pin = ""
+    @State private var startAtLogin = LoginItem.isEnabled
+    @State private var loginItemError: String?
     @State private var isPairing = false
 
     var body: some View {
@@ -117,6 +119,24 @@ struct SidecarMenu: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+
+            Toggle("Start at login", isOn: Binding(
+                get: { startAtLogin },
+                set: { wanted in
+                    do {
+                        try LoginItem.setEnabled(wanted)
+                        startAtLogin = LoginItem.isEnabled
+                        loginItemError = nil
+                    } catch {
+                        startAtLogin = LoginItem.isEnabled
+                        loginItemError = "Could not change the login item: \(error.localizedDescription)"
+                    }
+                }))
+                .font(.caption)
+            if let loginItemError {
+                Text(loginItemError).font(.caption).foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
 
             Button("Forget this pairing") {
                 session.unpair()

--- a/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
@@ -53,6 +53,9 @@ public final class SidecarSession: ObservableObject {
     private var pairing: StoredPairing?
     private var heartbeatTask: Task<Void, Never>?
     private var jobTask: Task<Void, Never>?
+    /// Held while a job runs so macOS neither naps the app nor idles the machine to sleep under
+    /// an encode. A lid close still sleeps the Mac; that path hands the job back first.
+    private var activity: NSObjectProtocol?
 
     public init(
         client: SidecarClient = SidecarClient(),
@@ -123,9 +126,63 @@ public final class SidecarSession: ObservableObject {
         // hands the lease back, so the server can reassign rather than wait for it to lapse.
         jobTask?.cancel()
         jobTask = nil
+        endActivity()
         try? store.clear()
         pairing = nil
         status = .unpaired
+    }
+
+    /// Stops the job in flight, if any, and waits until the lease has been handed back, so the
+    /// server can reassign at once rather than after the lease lapses. The reason is what the
+    /// menu shows afterwards, in place of the runner's generic cancellation wording.
+    public func stopWork(because reason: String) async {
+        guard let task = jobTask else { return }
+        task.cancel()
+        await task.value
+        if case let .released(jobId, _) = lastOutcome {
+            lastOutcome = .released(jobId: jobId, reason: reason)
+        }
+    }
+
+    /// The Mac is about to sleep. A sleeping worker cannot renew, so the lease would lapse and
+    /// the job go back to the queue anyway, two minutes later and with the server unsure why.
+    /// Handing it back now is the same outcome, sooner and explained. Check-ins stop until wake.
+    public func systemWillSleep() async {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        await stopWork(because: "This Mac went to sleep, so the job was handed back for another machine to take.")
+        if pairing != nil, case .working = status {
+            status = .unreachable(reason: "Asleep")
+        }
+    }
+
+    /// Awake again: check in straight away rather than waiting out the old interval, so the
+    /// Workers tab sees the machine back within seconds and it can take work again.
+    public func systemDidWake() {
+        guard pairing != nil else { return }
+        startHeartbeat()
+    }
+
+    /// Called before the app exits. The heartbeat stops so the server sees a clean gap rather
+    /// than a beat followed by silence, and any job is handed back rather than left to lapse.
+    public func prepareToQuit() async {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        await stopWork(because: "The sidecar was quit, so the job was handed back.")
+    }
+
+    private func beginActivity() {
+        guard activity == nil else { return }
+        activity = ProcessInfo.processInfo.beginActivity(
+            options: [.userInitiated, .idleSystemSleepDisabled],
+            reason: "Encoding for Optimisarr")
+    }
+
+    private func endActivity() {
+        if let activity {
+            ProcessInfo.processInfo.endActivity(activity)
+        }
+        activity = nil
     }
 
     private func startHeartbeat() {
@@ -194,6 +251,7 @@ public final class SidecarSession: ObservableObject {
 
         status = .working(jobId: assignment.jobId, progress: .fetchingSource)
         let jobId = assignment.jobId
+        beginActivity()
         // The task holds the session for the job's duration, which is intended: a job is stopped
         // by cancelling this task (see unpair), never by the session quietly going away under it.
         jobTask = Task { [weak self] in
@@ -213,6 +271,7 @@ public final class SidecarSession: ObservableObject {
     private func finish(_ outcome: JobOutcome, workerId: Int) {
         lastOutcome = outcome
         jobTask = nil
+        endActivity()
         if pairing != nil {
             status = .connected(workerId: workerId, lastCheckIn: Date())
         }

--- a/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
@@ -40,6 +40,26 @@ final class ScriptedTransport: HTTPTransport, @unchecked Sendable {
     }
 }
 
+/// A job that runs until it is cancelled, then reports what the real runner would after handing
+/// the lease back. Lets the sleep and quit paths be walked without ffmpeg or a server.
+final class HangingExecutor: WorkExecutor, @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var started = false
+    private(set) var cancelled = false
+
+    func execute(
+        _ assignment: Assignment, pairing: StoredPairing,
+        progress: @escaping @Sendable (JobProgress) -> Void
+    ) async -> JobOutcome {
+        lock.withLock { started = true }
+        while !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 2_000_000)
+        }
+        lock.withLock { cancelled = true }
+        return .released(jobId: assignment.jobId, reason: "The job was cancelled on this machine.")
+    }
+}
+
 @MainActor
 @Suite("Session lifecycle")
 struct SidecarSessionTests {
@@ -154,6 +174,77 @@ struct SidecarSessionTests {
         }
 
         #expect(session.status.summary == "Connected")
+    }
+
+    private static let beat: ScriptedTransport.Reply =
+        .init(status: 200, json: ["workerId": 11, "protocolVersion": 1, "heartbeatIntervalSeconds": 30])
+    private static let claim: ScriptedTransport.Reply = .init(status: 200, json: [
+        "leaseId": "lease-1", "jobId": 12, "sourceBytes": 4096, "videoEncoder": "libx265",
+        "renewWithinSeconds": 30, "arguments": ["-i", "{{input}}", "{{output}}.mp4"], "outputExtension": "mp4",
+        "quality": ["measure": false, "model": "vmaf_v0.6.1", "frameSubsample": 1, "clipVmaf": false,
+                    "minimumHarmonicMean": 93.0, "minimumMinimum": 80.0],
+    ])
+
+    private func workingSession(_ executor: HangingExecutor) async throws -> SidecarSession {
+        let store = InMemoryCredentialStore(
+            stored: StoredPairing(serverAddress: "localhost:8787", credential: "c", workerId: 11))
+        // Beat, claim, then whatever comes next (a release, a beat) is answered 204.
+        let transport = ScriptedTransport([Self.beat, Self.claim, .init(status: 204, json: [:])])
+        let session = SidecarSession(
+            client: SidecarClient(transport: transport), store: store,
+            capabilities: SidecarCapabilities(name: "Test", videoEncoders: ["libx265"], maxConcurrency: 1),
+            executor: executor,
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+        session.restore()
+        try await waitFor { executor.started }
+        return session
+    }
+
+    @Test("going to sleep hands the job back at once and stops checking in")
+    func sleepHandsTheJobBack() async throws {
+        let executor = HangingExecutor()
+        let session = try await workingSession(executor)
+
+        await session.systemWillSleep()
+
+        #expect(executor.cancelled)
+        guard case let .released(jobId, reason) = session.lastOutcome else {
+            Issue.record("expected a release, got \(String(describing: session.lastOutcome))")
+            return
+        }
+        #expect(jobId == 12)
+        #expect(reason.contains("went to sleep"))
+    }
+
+    @Test("quitting hands the job back before the app exits")
+    func quitHandsTheJobBack() async throws {
+        let executor = HangingExecutor()
+        let session = try await workingSession(executor)
+
+        await session.prepareToQuit()
+
+        #expect(executor.cancelled)
+        guard case let .released(_, reason) = session.lastOutcome else {
+            Issue.record("expected a release, got \(String(describing: session.lastOutcome))")
+            return
+        }
+        #expect(reason.contains("quit"))
+    }
+
+    @Test("stopping work when idle is a no-op")
+    func stopWhenIdle() async throws {
+        let store = InMemoryCredentialStore(
+            stored: StoredPairing(serverAddress: "localhost:8787", credential: "c", workerId: 11))
+        let (session, _) = session([Self.beat], store: store)
+        session.restore()
+        try await waitFor {
+            if case .connected = session.status { return true }
+            return false
+        }
+
+        await session.stopWork(because: "nothing")
+
+        #expect(session.lastOutcome == nil)
     }
 
     /// Polls a condition rather than sleeping a fixed time, so the tests stay fast and are not


### PR DESCRIPTION
The macOS sidecar now survives a lid and a quit, and can start at login.

## What changes

- **No App Nap, no idle sleep under an encode.** The session holds a `ProcessInfo` activity assertion (`userInitiated`, `idleSystemSleepDisabled`) for the life of a job and releases it when the job ends, however it ends.
- **Sleep hands the job back first.** On `NSWorkspace.willSleepNotification` the app cancels the job, which makes the runner release the lease, and waits for that release before the Mac sleeps; check-ins stop. On wake it checks in immediately rather than waiting out the old interval. Without this a sleeping worker went silent, the lease lapsed after two minutes, and the server requeued the job with no explanation; now it is reassigned at once and the menu says why.
- **Quit hands the job back too.** `applicationShouldTerminate` defers the reply for exactly as long as the release takes.
- **Start at login** toggle in the menu, via `SMAppService.mainApp`, so it also appears in System Settings › Login Items. Needs the built bundle; from a bare build directory the toggle reports the refusal.
- AppKit stays out of `SidecarCore`: the app forwards the two power events to `systemWillSleep()` / `systemDidWake()`, and `prepareToQuit()`, all testable without a menu bar.

## Verification

- `swift test`: 72 passed. New: sleep hands the job back at once with the sleep reason; quit hands it back; stopping work when idle is a no-op. `swift build` of the app target clean.
- Docs: CHANGELOG, roadmap item 9, sidecar README. `check_docs.py` and release metadata clean.
