### PR TITLE
Resume dropped source downloads, renew the lease in every stage, gate the sidecar in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,17 @@ jobs:
             RENDER_GID=107 docker compose -f "$file" config --quiet
           done
 
+  macos-sidecar:
+    name: macOS sidecar build & test
+    runs-on: macos-15
+    defaults:
+      run:
+        working-directory: sidecars/macos
+    steps:
+      - uses: actions/checkout@v7
+      - run: swift test
+      - run: swift build --configuration release
+
   docker:
     name: Docker image, smoke, and publish
     needs: [backend, frontend, docs]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### Added
 
+- **A dropped source download resumes instead of starting a multi-gigabyte file again.** The macOS
+  sidecar fetches sources in bounded 64 MB byte ranges, keeps every complete range across transient
+  failures, and asks for the next missing byte. It validates each `Content-Range`, requires the
+  source hash on every response, and still hashes the assembled source before ffmpeg sees it. A
+  server that predates ranged delivery can return the whole file as before.
+- **A remote job keeps its lease during every long-running stage.** Renewal used to run only beside
+  ffmpeg, leaving a slow source download or candidate upload able to outlive its lease. Fetching,
+  encoding, VMAF measurement, and delivery now all renew with their current stage; if renewal says
+  the lease is gone, the in-flight transfer or process is cancelled immediately.
+- **The macOS sidecar has its own CI gate.** Pull requests and protected-branch pushes now run the
+  Swift protocol/lifecycle suite and a release build on an Apple Silicon macOS runner, so this
+  separately versioned client can no longer regress while the Linux backend and web jobs stay green.
+- **The macOS sidecar rechecks free scratch space before it downloads a claimed source.** The
+  server already considers reported capacity while assigning work, but free space can change
+  between a heartbeat and a claim, especially with several jobs at once. The runner now measures
+  the actual work volume immediately before transfer and hands back a job that cannot still hold
+  its source plus candidate allowance; an unreadable capacity fails closed before any media moves.
+  Every heartbeat also refreshes that same work-volume capacity instead of repeating the value
+  measured at launch, so a low-space Mac stops being offered work rather than repeatedly refusing it.
 - **A library can say where its work may run once remote workers are on.** Advanced options gain
   **Where this library's work may run**, shown only while remote workers are switched on and the
   preview flag is present: *Here or on a worker* (the default, and what every existing library

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,8 @@ dotnet test  Optimisarr.slnx          # run the suite
 cd web && npm run check               # frontend type/lint check
 cd web && npm run test:e2e            # Playwright end-to-end suite (CI gate — run it)
 cd web && npm run build               # emits static assets into Optimisarr.Api/wwwroot
+cd sidecars/macos && swift test        # macOS sidecar protocol and lifecycle suite
+cd sidecars/macos && swift build -c release
 ```
 
 ## 8. Project layout
@@ -191,6 +193,9 @@ to `dev`/`main`, every tag `v*`, and every pull request targeting `dev`/`main`:
 - **frontend** — `npm ci` → `npm run check` → `npx playwright install chromium` →
   `npm run test:e2e`. Both must be clean. The end-to-end suite is a gate, not an optional
   extra, so run it locally before pushing rather than discovering it here.
+- **macos-sidecar** — `swift test` → release build on an Apple Silicon macOS runner. Live
+  VideoToolbox and server tests remain explicit hardware acceptance runs because CI does not bundle
+  the sidecar's pinned FFmpeg or provision a paired Optimisarr server.
 - **docker** — builds the image (after backend + frontend pass) and **publishes
   to GHCR** as `ghcr.io/jellman86/optimisarr`.
 - [`.github/workflows/security.yml`](.github/workflows/security.yml) checks the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -477,9 +477,9 @@ the replacement workflow is trustworthy.
      logic — the control plane owns the contract and a newer sidecar falls back to what this build
      speaks, non-overlapping ranges are refused with a reason, and an assignment is offered only
      when the encoder, hardware decoder, VMAF mode, scratch space, and concurrency all clear, with
-     every unmet requirement named. Nothing is wired to HTTP, persistence, or the queue yet, so no
-     work can currently reach a sidecar. **Still to define:** registration, heartbeats, leases,
-     progress and cancellation, hashes, the resolved-policy payload, evidence, and acknowledgement.
+     every unmet requirement named. Registration, heartbeats, leases, progress, cancellation,
+     hashes, the resolved-policy payload, evidence, and acknowledgement are now wired through the
+     HTTP API, persistence, queue, and macOS sidecar work loop.
    - **Secure pairing and revocation: started.** Register a sidecar through a short-lived,
      single-use code displayed by the main app, then issue it a unique revocable credential. Bind
      every assignment and result to the registered worker and job lease; redact credentials from
@@ -509,8 +509,8 @@ the replacement workflow is trustworthy.
      be forgotten at a call site. Reachability uses one rule shared by the API and UI — a 30-second
      interval against a 2-minute threshold, deliberately different so one dropped beat cannot flap
      the status — and the Workers tab shows Online, Offline, Drained, or Revoked.
-     **Still to build:** binding assignments and results to the credential and lease, credential
-     rotation, and the TLS/LAN guidance.
+     Assignments, source access, evidence, and results are now bound to the credential and lease.
+     **Still to build:** credential rotation and the TLS/LAN guidance.
    - **Efficient, integrity-checked media delivery: started.** Support resumable, bounded, checksummed
      streaming when the sidecar cannot see the library. Also offer an explicit shared-storage path
      mapping for SMB/NFS-mounted media so multi-gigabyte sources need not cross the network twice.
@@ -530,7 +530,7 @@ the replacement workflow is trustworthy.
      the one recorded when the source was fetched, and the upload matches the hash the worker
      declared — which together cover the late result, the duplicate delivery, the candidate encoded
      from the wrong original, and the truncated upload. An accepted candidate lands in the work
-     directory a local transcode would have used and the job moves to `Verifying`, never to
+     directory a local transcode would have used and the job moves to `AwaitingVerification`, never to
      `ReadyToReplace`.
      **Landed on the evidence side:** `RemoteQualityEvidenceValidator` defines what makes a remote
      VMAF measurement admissible, failing closed on every path. Evidence is refused unless it names
@@ -539,10 +539,10 @@ the replacement workflow is trustworthy.
      and was measured against thresholds at least as strict as the library requires. Stricter is
      accepted: passing a harder test than the one set still passes the one set. Absent evidence is
      refused rather than read as "nothing objected".
-     **Still to build:** the shared-storage path mapping for workers that can already see the
-     library, resumable upload, wiring the evidence contract into the result route, and running the
-     existing verification over a returned candidate so every structural, decode, duration, tail,
-     stream and size gate is repeated locally.
+     Resumable upload, worker-side evidence, and the local verification pass have since landed.
+     Source downloads now resume in validated 64 MB ranges too, with a final whole-file hash before
+     encoding. **Still to build:** the shared-storage path mapping for workers that can already see
+     the library.
    - **Capability-aware leases and recovery: started.** Schedule only when OS, architecture, FFmpeg
      build, encoder, decoder, VMAF mode, free scratch space, and configured concurrency satisfy the
      job. Persist idempotent leases with expiry and heartbeats, expose drain/disable controls, and
@@ -644,10 +644,8 @@ the replacement workflow is trustworthy.
         since selection runs on this machine's encoder and does not transfer. The VideoToolbox
         family is now known to the selector, the quality, preset and tuning policies, and the
         command builder (`-q:v` on a linear map from the CRF scale; **real-hardware calibration of
-        that line is still owed**). Left for later pieces: adaptive selection on the worker,
-        hardware decode for a worker that proves a decoder, the VMAF command itself (piece 3 will
-        ship it as a second server-built array so crop, frame-rate and HDR preparation stay in one
-        place), and the worker-side allowlist validation.
+        that line is still owed**). Hardware decode, the VMAF command, and worker-side allowlist
+        validation have since landed. Adaptive selection on the worker remains.
 
      2. **A verification pass for a delivered candidate: landed 2026-09-04.** Before it,
         `POST /api/workers/leases/{id}/result`
@@ -681,9 +679,9 @@ the replacement workflow is trustworthy.
         candidate found mid-verification, recognised by its `remote-<job>` name (`RemoteCandidate`),
         and requeues local work as before. Enqueue de-duplication, timed cleanup, stats, queue
         clearing, cancel and the queue page all know the two remote statuses. A result for a job
-        that is no longer `Leased` (cancelled, say) is refused. VMAF is re-measured locally for now;
-        `RemoteQualityEvidenceValidator` is wired in with piece 3, when a worker can produce
-        evidence to validate.
+        that is no longer `Leased` (cancelled, say) is refused. Worker-side VMAF evidence has since
+        landed and is accepted only when its hashes and policy satisfy `RemoteQualityEvidenceValidator`;
+        otherwise the server measures locally.
 
      3. **The sidecar's work loop: landed 2026-09-04.** Claim, renew, release, source download
         with a hash check, transcode with progress, and result upload are implemented
@@ -692,9 +690,9 @@ the replacement workflow is trustworthy.
         allowlist of the options the server's builder emits, the two placeholder tokens as the only
         input and output, and no path-like value; a refused command hands the job back naming the
         token. Losing the lease cancels the encode; forgetting the pairing cancels the job; scratch
-        is removed on every exit path. **Left for later:** Range-resumed downloads (a dropped
-        transfer restarts today), and VMAF measurement on the worker with the evidence upload that
-        `RemoteQualityEvidenceValidator` will judge (the server re-measures until then).
+        is removed on every exit path. Worker-side VMAF and resumable uploads landed on 2026-09-10.
+        On 2026-09-12 source downloads also became resumable in validated 64 MB ranges, and the
+        runner gained a fail-closed free-space recheck immediately before fetching a claimed source.
 
         **Real-hardware evidence (2026-09-04, Apple Silicon Mac, local server built from dev):**
         `LiveWorkLoopTests` paired with proved capabilities, claimed a queued 1080p60 H.264 job,
@@ -712,9 +710,9 @@ the replacement workflow is trustworthy.
         for its escaped comma until taught to tell an escape from a Windows path, which is the
         fail-closed behaviour it exists for.
 
-     4. **Drain controls**, and then productionisation: launch-at-login, sleep/wake, App Nap,
-        low-disk handling, cancel-on-quit. Developer ID signing and notarisation are unblocked — a
-        paid Apple Developer membership is available — but remain the last step, and neither
+     4. **Productionisation.** Drain controls, launch-at-login, sleep/wake, App Nap,
+        cancel-on-quit, and a pre-transfer low-disk refusal have landed. Developer ID signing,
+        notarisation, update packaging, and the full release-build acceptance run remain; neither
         platform is described as supported until there is real-hardware acceptance evidence.
 
    - **Preserve the verification boundary.** The sidecar returns the candidate, VMAF measurements,
@@ -744,13 +742,16 @@ the replacement workflow is trustworthy.
      and the feature being switched off server-side are each surfaced distinctly rather than as a
      generic failure. A live test suite runs the real client against a running server, which is how
      this contract gets a second implementation holding it honest. It now claims work, fetches the
-     source by lease, validates and runs the server's command with the bundled ffmpeg, renews the
-     lease throughout, and delivers the candidate with both hashes (see piece 3 above), and has
+     source by lease in resumable ranges, validates and runs the server's command with the bundled
+     ffmpeg, keeps the lease renewed, measures VMAF, and delivers the candidate with both hashes in
+     resumable chunks (see piece 3 above), and has
      done so end to end on real Apple Silicon hardware against a server built from `dev`, with the
-     candidate passing every server gate including VMAF. **Still to build:** VMAF on the worker,
-     Range-resumed transfers, launch-at-login, sleep/wake and App Nap handling, drain controls,
-     and Developer ID signing and notarisation. Neither platform is described as supported until
-     that list is done and the evidence is repeated on a release build.
+     candidate passing every server gate including VMAF. Launch-at-login, sleep/wake, App Nap,
+     drain controls, concurrent jobs, and a pre-transfer low-disk refusal have landed too.
+     Every long-running stage now renews the lease and cancels its transfer or process if the lease
+     is lost. **Still to build:** upgrade packaging, Developer ID signing and notarisation, and the
+     full acceptance run on a release build.
+     Neither platform is described as supported until that list is done.
    - **Operational UI and acceptance evidence.** The main app shows each worker's trustworthy name,
      platform, version, capabilities, health, load, active lease, transfer progress, and last error;
      worker removal immediately prevents new assignments. Automated contract and end-to-end tests

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -16,8 +16,12 @@ server has verified it can finish a job that came back — asks for work. A job 
    `{{output}}` token in last position carrying the promised extension, and no other value looks
    like a path. Anything else is refused whole and the job handed back with the offending token
    named. The server decides *what* to encode; it never names files on this machine.
-3. **Fetch and prove.** The source is downloaded by lease into the app's own scratch and hashed;
-   a transfer that does not match the server's hash is never encoded.
+3. **Fetch and prove.** The source is downloaded by lease into the app's own scratch in 64 MB byte
+   ranges. A dropped connection resumes from the last complete range rather than restarting a
+   multi-gigabyte file. Every range is checked against the server's response and the assembled
+   source is hashed; a transfer that does not match the server's hash is never encoded. Immediately
+   before the first byte, the sidecar also rechecks that its real work volume can still hold the
+   source plus the candidate allowance and hands the lease back if it cannot.
 4. **Encode, renewing.** The bundled ffmpeg runs the command against this Mac's paths. The lease
    is renewed throughout; losing it stops the encode rather than finishing work the server has
    already given to someone else.
@@ -138,10 +142,14 @@ width. Once visible it can be ⌘-dragged wherever suits.
 
 ```bash
 swift test
+swift build --configuration release
 ```
 
-43 tests covering the protocol client, the pairing and check-in lifecycle, address handling,
-and capability probing — including live probes against the bundled ffmpeg.
+The suite covers the protocol client, resumable transfers, scratch-space refusal, lease loss during
+transfers, the pairing and check-in lifecycle, address handling, and capability probing — including
+live probes against the bundled ffmpeg. CI runs the ordinary suite and release build on an Apple
+Silicon macOS runner; the live suites remain explicit acceptance tests because they need the pinned
+FFmpeg and, for the work loop, a paired server with a suitable queued job.
 
 There is also a live suite that runs against a real server, skipped unless you point it at one:
 

--- a/sidecars/macos/Sources/SidecarCore/JobRunner.swift
+++ b/sidecars/macos/Sources/SidecarCore/JobRunner.swift
@@ -114,6 +114,11 @@ final class LatestProgress: @unchecked Sendable {
     }
 }
 
+private enum LeaseOperation<T: Sendable>: Sendable {
+    case completed(T)
+    case renewalStopped
+}
+
 /// Executes assignments, so the session can be driven in tests without an ffmpeg or a server.
 public protocol WorkExecutor: Sendable {
     func execute(
@@ -137,6 +142,7 @@ public struct JobRunner: WorkExecutor {
     private let ffmpeg: URL?
     private let runner: TranscodeRunner
     private let scratchRoot: URL
+    private let availableScratchBytes: @Sendable (URL) -> Int64?
     private let sleep: @Sendable (TimeInterval) async throws -> Void
 
     public init(
@@ -144,6 +150,7 @@ public struct JobRunner: WorkExecutor {
         ffmpeg: URL? = CapabilityProber.bundledFfmpeg(),
         runner: TranscodeRunner = ProcessTranscodeRunner(),
         scratchRoot: URL = JobRunner.defaultScratchRoot(),
+        availableScratchBytes: @escaping @Sendable (URL) -> Int64? = JobRunner.availableScratchBytes,
         sleep: @escaping @Sendable (TimeInterval) async throws -> Void = { seconds in
             try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
         }
@@ -152,6 +159,7 @@ public struct JobRunner: WorkExecutor {
         self.ffmpeg = ffmpeg
         self.runner = runner
         self.scratchRoot = scratchRoot
+        self.availableScratchBytes = availableScratchBytes
         self.sleep = sleep
     }
 
@@ -161,6 +169,20 @@ public struct JobRunner: WorkExecutor {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? FileManager.default.temporaryDirectory
         return base.appendingPathComponent("OptimisarrSidecar/work", isDirectory: true)
+    }
+
+    /// Capacity of the volume that will actually hold work. The app-support path may not exist on
+    /// first launch, so walk to its nearest existing ancestor rather than reporting zero from a
+    /// URL whose volume metadata cannot yet be read.
+    public static func availableScratchBytes(at directory: URL) -> Int64? {
+        var existing = directory
+        while !FileManager.default.fileExists(atPath: existing.path) {
+            let parent = existing.deletingLastPathComponent()
+            guard parent != existing else { return nil }
+            existing = parent
+        }
+        let values = try? existing.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        return values?.volumeAvailableCapacityForImportantUsage
     }
 
     public func execute(
@@ -196,6 +218,63 @@ public struct JobRunner: WorkExecutor {
 
     /// How many times a chunk may fail before the delivery is given up.
     static let maxChunkFailures = 20
+
+    /// Source ranges use the same bounded retry budget as candidate chunks. A transient network
+    /// failure keeps the complete ranges already on disk; an exhausted budget hands the lease
+    /// back instead of retrying forever.
+    static let maxSourceFailures = 20
+
+    private func fetchSource(
+        _ assignment: Assignment, pairing: StoredPairing, destination: URL
+    ) async throws -> String {
+        var failures = 0
+        while true {
+            try Task.checkCancellation()
+            do {
+                return try await client.fetchSource(
+                    serverAddress: pairing.serverAddress, credential: pairing.credential,
+                    leaseId: assignment.leaseId, to: destination)
+            } catch SidecarError.transferFailed {
+                failures += 1
+                guard failures <= Self.maxSourceFailures else {
+                    throw SidecarError.transferFailed(reason: "The source download failed \(failures) times.")
+                }
+                try await sleep(min(30, Double(failures) * 2))
+            }
+        }
+    }
+
+    /// Runs a potentially long stage beside the lease heartbeat. Whichever finishes first stops
+    /// the other: a completed stage no longer needs its renewal loop, while a refused renewal
+    /// cancels the transfer or process immediately so this Mac does no more work under a dead
+    /// lease. This wraps fetching, encoding, measuring, and delivery — not only ffmpeg.
+    private func whileRenewingLease<T: Sendable>(
+        _ assignment: Assignment,
+        pairing: StoredPairing,
+        progress: @escaping @Sendable () -> JobProgress,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: LeaseOperation<T>.self) { group in
+            group.addTask { .completed(try await operation()) }
+            group.addTask {
+                let interval = min(15, max(5, Double(assignment.renewWithinSeconds) / 2))
+                while !Task.isCancelled {
+                    try await sleep(interval)
+                    try await client.renew(
+                        serverAddress: pairing.serverAddress, credential: pairing.credential,
+                        leaseId: assignment.leaseId, progress: progress())
+                }
+                return .renewalStopped
+            }
+
+            defer { group.cancelAll() }
+            guard let first = try await group.next() else { throw CancellationError() }
+            switch first {
+            case let .completed(value): return value
+            case .renewalStopped: throw CancellationError()
+            }
+        }
+    }
 
     /// Delivers the candidate in chunks the server confirms, resuming from whatever it holds
     /// after a failure; a server that predates resumable delivery gets the whole file at once.
@@ -266,20 +345,6 @@ public struct JobRunner: WorkExecutor {
         return logs
     }
 
-    /// A renewal that only says where the job is; a lost lease still surfaces, everything else is
-    /// left for the regular renewal loop to notice.
-    private func renewQuietly(_ assignment: Assignment, pairing: StoredPairing, progress: JobProgress) async throws {
-        do {
-            try await client.renew(
-                serverAddress: pairing.serverAddress, credential: pairing.credential,
-                leaseId: assignment.leaseId, progress: progress)
-        } catch SidecarError.leaseLost {
-            throw SidecarError.leaseLost(reason: "The lease was lost while measuring quality.")
-        } catch {
-            // Transient; the next renewal will say the same thing.
-        }
-    }
-
     private func run(
         _ assignment: Assignment,
         pairing: StoredPairing,
@@ -299,13 +364,31 @@ public struct JobRunner: WorkExecutor {
         }
 
         try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        let required = assignment.sourceBytes.addingReportingOverflow(assignment.sourceBytes / 2)
+        guard assignment.sourceBytes > 0, !required.overflow else {
+            return await release(assignment, pairing: pairing, reason: "The assignment named an invalid source size.")
+        }
+        let requiredScratch = required.partialValue
+        guard let available = availableScratchBytes(scratch) else {
+            return await release(
+                assignment, pairing: pairing,
+                reason: "The Mac could not determine how much scratch space is available, so it did not download the source.")
+        }
+        guard available >= requiredScratch else {
+            return await release(
+                assignment, pairing: pairing,
+                reason: "The job needs \(requiredScratch) bytes of scratch space, but only \(available) bytes are available.")
+        }
         let source = scratch.appendingPathComponent("source", isDirectory: false)
         let candidate = scratch.appendingPathComponent("candidate.\(assignment.outputExtension)", isDirectory: false)
+        let latest = LatestProgress(.fetchingSource)
 
         progress(.fetchingSource)
-        let declaredSourceHash = try await client.fetchSource(
-            serverAddress: pairing.serverAddress, credential: pairing.credential,
-            leaseId: assignment.leaseId, to: source)
+        let declaredSourceHash = try await whileRenewingLease(
+            assignment, pairing: pairing, progress: latest.get
+        ) {
+            try await fetchSource(assignment, pairing: pairing, destination: source)
+        }
         let actualSourceHash = try Self.sha256(of: source)
         guard actualSourceHash.caseInsensitiveCompare(declaredSourceHash) == .orderedSame else {
             return await release(assignment, pairing: pairing,
@@ -313,38 +396,20 @@ public struct JobRunner: WorkExecutor {
         }
 
         let arguments = command.materialise(input: source, output: candidate)
-        let latest = LatestProgress(.encoding(encodedSeconds: 0))
-        let encode = try await withThrowingTaskGroup(of: (Int32, String)?.self) { group in
-            group.addTask {
-                let result = try await runner.run(ffmpeg, arguments) { seconds in
-                    latest.set(.encoding(encodedSeconds: seconds))
-                    progress(.encoding(encodedSeconds: seconds))
-                }
-                return result
+        latest.set(.encoding(encodedSeconds: 0))
+        let encode = try await whileRenewingLease(
+            assignment, pairing: pairing, progress: latest.get
+        ) {
+            try await runner.run(ffmpeg, arguments) { seconds in
+                latest.set(.encoding(encodedSeconds: seconds))
+                progress(.encoding(encodedSeconds: seconds))
             }
-            group.addTask {
-                // Renew at half the window the server states, so one missed renewal does not
-                // cost the lease, and no less often than every fifteen seconds so the bar the
-                // operator watches actually moves. A lost lease throws, which cancels the encode.
-                let interval = min(15, max(5, Double(assignment.renewWithinSeconds) / 2))
-                while true {
-                    try await sleep(interval)
-                    try await client.renew(
-                        serverAddress: pairing.serverAddress, credential: pairing.credential,
-                        leaseId: assignment.leaseId, progress: latest.get())
-                }
-            }
-            // The encode finishes first in every healthy run; the renewal loop only ever ends by
-            // throwing. Either way the other task is cancelled before returning.
-            let first = try await group.next()
-            group.cancelAll()
-            return first ?? nil
         }
 
-        guard let encode, encode.0 == 0 else {
-            let detail = encode?.1.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard encode.0 == 0 else {
+            let detail = encode.1.trimmingCharacters(in: .whitespacesAndNewlines)
             return await release(assignment, pairing: pairing,
-                reason: "ffmpeg exited with code \(encode?.0 ?? -1)." + (detail.isEmpty ? "" : " \(detail)"))
+                reason: "ffmpeg exited with code \(encode.0)." + (detail.isEmpty ? "" : " \(detail)"))
         }
 
         let candidateHash = try Self.sha256(of: candidate)
@@ -354,8 +419,13 @@ public struct JobRunner: WorkExecutor {
         // cannot be made, the candidate is still delivered and the server measures for itself.
         if assignment.quality.measure, !assignment.quality.commands.isEmpty {
             progress(.measuring)
-            try await renewQuietly(assignment, pairing: pairing, progress: .measuring)
-            if let logs = await measure(assignment, ffmpeg: ffmpeg, source: source, candidate: candidate, scratch: scratch) {
+            latest.set(.measuring)
+            let logs = try await whileRenewingLease(
+                assignment, pairing: pairing, progress: latest.get
+            ) {
+                await measure(assignment, ffmpeg: ffmpeg, source: source, candidate: candidate, scratch: scratch)
+            }
+            if let logs {
                 try? await client.reportQuality(
                     serverAddress: pairing.serverAddress, credential: pairing.credential,
                     leaseId: assignment.leaseId, sourceSha256: declaredSourceHash,
@@ -364,9 +434,14 @@ public struct JobRunner: WorkExecutor {
         }
 
         progress(.delivering)
-        let receipt = try await deliver(
-            assignment, pairing: pairing, candidate: candidate,
-            sourceSha256: declaredSourceHash, candidateSha256: candidateHash)
+        latest.set(.delivering)
+        let receipt = try await whileRenewingLease(
+            assignment, pairing: pairing, progress: latest.get
+        ) {
+            try await deliver(
+                assignment, pairing: pairing, candidate: candidate,
+                sourceSha256: declaredSourceHash, candidateSha256: candidateHash)
+        }
         return .delivered(jobId: receipt.jobId, bytes: receipt.bytes)
     }
 

--- a/sidecars/macos/Sources/SidecarCore/SidecarClient.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarClient.swift
@@ -99,6 +99,23 @@ public struct URLSessionTransport: HTTPTransport {
         if http.statusCode == 200 {
             try? FileManager.default.removeItem(at: destination)
             try FileManager.default.moveItem(at: temporary, to: destination)
+        } else if http.statusCode == 206 {
+            if !FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.moveItem(at: temporary, to: destination)
+                return http
+            }
+
+            let input = try FileHandle(forReadingFrom: temporary)
+            let output = try FileHandle(forWritingTo: destination)
+            defer {
+                try? input.close()
+                try? output.close()
+                try? FileManager.default.removeItem(at: temporary)
+            }
+            try output.seekToEnd()
+            while let bytes = try input.read(upToCount: 1024 * 1024), !bytes.isEmpty {
+                try output.write(contentsOf: bytes)
+            }
         } else {
             try? FileManager.default.removeItem(at: temporary)
         }
@@ -121,9 +138,14 @@ public struct URLSessionTransport: HTTPTransport {
 /// with the server tests nothing about the contract.
 public struct SidecarClient: Sendable {
     private let transport: HTTPTransport
+    private let downloadChunkBytes: Int64
 
-    public init(transport: HTTPTransport = URLSessionTransport()) {
+    public init(
+        transport: HTTPTransport = URLSessionTransport(),
+        downloadChunkBytes: Int64 = 64 * 1024 * 1024
+    ) {
         self.transport = transport
+        self.downloadChunkBytes = max(1, downloadChunkBytes)
     }
 
     /// Redeems a PIN and returns the credential. The PIN is single-use: a failure here generally
@@ -335,30 +357,93 @@ public struct SidecarClient: Sendable {
     public func fetchSource(
         serverAddress: String, credential: String, leaseId: String, to destination: URL
     ) async throws -> String {
-        let request = try authorised(
-            serverAddress, "/api/workers/leases/\(leaseId)/source", credential: credential, method: "GET")
-        let response: HTTPURLResponse
-        do {
-            response = try await transport.download(request, to: destination)
-        } catch let error as SidecarError {
-            throw error
-        } catch {
-            throw SidecarError.transferFailed(reason: "The source transfer failed: \(error.localizedDescription)")
-        }
+        var offset = Self.fileSize(destination)
+        var declaredHash: String?
 
-        switch response.statusCode {
-        case 200:
-            guard let hash = response.value(forHTTPHeaderField: "X-Optimisarr-Source-Sha256"), !hash.isEmpty else {
-                throw SidecarError.unexpectedResponse(status: 200)
+        while true {
+            var request = try authorised(
+                serverAddress, "/api/workers/leases/\(leaseId)/source", credential: credential, method: "GET")
+            let width = downloadChunkBytes - 1
+            let end = offset > Int64.max - width ? Int64.max : offset + width
+            request.setValue("bytes=\(offset)-\(end)", forHTTPHeaderField: "Range")
+
+            let response: HTTPURLResponse
+            do {
+                response = try await transport.download(request, to: destination)
+            } catch let error as SidecarError {
+                throw error
+            } catch {
+                throw SidecarError.transferFailed(reason: "The source transfer failed: \(error.localizedDescription)")
             }
-            return hash
-        case 401:
-            throw SidecarError.credentialRejected
-        case 403, 404, 409:
-            throw SidecarError.leaseLost(reason: "The source is no longer available for this lease.")
-        case let status:
+
+            switch response.statusCode {
+            case 200:
+                return try Self.sourceHash(response, status: 200)
+            case 206:
+                let hash = try Self.sourceHash(response, status: 206)
+                if let declaredHash, declaredHash.caseInsensitiveCompare(hash) != .orderedSame {
+                    try? Self.truncate(destination, to: offset)
+                    throw SidecarError.transferFailed(reason: "The source changed while it was being downloaded.")
+                }
+                declaredHash = hash
+
+                guard let range = Self.contentRange(response), range.start == offset else {
+                    try? Self.truncate(destination, to: offset)
+                    throw SidecarError.transferFailed(reason: "The server returned an invalid source byte range.")
+                }
+                let expectedSize = range.end + 1
+                guard Self.fileSize(destination) == expectedSize else {
+                    try? Self.truncate(destination, to: offset)
+                    throw SidecarError.transferFailed(reason: "The source range did not arrive in full.")
+                }
+                if expectedSize == range.total {
+                    return hash
+                }
+                offset = expectedSize
+            case 401:
+                throw SidecarError.credentialRejected
+            case 403, 404, 409:
+                throw SidecarError.leaseLost(reason: "The source is no longer available for this lease.")
+            case let status:
+                throw SidecarError.unexpectedResponse(status: status)
+            }
+        }
+    }
+
+    private static func sourceHash(_ response: HTTPURLResponse, status: Int) throws -> String {
+        guard let hash = response.value(forHTTPHeaderField: "X-Optimisarr-Source-Sha256"), !hash.isEmpty else {
             throw SidecarError.unexpectedResponse(status: status)
         }
+        return hash
+    }
+
+    private static func contentRange(_ response: HTTPURLResponse) -> (start: Int64, end: Int64, total: Int64)? {
+        guard
+            let value = response.value(forHTTPHeaderField: "Content-Range"),
+            value.hasPrefix("bytes ")
+        else { return nil }
+        let parts = value.dropFirst("bytes ".count).split(separator: "/", maxSplits: 1)
+        guard parts.count == 2, let total = Int64(parts[1]) else { return nil }
+        let bounds = parts[0].split(separator: "-", maxSplits: 1)
+        guard
+            bounds.count == 2,
+            let start = Int64(bounds[0]),
+            let end = Int64(bounds[1]),
+            start >= 0,
+            end >= start,
+            total > end
+        else { return nil }
+        return (start, end, total)
+    }
+
+    private static func fileSize(_ file: URL) -> Int64 {
+        (try? FileManager.default.attributesOfItem(atPath: file.path)[.size] as? NSNumber)?.int64Value ?? 0
+    }
+
+    private static func truncate(_ file: URL, to size: Int64) throws {
+        let handle = try FileHandle(forWritingTo: file)
+        defer { try? handle.close() }
+        try handle.truncate(atOffset: UInt64(size))
     }
 
     /// Delivers the candidate, declaring both hashes so the server can bind the file to the

--- a/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
@@ -56,6 +56,7 @@ public final class SidecarSession: ObservableObject {
     private let store: CredentialStore
     private let prober: CapabilityProber?
     private let executor: WorkExecutor?
+    private let scratchCapacity: @Sendable () -> Int64
     private var capabilities: SidecarCapabilities
     private let sleep: @Sendable (TimeInterval) async throws -> Void
 
@@ -73,6 +74,9 @@ public final class SidecarSession: ObservableObject {
         capabilities: SidecarCapabilities = .provenToday(name: Host.current().localizedName ?? "Mac"),
         prober: CapabilityProber? = CapabilityProber(),
         executor: WorkExecutor? = JobRunner(),
+        scratchCapacity: @escaping @Sendable () -> Int64 = {
+            JobRunner.availableScratchBytes(at: JobRunner.defaultScratchRoot()) ?? 0
+        },
         jobConcurrency: Int = UserDefaults.standard.object(forKey: "jobConcurrency") as? Int ?? 1,
         persistConcurrency: @escaping @Sendable (Int) -> Void = { UserDefaults.standard.set($0, forKey: "jobConcurrency") },
         sleep: @escaping @Sendable (TimeInterval) async throws -> Void = { seconds in
@@ -84,6 +88,7 @@ public final class SidecarSession: ObservableObject {
         self.capabilities = capabilities
         self.prober = prober
         self.executor = executor
+        self.scratchCapacity = scratchCapacity
         self.jobConcurrency = Self.concurrencyRange.contains(jobConcurrency) ? jobConcurrency : 1
         self.persistConcurrency = persistConcurrency
         self.sleep = sleep
@@ -139,6 +144,7 @@ public final class SidecarSession: ObservableObject {
         if let prober {
             capabilities = await prober.probe(name: capabilities.name, maxConcurrency: jobConcurrency)
         }
+        capabilities.freeScratchBytes = max(0, scratchCapacity())
 
         do {
             let result = try await client.pair(
@@ -243,6 +249,7 @@ public final class SidecarSession: ObservableObject {
             guard let pairing else { return }
 
             do {
+                capabilities.freeScratchBytes = max(0, scratchCapacity())
                 let beat = try await client.heartbeat(
                     serverAddress: pairing.serverAddress,
                     credential: pairing.credential,

--- a/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
@@ -15,6 +15,7 @@ final class ScriptedTransport: HTTPTransport, @unchecked Sendable {
     private(set) var callCount = 0
     /// How many times work was asked for, whatever the scripted answer was.
     private(set) var claims = 0
+    private(set) var heartbeatScratchBytes: [Int64] = []
 
     init(_ replies: [Reply]) {
         self.replies = replies
@@ -24,6 +25,12 @@ final class ScriptedTransport: HTTPTransport, @unchecked Sendable {
         let reply: Reply = lock.withLock {
             callCount += 1
             if request.url?.path.hasSuffix("/claim") == true { claims += 1 }
+            if request.url?.path.hasSuffix("/heartbeat") == true,
+               let body = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+               let bytes = (json["freeScratchBytes"] as? NSNumber)?.int64Value {
+                heartbeatScratchBytes.append(bytes)
+            }
             return replies.count > 1 ? replies.removeFirst() : replies[0]
         }
         let data = (try? JSONSerialization.data(withJSONObject: reply.json)) ?? Data()
@@ -187,6 +194,31 @@ struct SidecarSessionTests {
         }
 
         #expect(session.status.summary == "Connected")
+    }
+
+    @Test("every check-in reports current work-volume capacity rather than the launch-time value")
+    func heartbeatRefreshesScratchCapacity() async throws {
+        let store = InMemoryCredentialStore(
+            stored: StoredPairing(serverAddress: "localhost:8787", credential: "c", workerId: 11))
+        let transport = ScriptedTransport([
+            .init(status: 200, json: ["workerId": 11, "protocolVersion": 1, "heartbeatIntervalSeconds": 30]),
+        ])
+        let session = SidecarSession(
+            client: SidecarClient(transport: transport),
+            store: store,
+            capabilities: SidecarCapabilities(
+                name: "Test", videoEncoders: ["libx265"], freeScratchBytes: 999, maxConcurrency: 1),
+            prober: nil,
+            executor: nil,
+            scratchCapacity: { 321 },
+            persistConcurrency: { _ in },
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        session.restore()
+        try await waitFor { !transport.heartbeatScratchBytes.isEmpty }
+
+        #expect(transport.heartbeatScratchBytes.first == 321)
+        session.unpair()
     }
 
     private static let beat: ScriptedTransport.Reply =

--- a/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
@@ -153,6 +153,16 @@ final class FakeWorkerServer: HTTPTransport, @unchecked Sendable {
     private var staged = Data()
     private(set) var chunkOffsets: [Int64] = []
     private(set) var completedViaChunks = false
+    /// Serve the source in the byte ranges the client asks for rather than as one response.
+    var rangedSource = false
+    /// Drop the range beginning at this offset once, as an interrupted download would.
+    var dropSourceAt: Int64? = nil
+    private(set) var sourceOffsets: [Int64] = []
+    private(set) var sourceDownloads = 0
+    var sourceDelay: TimeInterval = 0
+    private(set) var sourceDownloadCompleted = false
+    var deliveryDelay: TimeInterval = 0
+    private(set) var deliveryCompleted = false
 
     init(sourceBytes: Data, claimJSON: [String: Any]? = nil) {
         self.sourceBytes = sourceBytes
@@ -218,13 +228,48 @@ final class FakeWorkerServer: HTTPTransport, @unchecked Sendable {
     }
 
     func download(_ request: URLRequest, to destination: URL) async throws -> HTTPURLResponse {
+        sourceDownloads += 1
+        if sourceDelay > 0 {
+            try await Task.sleep(nanoseconds: UInt64(sourceDelay * 1_000_000_000))
+        }
+        sourceDownloadCompleted = true
+        if rangedSource {
+            let range = request.value(forHTTPHeaderField: "Range") ?? ""
+            let bounds = range
+                .replacingOccurrences(of: "bytes=", with: "")
+                .split(separator: "-", maxSplits: 1)
+            let start = Int64(bounds.first ?? "") ?? -1
+            let requestedEnd = Int64(bounds.count > 1 ? bounds[1] : "") ?? -1
+            sourceOffsets.append(start)
+            if let drop = dropSourceAt, drop == start {
+                dropSourceAt = nil
+                throw SidecarError.transferFailed(reason: "connection reset")
+            }
+            let end = min(requestedEnd, Int64(sourceBytes.count) - 1)
+            let chunk = sourceBytes[Int(start)...Int(end)]
+            if !FileManager.default.fileExists(atPath: destination.path) {
+                FileManager.default.createFile(atPath: destination.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: destination)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: chunk)
+            return response(request, 206, headers: [
+                "Content-Range": "bytes \(start)-\(end)/\(sourceBytes.count)",
+                "X-Optimisarr-Source-Sha256": sourceSha256,
+            ])
+        }
         try sourceBytes.write(to: destination)
         return response(request, 200, headers: ["X-Optimisarr-Source-Sha256": sourceSha256])
     }
 
     func upload(_ request: URLRequest, fromFile file: URL) async throws -> (Data, HTTPURLResponse) {
+        if deliveryDelay > 0 {
+            try await Task.sleep(nanoseconds: UInt64(deliveryDelay * 1_000_000_000))
+        }
         let delivered = try Data(contentsOf: file)
         return lock.withLock {
+            deliveryCompleted = true
             deliveredFile = delivered
             deliveredHeaders = request.allHTTPHeaderFields ?? [:]
             let body = deliverStatus == 202
@@ -236,6 +281,29 @@ final class FakeWorkerServer: HTTPTransport, @unchecked Sendable {
 
     private func response(_ request: URLRequest, _ status: Int, headers: [String: String] = [:]) -> HTTPURLResponse {
         HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: headers)!
+    }
+}
+
+@Suite("Resumable source download")
+struct ResumableSourceDownloadTests {
+    @Test("a dropped source range resumes from the last complete byte without downloading it twice")
+    func resumesAfterDroppedRange() async throws {
+        let bytes = Data((0..<200).map(UInt8.init))
+        let server = FakeWorkerServer(sourceBytes: bytes)
+        server.rangedSource = true
+        server.dropSourceAt = 64
+        let runner = JobRunner(
+            client: SidecarClient(transport: server, downloadChunkBytes: 64),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: FakeTranscodeRunner(),
+            scratchRoot: scratch(),
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        let outcome = await runner.execute(assignment(), pairing: pairing) { _ in }
+
+        #expect(outcome == .delivered(jobId: 12, bytes: 15))
+        #expect(server.sourceOffsets == [0, 64, 64, 128, 192])
+        #expect(server.deliveredFile == Data("candidate bytes".utf8))
     }
 }
 
@@ -276,15 +344,43 @@ private let measurementCommand: [String] = [
     "-f", "null", "-",
 ]
 
-private func assignment(renewWithinSeconds: Int = 30, measure: Bool = false) -> Assignment {
+private func assignment(renewWithinSeconds: Int = 30, measure: Bool = false, sourceBytes: Int64 = 4_096) -> Assignment {
     Assignment(
-        leaseId: "8b1e2c3d-0000-4000-8000-000000000001", jobId: 12, sourceBytes: 4_096,
+        leaseId: "8b1e2c3d-0000-4000-8000-000000000001", jobId: 12, sourceBytes: sourceBytes,
         videoEncoder: "hevc_videotoolbox", renewWithinSeconds: renewWithinSeconds,
         arguments: serverCommand, outputExtension: "mp4",
         quality: QualityRequirement(
             measure: measure, model: "vmaf_v0.6.1", frameSubsample: 1, clipVmaf: false,
             minimumHarmonicMean: 93, minimumMinimum: 80,
             commands: measure ? [measurementCommand] : [], sampling: "Full file"))
+}
+
+@Suite("Scratch capacity")
+struct ScratchCapacityTests {
+    @Test("a job that no longer fits is handed back before its source is downloaded")
+    func refusesBeforeDownload() async throws {
+        let server = FakeWorkerServer(sourceBytes: Data(repeating: 7, count: 100))
+        let runner = JobRunner(
+            client: SidecarClient(transport: server),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: FakeTranscodeRunner(),
+            scratchRoot: scratch(),
+            availableScratchBytes: { _ in 149 },
+            sleep: { _ in })
+
+        let outcome = await runner.execute(
+            assignment(sourceBytes: 100), pairing: pairing) { _ in }
+
+        guard case let .released(jobId, reason) = outcome else {
+            Issue.record("expected a release, got \(outcome)")
+            return
+        }
+        #expect(jobId == 12)
+        #expect(reason.contains("150 bytes"))
+        #expect(reason.contains("149 bytes"))
+        #expect(server.sourceDownloads == 0)
+        #expect(server.deliveredFile == nil)
+    }
 }
 
 private let pairing = StoredPairing(serverAddress: "localhost:8787", credential: "secret", workerId: 3)
@@ -409,6 +505,52 @@ struct JobRunnerTests {
             return
         }
         #expect(Date().timeIntervalSince(started) < 4)
+        #expect(server.deliveredFile == nil)
+    }
+
+    @Test("losing the lease during a source transfer cancels the download")
+    func lostLeaseCancelsSourceTransfer() async throws {
+        let server = FakeWorkerServer(sourceBytes: Data(repeating: 1, count: 64))
+        server.sourceDelay = 0.2
+        server.renewStatus = 409
+        let runner = JobRunner(
+            client: SidecarClient(transport: server),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: FakeTranscodeRunner(),
+            scratchRoot: scratch(),
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        let outcome = await runner.execute(
+            assignment(renewWithinSeconds: 10), pairing: pairing) { _ in }
+
+        guard case .leaseLost = outcome else {
+            Issue.record("expected the lease to be lost, got \(outcome)")
+            return
+        }
+        #expect(!server.sourceDownloadCompleted)
+        #expect(server.deliveredFile == nil)
+    }
+
+    @Test("losing the lease during delivery cancels the upload")
+    func lostLeaseCancelsDelivery() async throws {
+        let server = FakeWorkerServer(sourceBytes: Data(repeating: 1, count: 64))
+        server.deliveryDelay = 0.2
+        server.renewStatus = 409
+        let runner = JobRunner(
+            client: SidecarClient(transport: server),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: FakeTranscodeRunner(),
+            scratchRoot: scratch(),
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        let outcome = await runner.execute(
+            assignment(renewWithinSeconds: 10), pairing: pairing) { _ in }
+
+        guard case .leaseLost = outcome else {
+            Issue.record("expected the lease to be lost, got \(outcome)")
+            return
+        }
+        #expect(!server.deliveryCompleted)
         #expect(server.deliveredFile == nil)
     }
 }

--- a/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
+++ b/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
@@ -946,15 +946,19 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
         var leaseId = assignment.GetProperty("leaseId").GetString()!;
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/api/workers/leases/{leaseId}/source");
-        request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(1000, null);
+        request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(1000, 1999);
 
         using var partial = await worker.SendAsync(request);
 
         // Without this a worker whose connection drops part-way through a multi-gigabyte source has
         // to start again from zero.
         Assert.Equal(HttpStatusCode.PartialContent, partial.StatusCode);
-        var tail = await partial.Content.ReadAsByteArrayAsync();
-        Assert.Equal(SourceBytes.Skip(1000).ToArray(), tail);
+        Assert.Equal(1000, partial.Content.Headers.ContentRange?.From);
+        Assert.Equal(1999, partial.Content.Headers.ContentRange?.To);
+        Assert.Equal(SourceBytes.Length, partial.Content.Headers.ContentRange?.Length);
+        var range = await partial.Content.ReadAsByteArrayAsync();
+        Assert.Equal(SourceBytes.Skip(1000).Take(1000).ToArray(), range);
+        Assert.Single(partial.Headers.GetValues("X-Optimisarr-Source-Sha256"));
     }
 
     [Fact]


### PR DESCRIPTION
## Outcome

The macOS sidecar survives a dropped source download without starting over, keeps its lease alive through every long stage, refuses work its scratch volume cannot hold, and is now built and tested in CI.

## Scope

- **Ranged source download.** 64 MB byte ranges, resume from the last complete byte, `Content-Range` validated on every response, the source hash required on every response, whole-file hash before encoding. A server that ignores `Range` still works.
- **Lease renewal in every stage.** Fetch, encode, measure and deliver all renew with their stage; a lost lease cancels the in-flight transfer or process.
- **Free-space recheck before transfer,** measured on the real work volume, and reported on every heartbeat.
- **CI:** new `macos-sidecar` job (`swift test` + release build on `macos-15`). CLAUDE.md, the sidecar README, the roadmap and the CHANGELOG are updated.
- Server: only `WorkerLeaseEndpointTests` tightened to assert `Content-Range` and the hash header on a partial response. No server source changed; the server already served ranges.

Excluded: the VMAF alignment bug found in today's first live run is a separate PR.

## Verification

- `swift test`: 83 tests in 19 suites passed. `swift build -c release`: clean.
- `dotnet test --filter WorkerLeaseEndpointTests`: 36 passed.
- The built app from this branch paired with the live server today and ran job 5845 through download, encode, measure and chunked delivery three times.

## Risk

Sidecar-side. The first run of the new macOS CI job is on this PR.
