### PR TITLE
Let a remote worker decode in hardware when it proved it can

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@
   than two minutes later when the lease lapses; check-ins resume on wake. Quitting the app
   mid-job hands the job back before exiting. The menu gains **Start at login**, registered
   through the system's login-item service.
+- **A remote worker decodes in hardware when it proved it can.** A worker that proved
+  VideoToolbox decode by a real decode is sent a command that decodes with it, for VideoToolbox
+  encodes, with the frames left in system memory so every software filter still applies; the
+  claim requires the proved decoder and the lease records it. A delivered candidate that fails
+  verification with the signature of decoder corruption is not failed: the job is requeued to
+  decode in software wherever it runs next, and the worker's card says why. Migration
+  `AddDecodeFacts`.
 
 ## 0.2.12 — 2026-09-10
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -598,7 +598,9 @@ The assignment's `quality` block carries the server's own libvmaf command per me
 (`commands`, with `{{distorted}}`, `{{reference}}` and `{{log}}` placeholders) and the `sampling`
 those windows represent, fixed at claim and recorded on the lease. A worker that returns its logs
 before delivering spares the server the VMAF pass, which is roughly half the cost of verification;
-every other gate is still repeated locally. Evidence that is missing, names other bytes, or was
+every other gate is still repeated locally. The command decodes with a hardware decoder only
+when the worker proved it and it belongs to the encoder's family; the lease records the decoder,
+and a candidate that fails with decoder corruption requeues the job for software decode. Evidence that is missing, names other bytes, or was
 measured under a weaker policy than the library now requires is not used: the server measures
 VMAF itself and writes the reason on the worker's card.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -602,7 +602,10 @@ the replacement workflow is trustworthy.
      strict as now required, otherwise measured again here with the reason on the worker's card.
      **Sidecar lifecycle, same day:** an activity assertion while a job runs (no App Nap, no
      idle sleep), the job handed back before the Mac sleeps or the app quits, check-ins resumed on
-     wake, and a Start-at-login toggle via `SMAppService`. **Still to build:** an "on a worker"
+     wake, and a Start-at-login toggle via `SMAppService`. **Hardware decode on the worker:** a
+     proved VideoToolbox decoder is used for VideoToolbox encodes with frames left in system
+     memory, recorded on the lease, and a corrupt result requeues the job for software decode
+     (`Job.PreferSoftwareDecode`). **Still to build:** an "on a worker"
      placement for adaptive libraries once selection can hand the final encode over.
    - **The next four pieces, in dependency order (recorded 2026-09-01).** Everything below waits on
      the first, and the first two are server work of similar size to a normal feature slice.

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -59,6 +59,12 @@ build lists VideoToolbox whether or not a given machine can open it, so listing 
 sidecar advertise encoders that fail on first use. Hardware *decode* is proved the same way — encode
 a clip, decode it back with VideoToolbox engaged, and both halves must succeed.
 
+When the server has seen that proof, the command it sends decodes with VideoToolbox for a
+VideoToolbox encode, with the frames left in system memory so its filters still apply; the
+validator accepts `-hwaccel videotoolbox` and nothing else under that option. If a candidate decoded
+that way comes back with the signature of decoder corruption, the server requeues the job to decode
+in software and says so on this worker's card.
+
 A machine that proves nothing reports nothing, and Optimisarr's capability matcher fails closed, so
 such a worker is never offered work. Honesty here is the safety mechanism: a sidecar that overstated
 itself would have jobs scheduled onto it that could only fail.

--- a/sidecars/macos/Sources/SidecarCore/AssignmentCommand.swift
+++ b/sidecars/macos/Sources/SidecarCore/AssignmentCommand.swift
@@ -12,6 +12,7 @@ public enum AssignmentCommandError: Error, Equatable, Sendable {
     case invalidOutputExtension(String)
     case pathLikeValue(String)
     case strayPlaceholder(String)
+    case unknownHardwareDecoder(String)
 }
 
 /// The server's argument array, checked before this machine will run it.
@@ -40,8 +41,12 @@ public struct AssignmentCommand: Sendable, Equatable {
         "-global_quality", "-rc_mode", "-quality", "-lossless",
         "-tune", "-maxrate", "-minrate", "-bufsize", "-x264-params", "-x265-params",
         "-spatial-aq", "-temporal-aq", "-fps_mode", "-enc_time_base:v:0",
-        "-ss", "-t", "-movflags",
+        "-ss", "-t", "-movflags", "-hwaccel",
     ]
+
+    /// The one hardware decoder this platform has. The server names it only when this machine
+    /// proved it by a real decode; anything else would be a command for some other machine.
+    static let hardwareDecoders: Set<String> = ["videotoolbox"]
 
     public let arguments: [String]
     public let outputExtension: String
@@ -80,6 +85,10 @@ public struct AssignmentCommand: Sendable, Equatable {
                     throw AssignmentCommandError.inputMustBePlaceholder(value)
                 }
                 inputs += 1
+            } else if token == "-hwaccel" {
+                guard hardwareDecoders.contains(value) else {
+                    throw AssignmentCommandError.unknownHardwareDecoder(value)
+                }
             } else {
                 try Self.checkValue(value)
             }

--- a/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
@@ -96,6 +96,20 @@ struct AssignmentCommandTests {
         }
     }
 
+    @Test("this platform's own hardware decoder is accepted, any other is refused by name")
+    func hardwareDecoder() throws {
+        var apple = serverCommand
+        apple.insert(contentsOf: ["-hwaccel", "videotoolbox"], at: 0)
+        let command = try AssignmentCommand.validate(apple, outputExtension: "mp4")
+        #expect(command.arguments.prefix(2) == ["-hwaccel", "videotoolbox"])
+
+        var other = serverCommand
+        other.insert(contentsOf: ["-hwaccel", "cuda"], at: 0)
+        #expect(throws: AssignmentCommandError.unknownHardwareDecoder("cuda")) {
+            try AssignmentCommand.validate(other, outputExtension: "mp4")
+        }
+    }
+
     @Test("a second input is refused however it is spelt")
     func refusesSecondInput() {
         var tampered = serverCommand

--- a/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
@@ -203,7 +203,8 @@ internal static class WorkerLeaseEndpoints
 
                 var requirements = new JobRequirements(
                     VideoEncoder: assignment.VideoEncoder,
-                    HardwareDecoder: null,
+                    // Named only when the command actually uses one, and then it must be proved.
+                    HardwareDecoder: assignment.HardwareDecoder,
                     // Only a job whose policy will judge VMAF needs a worker that can score it.
                     Vmaf: assignment.Verification.QualityGateEnabled ? VmafCapability.Cpu : VmafCapability.None,
                     // Scratch for the candidate plus headroom; a worker that cannot hold the output
@@ -232,6 +233,7 @@ internal static class WorkerLeaseEndpoints
                     // Bound to the lease so delivery names the candidate by the contract, not by
                     // the source; the replacement's final extension comes from that name.
                     OutputExtension = assignment.OutputExtension,
+                    HardwareDecoder = assignment.HardwareDecoder,
                     // What the worker was asked to measure, fixed now so the evidence it returns is
                     // judged against this, not against a policy that may have changed since.
                     QualityContractJson = assignment.Quality is null

--- a/src/Optimisarr.Api/Queue/QueueDispatcher.cs
+++ b/src/Optimisarr.Api/Queue/QueueDispatcher.cs
@@ -745,7 +745,33 @@ public sealed class QueueDispatcher(
                     cancellationToken);
             }
 
-            await VerifyAndFinishAsync(jobId, candidatePath, work.Value, cancellationToken, remoteQuality: delivered.Accepted);
+            var disposition = await VerifyAndFinishAsync(
+                jobId, candidatePath, work.Value, cancellationToken,
+                // A worker's hardware decode can corrupt frames as a local one can; the retry
+                // cannot happen on the worker, so it is a requeue with software decode required.
+                softwareDecodeRetryAvailable: deliveredLease!.HardwareDecoder is not null,
+                remoteQuality: delivered.Accepted);
+            if (disposition == VerificationDisposition.RetryWithSoftwareDecode)
+            {
+                DeleteWorkOutput(candidatePath);
+                await WithJobAsync(jobId, job =>
+                {
+                    job.PreferSoftwareDecode = true;
+                    job.Status = JobStatus.Queued;
+                    job.Progress = 0;
+                    job.WorkOutputPath = null;
+                    job.UpdatedAt = DateTimeOffset.UtcNow;
+                }, cancellationToken);
+                logger.LogWarning(
+                    "Job {JobId}: the candidate {Worker} decoded with {Decoder} showed decoder corruption; requeued to be encoded with software decode",
+                    jobId, deliveredBy.Name, deliveredLease.HardwareDecoder);
+                await RecordWorkerProblemAsync(
+                    deliveredBy.Id,
+                    $"Its {deliveredLease.HardwareDecoder} decode of {Path.GetFileName(work.Value.Original.Path)} produced corrupt frames; the job was requeued to decode in software.",
+                    cancellationToken);
+                return;
+            }
+
             await RecordDeliveredVerdictAsync(jobId, deliveredBy.Id, cancellationToken);
         }
         catch (JobNoLongerEligibleException ex)
@@ -1211,7 +1237,8 @@ public sealed class QueueDispatcher(
             Path.GetExtension(work.Spec.OutputPath).TrimStart('.'),
             work.VerificationPolicy,
             QualityScoreCommandBuilder.ModelVersionFor(width, height),
-            quality));
+            quality,
+            work.UsedHardwareDecode ? RemoteHardwareDecoder(worker, work.VideoEncoder) : null));
     }
 
     /// <summary>
@@ -1576,10 +1603,17 @@ public sealed class QueueDispatcher(
         // reordering around an input seek can move the clip several frames before its VMAF
         // reference. Hardware encoding remains enabled. Normal jobs retain the existing
         // hardware-decode path and transparent software fallback.
-        // A remote worker's decoders are not yet part of the contract, so its command decodes in
-        // software: the path every filter here is proven on, and the one that needs no device.
-        var hardwareDecode = !placement.IsRemote && HardwareDecodePolicy.ShouldUse(
-            queueSettings.HardwareDecode,
+        // A remote worker decodes in hardware only with a decoder it proved by a real decode, and
+        // only for the encoder family that decoder belongs to; otherwise its command decodes in
+        // software, the path every filter here is proven on. A job whose hardware-decoded candidate
+        // already came back corrupt decodes in software wherever it runs next.
+        var remoteHardwareDecoder = placement.RemoteWorker is { } decodingWorker
+            ? RemoteHardwareDecoder(decodingWorker, videoEncoderName)
+            : null;
+        var hardwareDecode = !job.PreferSoftwareDecode
+            && (placement.IsRemote ? remoteHardwareDecoder is not null : true)
+            && HardwareDecodePolicy.ShouldUse(
+            placement.IsRemote || queueSettings.HardwareDecode,
             isDisposable,
             spec.Kind,
             spec.VideoCodec,
@@ -1686,8 +1720,20 @@ public sealed class QueueDispatcher(
             hardwareToneMap,
             media.Width is > 0 && media.Height is > 0
                 ? new PictureSize(media.Width.Value, media.Height.Value)
-                : null);
+                : null,
+            SoftwareDecodeRetryReason: job.PreferSoftwareDecode ? HardwareDecodeFallback.SoftwareDecodeRetryReason : null);
     }
+
+    /// <summary>
+    /// The decoder a worker's command may use: VideoToolbox, when the worker proved it and the
+    /// encoder is VideoToolbox too. Other families are not paired with a worker decoder yet.
+    /// </summary>
+    private static string? RemoteHardwareDecoder(WorkerCapabilities worker, string? videoEncoder) =>
+        videoEncoder is not null
+        && videoEncoder.EndsWith("_videotoolbox", StringComparison.OrdinalIgnoreCase)
+        && worker.HardwareDecoders.Any(decoder => string.Equals(decoder, "videotoolbox", StringComparison.OrdinalIgnoreCase))
+            ? "videotoolbox"
+            : null;
 
     /// <summary>
     /// Runs a bounded, fail-open preparation search for an adaptive library. Every candidate uses

--- a/src/Optimisarr.Api/Workers/RemoteWorkPlan.cs
+++ b/src/Optimisarr.Api/Workers/RemoteWorkPlan.cs
@@ -16,7 +16,9 @@ public sealed record RemoteAssignment(
     VerificationPolicy Verification,
     string VmafModel,
     /// <summary>The VMAF measurement the worker is asked to make; null when the policy has no gate.</summary>
-    RemoteQualityContract? Quality = null);
+    RemoteQualityContract? Quality = null,
+    /// <summary>The hardware decoder the command uses, which the worker must have proved; null for software.</summary>
+    string? HardwareDecoder = null);
 
 /// <summary>
 /// Whether a job may be offered to a worker, and why not when it may not. A refusal is the

--- a/src/Optimisarr.Core/Queue/FfmpegCommandBuilder.cs
+++ b/src/Optimisarr.Core/Queue/FfmpegCommandBuilder.cs
@@ -137,7 +137,7 @@ public static class FfmpegCommandBuilder
         // A hardware tone-map consumes the decoded GPU surfaces directly. All other HDR-to-SDR
         // work retains the software colour pipeline and therefore needs system-memory frames.
         var useHardwareDecode = hardwareDecode
-            && family is EncoderFamily.Nvenc or EncoderFamily.Qsv or EncoderFamily.Vaapi
+            && family is EncoderFamily.Nvenc or EncoderFamily.Qsv or EncoderFamily.Vaapi or EncoderFamily.VideoToolbox
             && (!spec.TonemapToSdr || useHardwareToneMap);
 
         AppendHardwareDeviceInit(args, family, useHardwareDecode);
@@ -581,6 +581,14 @@ public static class FfmpegCommandBuilder
                 args.Add("cuda");
                 args.Add("-hwaccel_output_format");
                 args.Add("cuda");
+                break;
+            case EncoderFamily.VideoToolbox when hardwareDecode:
+                // Decode with VideoToolbox but leave the frames in system memory: without an
+                // output format ffmpeg downloads them, so every software filter here still works
+                // and the encoder uploads once. Apple's zero-copy path is not needed for the
+                // encoder to be fast, and a proven software-filter graph is worth more.
+                args.Add("-hwaccel");
+                args.Add("videotoolbox");
                 break;
             case EncoderFamily.Vaapi:
                 args.Add("-vaapi_device");

--- a/src/Optimisarr.Data/Job.cs
+++ b/src/Optimisarr.Data/Job.cs
@@ -199,6 +199,13 @@ public sealed class Job
 
     public DateTimeOffset? VerifiedAt { get; set; }
 
+    /// <summary>
+    /// Set when a hardware-decoded candidate for this job failed verification with the signature
+    /// of decoder corruption, so the next attempt — here or on a worker — decodes in software. The
+    /// local path retries within one run; a remote job cannot, so the fact is kept on the job.
+    /// </summary>
+    public bool PreferSoftwareDecode { get; set; }
+
     public DateTimeOffset EnqueuedAt { get; set; } = DateTimeOffset.UtcNow;
 
     public DateTimeOffset? StartedAt { get; set; }

--- a/src/Optimisarr.Data/JobLease.cs
+++ b/src/Optimisarr.Data/JobLease.cs
@@ -63,6 +63,13 @@ public sealed class JobLease
     public string? DeliveredSha256 { get; set; }
 
     /// <summary>
+    /// The hardware decoder the assignment told the worker to use, or null for software decode.
+    /// Recorded so a delivered candidate that fails with the signature of decoder corruption can be
+    /// tried again in software rather than failed outright.
+    /// </summary>
+    public string? HardwareDecoder { get; set; }
+
+    /// <summary>
     /// Seconds of output the worker's ffmpeg had produced at its latest renewal. The server turns
     /// this into a fraction against the source duration, because the worker never learns it.
     /// </summary>

--- a/src/Optimisarr.Data/Migrations/20260910133300_AddDecodeFacts.Designer.cs
+++ b/src/Optimisarr.Data/Migrations/20260910133300_AddDecodeFacts.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Optimisarr.Data;
 
@@ -10,9 +11,11 @@ using Optimisarr.Data;
 namespace Optimisarr.Data.Migrations
 {
     [DbContext(typeof(OptimisarrDbContext))]
-    partial class OptimisarrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260910133300_AddDecodeFacts")]
+    partial class AddDecodeFacts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/src/Optimisarr.Data/Migrations/20260910133300_AddDecodeFacts.cs
+++ b/src/Optimisarr.Data/Migrations/20260910133300_AddDecodeFacts.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Optimisarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDecodeFacts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "PreferSoftwareDecode",
+                table: "Jobs",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HardwareDecoder",
+                table: "JobLeases",
+                type: "TEXT",
+                maxLength: 32,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PreferSoftwareDecode",
+                table: "Jobs");
+
+            migrationBuilder.DropColumn(
+                name: "HardwareDecoder",
+                table: "JobLeases");
+        }
+    }
+}

--- a/src/Optimisarr.Data/OptimisarrDbContext.cs
+++ b/src/Optimisarr.Data/OptimisarrDbContext.cs
@@ -192,6 +192,7 @@ public sealed class OptimisarrDbContext(DbContextOptions<OptimisarrDbContext> op
             entity.Property(lease => lease.QualitySourceSha256).HasMaxLength(64);
             entity.Property(lease => lease.QualityCandidateSha256).HasMaxLength(64);
             entity.Property(lease => lease.DeliveredSha256).HasMaxLength(64);
+            entity.Property(lease => lease.HardwareDecoder).HasMaxLength(32);
 
             // Removing a job removes its leases; a lease without a job claims nothing.
             entity.HasOne(lease => lease.Job)

--- a/tests/Optimisarr.Tests/FfmpegCommandBuilderTests.cs
+++ b/tests/Optimisarr.Tests/FfmpegCommandBuilderTests.cs
@@ -379,7 +379,9 @@ public sealed class FfmpegCommandBuilderTests
         Assert.DoesNotContain("-maxrate", args);
         Assert.DoesNotContain("-init_hw_device", args);
         Assert.DoesNotContain("-vaapi_device", args);
-        Assert.DoesNotContain("-hwaccel", args);
+        // Its decoder is the one hardware option it does take, and only as a plain -hwaccel: no
+        // device, no pinned output format, no upload filter.
+        Assert.DoesNotContain("-hwaccel_output_format", args);
         Assert.DoesNotContain("hwupload", string.Join(" ", args));
     }
 
@@ -553,6 +555,30 @@ public sealed class FfmpegCommandBuilderTests
         // The encoder is still QSV with its constant-quality knob.
         Assert.Equal("hevc_qsv", args[IndexOf(args, "-c:v:0") + 1]);
         Assert.Equal("24", args[IndexOf(args, "-global_quality") + 1]);
+    }
+
+    [Fact]
+    public void Videotoolbox_hardware_decode_adds_hwaccel_but_leaves_frames_in_system_memory()
+    {
+        var args = FfmpegCommandBuilder.Build(
+            Reencode(crf: 24), videoEncoder: "hevc_videotoolbox", hardwareDecode: true);
+
+        // Decoded by VideoToolbox, before -i; no output format, so ffmpeg downloads the frames
+        // and every software filter still works. That is the whole reason the option is safe.
+        var hwaccelIndex = IndexOf(args, "-hwaccel");
+        Assert.Equal("videotoolbox", args[hwaccelIndex + 1]);
+        Assert.True(hwaccelIndex < IndexOf(args, "-i"));
+        Assert.DoesNotContain("-hwaccel_output_format", args);
+        Assert.Equal("hevc_videotoolbox", args[IndexOf(args, "-c:v:0") + 1]);
+    }
+
+    [Fact]
+    public void Videotoolbox_without_hardware_decode_names_no_hwaccel()
+    {
+        var args = FfmpegCommandBuilder.Build(
+            Reencode(crf: 24), videoEncoder: "hevc_videotoolbox", hardwareDecode: false);
+
+        Assert.DoesNotContain("-hwaccel", args);
     }
 
     [Fact]

--- a/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
+++ b/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
@@ -83,7 +83,10 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
     private Task<HttpClient> PairWorkerWithEncoders(string name, params string[] encoders) =>
         PairWorkerWithEncoders(name, 1, encoders);
 
-    private async Task<HttpClient> PairWorkerWithEncoders(string name, int concurrency, params string[] encoders)
+    private Task<HttpClient> PairWorkerWithEncoders(string name, int concurrency, params string[] encoders) =>
+        PairWorker(name, concurrency, encoders, decoders: []);
+
+    private async Task<HttpClient> PairWorker(string name, int concurrency, string[] encoders, string[] decoders)
     {
         var admin = Admin();
         var issued = await admin.PostAsync("/api/workers/pairing-code", null);
@@ -99,7 +102,7 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
             protocolMinimum = 1,
             protocolMaximum = 1,
             videoEncoders = encoders,
-            hardwareDecoders = Array.Empty<string>(),
+            hardwareDecoders = decoders,
             vmaf = "Cpu",
             freeScratchBytes = 500L * 1024 * 1024 * 1024,
             maxConcurrency = concurrency,
@@ -369,6 +372,69 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
         Assert.Contains("{{reference}}", command);
         Assert.Contains(command, arg => arg.Contains("log_path={{log}}") && arg.Contains("model=version=vmaf_v0.6.1"));
         Assert.Equal("-", command[^1]);
+    }
+
+    [Fact]
+    public async Task A_worker_that_proved_its_decoder_is_told_to_decode_in_hardware()
+    {
+        // The decoder is used only where it was proved by a real decode, and only with the
+        // encoder family it belongs to; the lease records it so a corrupt result can be retried
+        // in software rather than failed.
+        await EnableRemoteWorkers();
+        var worker = await PairWorker("Apple", 1, ["hevc_videotoolbox"], ["videotoolbox"]);
+        var jobId = await QueueAJob(videoEncoder: null);
+
+        using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.OK, claim.StatusCode);
+        var arguments = (await claim.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("arguments").EnumerateArray().Select(a => a.GetString()!).ToList();
+
+        var hwaccel = arguments.IndexOf("-hwaccel");
+        Assert.True(hwaccel >= 0, string.Join(" ", arguments));
+        Assert.Equal("videotoolbox", arguments[hwaccel + 1]);
+        Assert.Equal("hevc_videotoolbox", arguments[arguments.IndexOf("-c:v:0") + 1]);
+
+        using var scope = _api.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
+        var lease = await db.JobLeases.SingleAsync(l => l.JobId == jobId && l.State == Optimisarr.Core.Workers.LeaseState.Held);
+        Assert.Equal("videotoolbox", lease.HardwareDecoder);
+    }
+
+    [Fact]
+    public async Task A_worker_without_a_proved_decoder_decodes_in_software()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairWorker("Apple", 1, ["hevc_videotoolbox"], []);
+        await QueueAJob(videoEncoder: null);
+
+        using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.OK, claim.StatusCode);
+        var arguments = (await claim.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("arguments").EnumerateArray().Select(a => a.GetString()!).ToList();
+
+        Assert.DoesNotContain("-hwaccel", arguments);
+    }
+
+    [Fact]
+    public async Task A_job_whose_hardware_decode_came_back_corrupt_is_decoded_in_software_next_time()
+    {
+        await EnableRemoteWorkers();
+        var worker = await PairWorker("Apple", 1, ["hevc_videotoolbox"], ["videotoolbox"]);
+        var jobId = await QueueAJob(videoEncoder: null);
+        using (var scope = _api.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<OptimisarrDbContext>();
+            var job = await db.Jobs.SingleAsync(j => j.Id == jobId);
+            job.PreferSoftwareDecode = true;
+            await db.SaveChangesAsync();
+        }
+
+        using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.OK, claim.StatusCode);
+        var arguments = (await claim.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("arguments").EnumerateArray().Select(a => a.GetString()!).ToList();
+
+        Assert.DoesNotContain("-hwaccel", arguments);
     }
 
     [Fact]


### PR DESCRIPTION
A remote worker now decodes in hardware when it proved it can, and a corrupt result is retried in software rather than failed.

## What changes

- **VideoToolbox decode in the command builder.** `-hwaccel videotoolbox` before the input, with no output format, so ffmpeg leaves the frames in system memory and every software filter still applies. No device init, no upload filter.
- **The worker's proof drives the remote command.** For a VideoToolbox encode, the server names the decoder only when the worker advertised `videotoolbox`, which the sidecar advertises only after a real decode succeeded. The claim's requirements name that decoder so the matcher enforces it, and the lease records it. The existing software-filter rule still applies: a downscale, crop or frame-rate cap keeps software decode, as it does locally.
- **Corruption on a worker is a requeue, not a failure.** Local encodes retry a hardware-decoded candidate in software within one run; a remote job cannot. When a delivered candidate fails verification with the decoder-corruption signature, the job is requeued with `PreferSoftwareDecode`, the candidate is deleted, and the next attempt, here or on any worker, decodes in software with the report saying why. The worker's card records it. Migration `AddDecodeFacts`.
- **Sidecar allowlist:** `-hwaccel` is accepted only with `videotoolbox`; any other decoder name is refused by name.

## Verification

- `dotnet test`: 1903 passed. New: VideoToolbox hardware decode adds a plain `-hwaccel` and nothing pinned to the GPU; without hardware decode no `-hwaccel`; a worker that proved its decoder is told to decode in hardware and the lease records it; a worker without proof decodes in software; a job marked for software decode gets no `-hwaccel` even from a proved worker.
- `swift test`: 73 passed. New: `-hwaccel videotoolbox` accepted, `-hwaccel cuda` refused by name.
- `check_openapi.py --update`, release metadata, docs check, `npm run check`, `npm run build` clean.
- Docs: CHANGELOG, `docs/api.md`, roadmap item 9, sidecar README.
