### PR TITLE
Drop the no-sub-agents rule from the contributor contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,8 +240,6 @@ the repo's package settings if anonymous `docker pull` is expected.
 - Pull requests state the outcome, included and excluded scope, verification
   results, and material safety or migration risk. Do not merge while a required
   check is failing or a blocking review conversation is unresolved.
-- **No sub-agents.** Do the work inline. Do not spawn sub-agents (e.g. the Agent/Task
-  "Explore"/"Plan"/general-purpose agents) to carry out tasks in this repo.
 - **Write GitHub Releases for the person updating their server, not for the commit
   history.** Follow [`docs/development/releasing.md`](docs/development/releasing.md)
   and start from [`.github/RELEASE_NOTES_TEMPLATE.md`](.github/RELEASE_NOTES_TEMPLATE.md).


### PR DESCRIPTION
## Outcome

Removes the **No sub-agents** bullet from `CLAUDE.md` section 10. Whether an assistant delegates part of a task is a tooling choice, not a standard the change has to clear; every other rule in the contract still applies to whatever produces the work.

## Not included

`docs/superpowers/plans/2026-07-16-track-cleanup.md` says "No sub-agents; work inline" for that plan. It is a dated record of how one piece of work was run, so it is left as written.

## Verification

Documentation only; no code or behaviour changes.