### PR TITLE
Let the sidecar run several jobs at once and probe itself on every launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@
   the assembled file is hashed and judged exactly as a whole upload, and the staging file is
   named by lease so a resumed upload can only continue its own transfer. The macOS sidecar
   delivers this way when the server offers it and in one piece otherwise.
+- **The macOS sidecar runs more than one job at once, and works again after a relaunch.**
+  **Jobs at once** in the menu chooses one to four parallel jobs; the choice is persisted,
+  reported on every check-in, and filled from each check-in while slots are free, with every job
+  listed in the menu. Relaunching the app used to leave it reporting no encoders and zero
+  concurrency — "Drained" on the Workers tab — until it was paired again, because capabilities
+  were only probed at pairing; the machine is now probed on every launch.
 
 ## 0.2.12 — 2026-09-10
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -607,7 +607,9 @@ the replacement workflow is trustworthy.
      memory, recorded on the lease, and a corrupt result requeues the job for software decode
      (`Job.PreferSoftwareDecode`). **Resumable upload:** chunked delivery at server-confirmed
      offsets with a completion carrying both hashes; the sidecar resumes from the server's offset
-     after a dropped chunk. **Still to build:** an "on a worker"
+     after a dropped chunk. **Several jobs at once** on the sidecar (operator-chosen, one to four),
+     and a probe on every launch, which fixed a relaunched sidecar reporting itself drained.
+     **Still to build:** an "on a worker"
      placement for adaptive libraries once selection can hand the final encode over.
    - **The next four pieces, in dependency order (recorded 2026-09-01).** Everything below waits on
      the first, and the first two are server work of similar size to a normal feature slice.

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -33,7 +33,9 @@ server has verified it can finish a job that came back — asks for work. A job 
    encode. Nothing is replaced from here, ever.
 
 Scratch lives under `~/Library/Application Support/OptimisarrSidecar/work` and is removed on every
-exit path. One job at a time.
+exit path. **Jobs at once** in the menu chooses how many jobs run in parallel (one to four); the
+number is reported on every check-in and the server holds the worker to it. The machine is probed
+again on every launch, not only at pairing, so a relaunched app reports what it can do today.
 
 While a job runs the app holds a system activity assertion, so macOS neither naps it nor idles the
 machine to sleep under an encode. When the Mac does sleep — a closed lid, a chosen sleep — the job

--- a/sidecars/macos/Sources/OptimisarrSidecar/SidecarMenu.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/SidecarMenu.swift
@@ -101,10 +101,22 @@ struct SidecarMenu: View {
                     .font(.caption)
             }
 
-            if case let .working(jobId, progress) = session.status {
-                LabeledContent("Job", value: "#\(jobId)").font(.caption)
-                LabeledContent("Stage", value: progress.label).font(.caption)
+            ForEach(session.activeJobs.keys.sorted(), id: \.self) { jobId in
+                if let progress = session.activeJobs[jobId] {
+                    LabeledContent("Job #\(jobId)", value: progress.label).font(.caption)
+                }
             }
+
+            // Takes effect on the next check-in; a running job is never stopped to fit.
+            Picker("Jobs at once", selection: Binding(
+                get: { session.jobConcurrency },
+                set: { session.setJobConcurrency($0) })) {
+                ForEach(Array(SidecarSession.concurrencyRange), id: \.self) { count in
+                    Text("\(count)").tag(count)
+                }
+            }
+            .pickerStyle(.segmented)
+            .font(.caption)
 
             if let outcome = session.lastOutcome {
                 Text(outcome.label)

--- a/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
@@ -43,6 +43,15 @@ public final class SidecarSession: ObservableObject {
     /// How the last job ended, kept so the menu can say what this machine last did for the server.
     @Published public private(set) var lastOutcome: JobOutcome?
 
+    /// Every job in flight and where it has got to, keyed by job id.
+    @Published public private(set) var activeJobs: [Int: JobProgress] = [:]
+
+    /// How many jobs this Mac takes at once. Chosen by the operator, reported to the server on
+    /// every check-in, and the ceiling the claim loop fills up to.
+    @Published public private(set) var jobConcurrency: Int
+
+    public static let concurrencyRange = 1...4
+
     private let client: SidecarClient
     private let store: CredentialStore
     private let prober: CapabilityProber?
@@ -50,9 +59,10 @@ public final class SidecarSession: ObservableObject {
     private var capabilities: SidecarCapabilities
     private let sleep: @Sendable (TimeInterval) async throws -> Void
 
+    private let persistConcurrency: @Sendable (Int) -> Void
     private var pairing: StoredPairing?
     private var heartbeatTask: Task<Void, Never>?
-    private var jobTask: Task<Void, Never>?
+    private var jobTasks: [Int: Task<Void, Never>] = [:]
     /// Held while a job runs so macOS neither naps the app nor idles the machine to sleep under
     /// an encode. A lid close still sleeps the Mac; that path hands the job back first.
     private var activity: NSObjectProtocol?
@@ -63,6 +73,8 @@ public final class SidecarSession: ObservableObject {
         capabilities: SidecarCapabilities = .provenToday(name: Host.current().localizedName ?? "Mac"),
         prober: CapabilityProber? = CapabilityProber(),
         executor: WorkExecutor? = JobRunner(),
+        jobConcurrency: Int = UserDefaults.standard.object(forKey: "jobConcurrency") as? Int ?? 1,
+        persistConcurrency: @escaping @Sendable (Int) -> Void = { UserDefaults.standard.set($0, forKey: "jobConcurrency") },
         sleep: @escaping @Sendable (TimeInterval) async throws -> Void = { seconds in
             try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
         }
@@ -72,18 +84,46 @@ public final class SidecarSession: ObservableObject {
         self.capabilities = capabilities
         self.prober = prober
         self.executor = executor
+        self.jobConcurrency = Self.concurrencyRange.contains(jobConcurrency) ? jobConcurrency : 1
+        self.persistConcurrency = persistConcurrency
         self.sleep = sleep
     }
 
-    /// Restores a previous pairing, if there is one, and starts checking in.
+    /// Changes how many jobs run at once. Takes effect on the next check-in; jobs already in
+    /// flight are never stopped to fit a smaller number.
+    public func setJobConcurrency(_ count: Int) {
+        let clamped = min(max(count, Self.concurrencyRange.lowerBound), Self.concurrencyRange.upperBound)
+        jobConcurrency = clamped
+        persistConcurrency(clamped)
+        if capabilities.maxConcurrency > 0 {
+            capabilities.maxConcurrency = clamped
+        }
+    }
+
+    /// Restores a previous pairing, if there is one, and starts checking in. Idempotent: the menu
+    /// calls it every time it opens, and that must not restart a running check-in loop.
+    ///
+    /// The machine is probed again here, not only at pairing. Capabilities live in memory, so
+    /// without this a relaunched app reported no encoders and zero concurrency — "drained" to the
+    /// server — and never took work again until it was paired afresh.
     public func restore() {
+        guard pairing == nil else { return }
         guard let stored = try? store.load() else {
             status = .unpaired
             return
         }
         pairing = stored
         serverAddress = stored.serverAddress
-        startHeartbeat()
+        if let prober {
+            Task { [weak self] in
+                guard let self else { return }
+                let proved = await prober.probe(name: self.capabilities.name, maxConcurrency: self.jobConcurrency)
+                self.capabilities = proved
+                self.startHeartbeat()
+            }
+        } else {
+            startHeartbeat()
+        }
     }
 
     /// Redeems a PIN. On success the credential is persisted immediately — the server returns it
@@ -97,7 +137,7 @@ public final class SidecarSession: ObservableObject {
         // otherwise be reported as it was, and a capability the server believes but the machine
         // cannot honour is a job that can only fail.
         if let prober {
-            capabilities = await prober.probe(name: capabilities.name, maxConcurrency: 1)
+            capabilities = await prober.probe(name: capabilities.name, maxConcurrency: jobConcurrency)
         }
 
         do {
@@ -122,10 +162,11 @@ public final class SidecarSession: ObservableObject {
     public func unpair() {
         heartbeatTask?.cancel()
         heartbeatTask = nil
-        // A job in flight is stopped too: cancelling the task terminates ffmpeg and the runner
-        // hands the lease back, so the server can reassign rather than wait for it to lapse.
-        jobTask?.cancel()
-        jobTask = nil
+        // Jobs in flight are stopped too: cancelling the tasks terminates ffmpeg and the runner
+        // hands each lease back, so the server can reassign rather than wait for it to lapse.
+        for task in jobTasks.values { task.cancel() }
+        jobTasks = [:]
+        activeJobs = [:]
         endActivity()
         try? store.clear()
         pairing = nil
@@ -136,9 +177,10 @@ public final class SidecarSession: ObservableObject {
     /// server can reassign at once rather than after the lease lapses. The reason is what the
     /// menu shows afterwards, in place of the runner's generic cancellation wording.
     public func stopWork(because reason: String) async {
-        guard let task = jobTask else { return }
-        task.cancel()
-        await task.value
+        let tasks = Array(jobTasks.values)
+        guard !tasks.isEmpty else { return }
+        for task in tasks { task.cancel() }
+        for task in tasks { await task.value }
         if case let .released(jobId, _) = lastOutcome {
             lastOutcome = .released(jobId: jobId, reason: reason)
         }
@@ -208,9 +250,11 @@ public final class SidecarSession: ObservableObject {
                     maxConcurrency: capabilities.maxConcurrency)
 
                 interval = beat.heartbeatInterval
-                if jobTask == nil {
+                if jobTasks.isEmpty {
                     status = .connected(workerId: beat.workerId, lastCheckIn: Date())
-                    await claimIfIdle(pairing: pairing, workerId: beat.workerId)
+                }
+                if !beat.draining {
+                    await claimUpToCapacity(pairing: pairing, workerId: beat.workerId)
                 }
             } catch SidecarError.credentialRejected {
                 // Terminal. Retrying cannot help, and holding a dead secret on disk serves no
@@ -233,45 +277,64 @@ public final class SidecarSession: ObservableObject {
         }
     }
 
-    /// Asks for work once per healthy check-in while idle. One job at a time: the capabilities
-    /// advertised one slot, and the server's matcher holds it to that.
-    private func claimIfIdle(pairing: StoredPairing, workerId: Int) async {
+    /// Asks for work on each healthy check-in until every slot the operator allowed is filled.
+    /// The server hands out one job per claim and holds the worker to the concurrency it
+    /// reported, so this can never run more than the server believes it can.
+    private func claimUpToCapacity(pairing: StoredPairing, workerId: Int) async {
         guard let executor, capabilities.maxConcurrency > 0 else { return }
 
-        let assignment: Assignment?
-        do {
-            assignment = try await client.claim(
-                serverAddress: pairing.serverAddress, credential: pairing.credential)
-        } catch {
-            // A failed claim is not a failed check-in. The next beat asks again; a credential
-            // problem surfaces through the heartbeat, which is the path that handles it.
-            return
-        }
-        guard let assignment else { return }
-
-        status = .working(jobId: assignment.jobId, progress: .fetchingSource)
-        let jobId = assignment.jobId
-        beginActivity()
-        // The task holds the session for the job's duration, which is intended: a job is stopped
-        // by cancelling this task (see unpair), never by the session quietly going away under it.
-        jobTask = Task { [weak self] in
-            guard let self else { return }
-            let outcome = await executor.execute(assignment, pairing: pairing) { progress in
-                Task { @MainActor in self.report(jobId: jobId, progress: progress) }
+        while jobTasks.count < capabilities.maxConcurrency {
+            let assignment: Assignment?
+            do {
+                assignment = try await client.claim(
+                    serverAddress: pairing.serverAddress, credential: pairing.credential)
+            } catch {
+                // A failed claim is not a failed check-in. The next beat asks again; a credential
+                // problem surfaces through the heartbeat, which is the path that handles it.
+                return
             }
-            self.finish(outcome, workerId: workerId)
+            guard let assignment, jobTasks[assignment.jobId] == nil else { return }
+
+            let jobId = assignment.jobId
+            activeJobs[jobId] = .fetchingSource
+            refreshWorkingStatus()
+            beginActivity()
+            // The task holds the session for the job's duration, which is intended: a job is
+            // stopped by cancelling this task (see unpair), never by the session quietly going
+            // away under it.
+            jobTasks[jobId] = Task { [weak self] in
+                guard let self else { return }
+                let outcome = await executor.execute(assignment, pairing: pairing) { progress in
+                    Task { @MainActor in self.report(jobId: jobId, progress: progress) }
+                }
+                self.finish(outcome, jobId: jobId, workerId: workerId)
+            }
         }
     }
 
     private func report(jobId: Int, progress: JobProgress) {
-        guard jobTask != nil else { return }
-        status = .working(jobId: jobId, progress: progress)
+        guard jobTasks[jobId] != nil else { return }
+        activeJobs[jobId] = progress
+        refreshWorkingStatus()
     }
 
-    private func finish(_ outcome: JobOutcome, workerId: Int) {
+    /// The menu bar shows one job; the earliest still running stands for the rest, and the menu
+    /// itself lists them all.
+    private func refreshWorkingStatus() {
+        guard let first = activeJobs.keys.min(), let progress = activeJobs[first] else { return }
+        status = .working(jobId: first, progress: progress)
+    }
+
+    private func finish(_ outcome: JobOutcome, jobId: Int, workerId: Int) {
         lastOutcome = outcome
-        jobTask = nil
-        endActivity()
+        jobTasks[jobId] = nil
+        activeJobs[jobId] = nil
+        if jobTasks.isEmpty {
+            endActivity()
+        } else {
+            refreshWorkingStatus()
+            return
+        }
         if pairing != nil {
             status = .connected(workerId: workerId, lastCheckIn: Date())
         }

--- a/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
@@ -13,6 +13,8 @@ final class ScriptedTransport: HTTPTransport, @unchecked Sendable {
     private let lock = NSLock()
     private var replies: [Reply]
     private(set) var callCount = 0
+    /// How many times work was asked for, whatever the scripted answer was.
+    private(set) var claims = 0
 
     init(_ replies: [Reply]) {
         self.replies = replies
@@ -21,6 +23,7 @@ final class ScriptedTransport: HTTPTransport, @unchecked Sendable {
     func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let reply: Reply = lock.withLock {
             callCount += 1
+            if request.url?.path.hasSuffix("/claim") == true { claims += 1 }
             return replies.count > 1 ? replies.removeFirst() : replies[0]
         }
         let data = (try? JSONSerialization.data(withJSONObject: reply.json)) ?? Data()
@@ -45,19 +48,26 @@ final class ScriptedTransport: HTTPTransport, @unchecked Sendable {
 final class HangingExecutor: WorkExecutor, @unchecked Sendable {
     private let lock = NSLock()
     private(set) var started = false
+    private(set) var startedCount = 0
     private(set) var cancelled = false
 
     func execute(
         _ assignment: Assignment, pairing: StoredPairing,
         progress: @escaping @Sendable (JobProgress) -> Void
     ) async -> JobOutcome {
-        lock.withLock { started = true }
+        lock.withLock { started = true; startedCount += 1 }
         while !Task.isCancelled {
             try? await Task.sleep(nanoseconds: 2_000_000)
         }
         lock.withLock { cancelled = true }
         return .released(jobId: assignment.jobId, reason: "The job was cancelled on this machine.")
     }
+}
+
+final class Persisted: @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var value: Int?
+    func set(_ new: Int) { lock.withLock { value = new } }
 }
 
 @MainActor
@@ -72,6 +82,9 @@ struct SidecarSessionTests {
             client: SidecarClient(transport: transport),
             store: store,
             capabilities: .provenToday(name: "Test"),
+            // No prober: the capabilities above are the test's statement of what this machine can do.
+            prober: nil,
+            persistConcurrency: { _ in },
             // Collapses the wait so a check-in loop can be walked without real time passing.
             sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) }
         )
@@ -185,19 +198,89 @@ struct SidecarSessionTests {
                     "minimumHarmonicMean": 93.0, "minimumMinimum": 80.0],
     ])
 
-    private func workingSession(_ executor: HangingExecutor) async throws -> SidecarSession {
+    private static func claim(jobId: Int) -> ScriptedTransport.Reply {
+        var json = claim.json
+        json["jobId"] = jobId
+        json["leaseId"] = "lease-\(jobId)"
+        return .init(status: 200, json: json)
+    }
+
+    private func workingSession(
+        _ executor: HangingExecutor, concurrency: Int = 1, claims: [ScriptedTransport.Reply]? = nil
+    ) async throws -> SidecarSession {
+        try await workingSessionAndTransport(executor, concurrency: concurrency, claims: claims).0
+    }
+
+    private func workingSessionAndTransport(
+        _ executor: HangingExecutor, concurrency: Int = 1, claims: [ScriptedTransport.Reply]? = nil
+    ) async throws -> (SidecarSession, ScriptedTransport) {
         let store = InMemoryCredentialStore(
             stored: StoredPairing(serverAddress: "localhost:8787", credential: "c", workerId: 11))
-        // Beat, claim, then whatever comes next (a release, a beat) is answered 204.
-        let transport = ScriptedTransport([Self.beat, Self.claim, .init(status: 204, json: [:])])
+        // Beat, the claims, then whatever comes next (a release, a beat) is answered 204.
+        let transport = ScriptedTransport([Self.beat] + (claims ?? [Self.claim]) + [.init(status: 204, json: [:])])
         let session = SidecarSession(
             client: SidecarClient(transport: transport), store: store,
-            capabilities: SidecarCapabilities(name: "Test", videoEncoders: ["libx265"], maxConcurrency: 1),
+            capabilities: SidecarCapabilities(name: "Test", videoEncoders: ["libx265"], maxConcurrency: concurrency),
+            prober: nil,
             executor: executor,
+            jobConcurrency: concurrency,
+            persistConcurrency: { _ in },
             sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
         session.restore()
         try await waitFor { executor.started }
-        return session
+        return (session, transport)
+    }
+
+    @Test("two slots take two jobs from one check-in, and no third is asked for while both are full")
+    func fillsEverySlot() async throws {
+        let executor = HangingExecutor()
+        // Beat, two claims, then beats for ever: a third claim would be answered with a beat
+        // and fail to parse, but the point is that it is never sent at all.
+        let store = InMemoryCredentialStore(
+            stored: StoredPairing(serverAddress: "localhost:8787", credential: "c", workerId: 11))
+        let transport = ScriptedTransport([Self.beat, Self.claim(jobId: 12), Self.claim(jobId: 13), Self.beat])
+        let session = SidecarSession(
+            client: SidecarClient(transport: transport), store: store,
+            capabilities: SidecarCapabilities(name: "Test", videoEncoders: ["libx265"], maxConcurrency: 2),
+            prober: nil, executor: executor, jobConcurrency: 2, persistConcurrency: { _ in },
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+        session.restore()
+
+        try await waitFor { executor.startedCount == 2 }
+        // Several more check-ins change nothing: both slots are full, so no claim is made.
+        let claimsAfterFilling = transport.claims
+        try await Task.sleep(nanoseconds: 20_000_000)
+        #expect(transport.claims == claimsAfterFilling)
+        #expect(executor.startedCount == 2)
+        #expect(Set(session.activeJobs.keys) == [12, 13])
+        guard case let .working(jobId, _) = session.status else {
+            Issue.record("expected working, got \(session.status)")
+            return
+        }
+        #expect(jobId == 12)
+
+        await session.stopWork(because: "test over")
+        #expect(session.activeJobs.isEmpty)
+    }
+
+    @Test("the concurrency choice is clamped, persisted and reported on the next check-in")
+    func concurrencyChoice() async throws {
+        let persisted = Persisted()
+        let session = SidecarSession(
+            client: SidecarClient(transport: ScriptedTransport([Self.beat])),
+            store: InMemoryCredentialStore(),
+            capabilities: SidecarCapabilities(name: "Test", videoEncoders: ["libx265"], maxConcurrency: 1),
+            prober: nil,
+            jobConcurrency: 9,
+            persistConcurrency: { persisted.set($0) },
+            sleep: { _ in })
+
+        #expect(session.jobConcurrency == 1)
+        session.setJobConcurrency(3)
+        #expect(session.jobConcurrency == 3)
+        #expect(persisted.value == 3)
+        session.setJobConcurrency(0)
+        #expect(session.jobConcurrency == 1)
     }
 
     @Test("going to sleep hands the job back at once and stops checking in")


### PR DESCRIPTION
The macOS sidecar runs more than one job at once, and works again after a relaunch.

## What changes

- **Jobs at once.** A segmented control in the menu chooses one to four parallel jobs. The choice is persisted, reported on every check-in, and the claim loop fills free slots on each check-in; the server already holds a worker to the concurrency it reports, so this can never exceed what the server believes. Every job in flight is listed in the menu with its stage; the menu-bar icon shows the earliest. Sleep, quit and unpair hand every job back.
- **Bug found on the way: a relaunched sidecar reported itself drained.** Capabilities were probed only at pairing and lived in memory, so after any relaunch the app checked in with no encoders and zero concurrency, showed "Drained" on the Workers tab, and never took work until it was paired afresh. The machine is now probed on every launch. `restore()` is also idempotent, since the menu calls it every time it opens.

## Verification

- `swift test`: 78 passed. New: two slots take two jobs from one check-in and no third claim is made while both are full; the concurrency choice is clamped, persisted and applied. `swift build` of the app target clean.
- Docs: CHANGELOG, roadmap item 9, sidecar README. `check_docs.py` and release metadata clean.
