### PR TITLE
Let the Workers tab notice a sidecar pairing without a reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,15 @@
   concurrency — "Drained" on the Workers tab — until it was paired again, because capabilities
   were only probed at pairing; the machine is now probed on every launch.
 
+### Fixed
+
+- **The Workers tab now notices a sidecar pairing without a reload.** While a pairing code was on
+  screen the page only counted down; it never asked the server whether the code had been redeemed
+  and never refreshed the worker list, and with no worker listed yet it never refreshed at all. A
+  freshly paired Mac therefore stayed invisible, under a code that had already been used, until the
+  operator reloaded. The page now polls every two seconds while a code is showing, drops the code
+  the moment the server no longer has it, and keeps a slow refresh going even when the list is empty.
+
 ## 0.2.12 — 2026-09-10
 
 ### Fixed

--- a/web/e2e/workers.spec.ts
+++ b/web/e2e/workers.spec.ts
@@ -131,3 +131,42 @@ test('drain and resume act on one card and show what the server recorded', async
   await expect(studio.getByText('Online')).toBeVisible()
   await expect(studio.getByRole('button', { name: 'Drain after this job' })).toBeVisible()
 })
+
+test('a sidecar that redeems the code appears on the page without a reload', async ({ page }) => {
+  // The list and the code both live server-side; the page has to keep asking while a code is
+  // showing, because the only thing that ends a pairing is the sidecar redeeming it elsewhere.
+  let rows: typeof workers = []
+  let code: { code: string; expiresUtc: string; attemptsRemaining: number } | null = null
+  await mockWorkers(page, rows)
+  await page.route((url) => url.pathname === '/api/workers', (route) => json(route, rows))
+  await page.route((url) => url.pathname === '/api/workers/pairing-code', (route) => {
+    const method = route.request().method()
+    if (method === 'POST') {
+      code = { code: '82397571', expiresUtc: new Date(Date.now() + 300_000).toISOString(), attemptsRemaining: 5 }
+      return json(route, code)
+    }
+    if (method === 'DELETE') {
+      code = null
+      return route.fulfill({ status: 204 })
+    }
+    return code ? json(route, code) : route.fulfill({ status: 204 })
+  })
+
+  await page.goto('/#/settings')
+  await page.getByRole('tab', { name: 'Workers' }).click()
+  await expect(page.getByText('No sidecars are paired.')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Pair a sidecar' }).click()
+  await expect(page.getByText('8239 7571')).toBeVisible()
+
+  // The sidecar redeems the code: the server forgets it and lists the new worker.
+  code = null
+  const stamp = new Date().toISOString()
+  rows = [{ ...workers[1], id: 7, name: 'Scott’s MacBook Air', pairedAt: stamp, lastSeenAt: stamp, drainRequestedAt: null, lastProblem: null, lastProblemAt: null }]
+
+  const card = page.locator('[data-testid="worker-card"]')
+  await expect(card).toHaveCount(1, { timeout: 10_000 })
+  await expect(card).toContainText('Scott’s MacBook Air')
+  await expect(page.getByText('8239 7571')).toBeHidden()
+  await expect(page.getByRole('button', { name: 'Pair a sidecar' })).toBeVisible()
+})

--- a/web/src/lib/components/WorkersPanel.svelte
+++ b/web/src/lib/components/WorkersPanel.svelte
@@ -42,15 +42,32 @@
     return () => clearInterval(handle)
   })
 
+  // Both the list and the code live on the server, and the one event that ends a pairing —
+  // the sidecar redeeming the code — happens on another machine. So while a code is on screen
+  // the page asks often, and it keeps asking even when the list is empty: a first worker can
+  // appear at any moment, and the page is the only thing that will tell the operator.
+  // A code still within its time. Derived so the effect below only re-arms when this flips,
+  // not on every tick of the countdown.
+  let codeShowing = $derived(pairing !== null && secondsLeft > 0)
+
   $effect(() => {
-    if (pairing || loading || workers.length === 0) return
-    const handle = setInterval(() => void refresh(), 15000)
+    if (loading) return
+    const handle = setInterval(() => void refresh(), codeShowing ? 2000 : 15000)
     return () => clearInterval(handle)
   })
 
   async function refresh() {
     try {
-      workers = await api.workers()
+      const askCode = codeShowing
+      const [list, code] = await Promise.all([
+        api.workers(),
+        askCode ? api.activeWorkerPairingCode() : Promise.resolve(null),
+      ])
+      workers = list
+      // A code the server no longer has while it should still be live was redeemed or cancelled
+      // from elsewhere, so the panel stops showing it. A code still live brings its attempts
+      // left. A lapsed code is left alone so the expiry notice stays on screen.
+      if (askCode) pairing = code
     } catch {
       // A missed refresh is not worth an error banner; the next one will try again.
     }


### PR DESCRIPTION
## Outcome

The Workers tab updates itself when a sidecar redeems the pairing code. Before, the page only counted the code down: it never re-asked the server about the code and never refreshed the worker list while a code was showing or while the list was empty, so the first real pairing on 2026-09-13 left the Mac invisible under an already-used code until a reload.

## Scope

- `WorkersPanel.svelte`: a single refresh timer that runs every 2 s while a code is within its time and every 15 s otherwise, including when the list is empty. Each refresh fetches the list and, while a code is showing, the code itself. A code the server no longer has is dropped; a live one brings its remaining attempts; a lapsed one keeps its expiry notice.
- Playwright: a new test issues a code, then has the mocked server forget it and list a new worker, and expects the card and the Pair button to appear with no reload.
- CHANGELOG entry under Unreleased → Fixed.

Excluded: the sidecar itself and the server are unchanged.

## Verification

- `npx playwright test e2e/workers.spec.ts`: 3 passed (the new test failed before the fix, passed after).
- `npm run check`: clean.

## Risk

UI-only. The extra request while a code is showing is one small GET every 2 s for at most five minutes.
