### PR TITLE
Pair sampled VMAF windows by picture, not by container-relative timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,22 @@
 
 ### Fixed
 
+- **Sampled VMAF no longer scores a candidate against its own neighbouring frames.** Both inputs
+  of a sampled window are seeked to the same whole second and then paired by timestamp, but FFmpeg
+  stamps frames relative to each file's container start, which is the earliest stream. A source
+  whose audio leads its video by a frame of priming and a candidate whose video starts a frame
+  into its container therefore present the same picture 20 ms apart: half a frame, exactly the
+  cadence filter's rounding tie, so each window was a coin toss between frame N and frame N+1.
+  Held frames still scored well and moving ones scored zero, which is the "lowest frame 0, mean in
+  the 80s" signature that the decoder-corruption check then read as a broken hardware decode. The
+  first real remote job on 2026-09-13 was re-encoded three times on that reading and failed anyway;
+  on the same file the corrected measurement scores every window in the low 90s with no frame
+  under 70. The measurement now seeks to the nearest source picture instant, so retained frames sit
+  on slot centres, and removes the candidate's extra lead before cadence rounding. Locally the
+  server measures both leads from its probes; a remote worker measures them itself with its
+  ffprobe and fills in a token the server leaves in the filter, and reports no evidence rather
+  than half an answer when it cannot. Full-file measurements, which rebase both timelines, were
+  never affected.
 - **The Workers tab now notices a sidecar pairing without a reload.** While a pairing code was on
   screen the page only counted down; it never asked the server whether the code had been redeemed
   and never refreshed the worker list, and with no worker listed yet it never refreshed at all. A

--- a/sidecars/macos/Sources/SidecarCore/CapabilityProber.swift
+++ b/sidecars/macos/Sources/SidecarCore/CapabilityProber.swift
@@ -59,8 +59,13 @@ public struct CapabilityProber: Sendable {
     /// roadmap treats FFmpeg build as a scheduling criterion for good reason: the same encode
     /// settings must produce comparable output for the server's verification of a returned
     /// candidate to mean anything.
-    public static func bundledFfmpeg() -> URL? {
-        guard let resource = Bundle.main.resourceURL?.appendingPathComponent("ffmpeg"),
+    public static func bundledFfmpeg() -> URL? { bundled("ffmpeg") }
+
+    /// The ffprobe built alongside it, used to measure where a file's pictures start.
+    public static func bundledFfprobe() -> URL? { bundled("ffprobe") }
+
+    private static func bundled(_ name: String) -> URL? {
+        guard let resource = Bundle.main.resourceURL?.appendingPathComponent(name),
               FileManager.default.isExecutableFile(atPath: resource.path)
         else {
             return nil

--- a/sidecars/macos/Sources/SidecarCore/JobRunner.swift
+++ b/sidecars/macos/Sources/SidecarCore/JobRunner.swift
@@ -140,7 +140,9 @@ public protocol WorkExecutor: Sendable {
 public struct JobRunner: WorkExecutor {
     private let client: SidecarClient
     private let ffmpeg: URL?
+    private let ffprobe: URL?
     private let runner: TranscodeRunner
+    private let leadProbe: CommandRunner
     private let scratchRoot: URL
     private let availableScratchBytes: @Sendable (URL) -> Int64?
     private let sleep: @Sendable (TimeInterval) async throws -> Void
@@ -148,7 +150,9 @@ public struct JobRunner: WorkExecutor {
     public init(
         client: SidecarClient = SidecarClient(),
         ffmpeg: URL? = CapabilityProber.bundledFfmpeg(),
+        ffprobe: URL? = CapabilityProber.bundledFfprobe(),
         runner: TranscodeRunner = ProcessTranscodeRunner(),
+        leadProbe: CommandRunner = ProcessCommandRunner(),
         scratchRoot: URL = JobRunner.defaultScratchRoot(),
         availableScratchBytes: @escaping @Sendable (URL) -> Int64? = JobRunner.availableScratchBytes,
         sleep: @escaping @Sendable (TimeInterval) async throws -> Void = { seconds in
@@ -157,7 +161,9 @@ public struct JobRunner: WorkExecutor {
     ) {
         self.client = client
         self.ffmpeg = ffmpeg
+        self.ffprobe = ffprobe
         self.runner = runner
+        self.leadProbe = leadProbe
         self.scratchRoot = scratchRoot
         self.availableScratchBytes = availableScratchBytes
         self.sleep = sleep
@@ -333,10 +339,22 @@ public struct JobRunner: WorkExecutor {
         _ assignment: Assignment, ffmpeg: URL, source: URL, candidate: URL, scratch: URL
     ) async -> [String]? {
         var logs: [String] = []
-        for (index, arguments) in assignment.quality.commands.enumerated() {
-            guard let command = try? MeasurementCommand.validate(arguments) else { return nil }
+        let commands = assignment.quality.commands.compactMap { try? MeasurementCommand.validate($0) }
+        guard commands.count == assignment.quality.commands.count else { return nil }
+        // A sampled window pairs pictures by timestamp, so the server wants the candidate's extra
+        // lead over the source removed first. Only this machine has both files to measure it from.
+        var distortedShift: String?
+        if commands.contains(where: \.needsDistortedShift) {
+            guard let ffprobe,
+                  let sourceLead = await TimelineLead.measure(ffprobe: ffprobe, file: source, runner: leadProbe),
+                  let candidateLead = await TimelineLead.measure(ffprobe: ffprobe, file: candidate, runner: leadProbe)
+            else { return nil }
+            distortedShift = TimelineLead.shift(candidate: candidateLead, source: sourceLead)
+        }
+        for (index, command) in commands.enumerated() {
             let log = scratch.appendingPathComponent("vmaf-\(index).json", isDirectory: false)
-            let materialised = command.materialise(distorted: candidate, reference: source, log: log)
+            let materialised = command.materialise(
+                distorted: candidate, reference: source, log: log, distortedShift: distortedShift)
             guard let result = try? await runner.run(ffmpeg, materialised, progress: { _ in }), result.exitCode == 0,
                   let contents = try? String(contentsOf: log, encoding: .utf8), !contents.isEmpty
             else { return nil }

--- a/sidecars/macos/Sources/SidecarCore/MeasurementCommand.swift
+++ b/sidecars/macos/Sources/SidecarCore/MeasurementCommand.swift
@@ -23,6 +23,10 @@ public struct MeasurementCommand: Sendable, Equatable {
     public static let distortedPlaceholder = "{{distorted}}"
     public static let referencePlaceholder = "{{reference}}"
     public static let logPlaceholder = "{{log}}"
+    /// Filled in by this worker, inside the filter only, with the seconds by which the candidate
+    /// presents each picture later than the source. Only the worker has both files once the encode
+    /// exists, so only it can measure that; the server leaves the token where the number goes.
+    public static let distortedShiftPlaceholder = "{{distortedShift}}"
 
     static let flags: Set<String> = ["-nostdin", "-stats", "-y", "-nostats"]
     /// From `QualityScoreCommandBuilder`'s CPU path. Device and hardware-decode options are absent
@@ -70,19 +74,29 @@ public struct MeasurementCommand: Sendable, Equatable {
     }
 
     /// Substitutes this machine's paths for the three tokens.
-    public func materialise(distorted: URL, reference: URL, log: URL) -> [String] {
+    /// Whether the server left the candidate's lead for this worker to measure and fill in.
+    public var needsDistortedShift: Bool {
+        arguments.contains { $0.contains(Self.distortedShiftPlaceholder) }
+    }
+
+    public func materialise(distorted: URL, reference: URL, log: URL, distortedShift: String? = nil) -> [String] {
         arguments.map { argument in
             switch argument {
             case Self.distortedPlaceholder: return distorted.path
             case Self.referencePlaceholder: return reference.path
-            default: return argument.replacingOccurrences(of: Self.logPlaceholder, with: log.path)
+            default:
+                var value = argument.replacingOccurrences(of: Self.logPlaceholder, with: log.path)
+                if let distortedShift {
+                    value = value.replacingOccurrences(of: Self.distortedShiftPlaceholder, with: distortedShift)
+                }
+                return value
             }
         }
     }
 
     private static func checkValue(_ value: String, allowingLog: Bool) throws {
         if value.contains(distortedPlaceholder) || value.contains(referencePlaceholder)
-            || (!allowingLog && value.contains(logPlaceholder)) {
+            || (!allowingLog && (value.contains(logPlaceholder) || value.contains(distortedShiftPlaceholder))) {
             throw MeasurementCommandError.strayPlaceholder(value)
         }
         if value.contains("/") || value.hasPrefix("~") || AssignmentCommand.hasPathLikeBackslash(value) {

--- a/sidecars/macos/Sources/SidecarCore/TimelineLead.swift
+++ b/sidecars/macos/Sources/SidecarCore/TimelineLead.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// How far into its container a file's first picture sits.
+///
+/// FFmpeg seeks and stamps frames relative to the container start, which is the earliest stream —
+/// often audio, which can lead the video by a frame or so of priming. Two files whose pictures
+/// match frame for frame can therefore present them at different instants, and a sampled VMAF
+/// window that pairs frames by timestamp then compares neighbours instead of the same picture.
+/// The server builds the measurement with a token where that difference goes; this measures it.
+public enum TimelineLead {
+    static let ffprobeArguments = [
+        "-v", "error",
+        "-show_entries", "format=start_time:stream=codec_type,start_time",
+        "-of", "json",
+    ]
+
+    /// The video stream's start less the container's, in seconds, or nil when either is missing.
+    public static func parse(_ json: String) -> Double? {
+        guard let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let format = root["format"] as? [String: Any],
+              let container = seconds(format["start_time"]),
+              let streams = root["streams"] as? [[String: Any]],
+              let video = streams.first(where: { $0["codec_type"] as? String == "video" }),
+              let picture = seconds(video["start_time"])
+        else { return nil }
+        return picture - container
+    }
+
+    public static func measure(ffprobe: URL, file: URL, runner: CommandRunner) async -> Double? {
+        let result = await runner.run(ffprobe, ffprobeArguments + [file.path])
+        guard result.exitCode == 0 else { return nil }
+        return parse(result.output)
+    }
+
+    /// The seconds by which the candidate presents a picture later than the source, formatted the
+    /// way the server formats seconds in a filter graph: up to six decimals, no trailing zeros.
+    public static func shift(candidate: Double, source: Double) -> String {
+        let value = (candidate - source * 1_000_000).rounded() == 0 ? 0 : candidate - source
+        var text = String(format: "%.6f", value)
+        while text.hasSuffix("0") { text.removeLast() }
+        if text.hasSuffix(".") { text.removeLast() }
+        return text == "-0" ? "0" : text
+    }
+
+    private static func seconds(_ value: Any?) -> Double? {
+        if let text = value as? String { return Double(text) }
+        if let number = value as? NSNumber { return number.doubleValue }
+        return nil
+    }
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
@@ -308,10 +308,34 @@ struct ResumableSourceDownloadTests {
 }
 
 /// Stands in for ffmpeg: writes the candidate the command names, or fails, without encoding.
+/// Remembers what a fake was asked to run, so a test can look at the materialised command.
+final class ArgumentRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [[String]] = []
+    var all: [[String]] { lock.withLock { recorded } }
+    func record(_ arguments: [String]) { lock.withLock { recorded.append(arguments) } }
+}
+
+/// Stands in for ffprobe: answers a container and video start for whichever file is named last.
+struct FakeLeadProbe: CommandRunner {
+    var candidate = (container: "0.000000", video: "0.041000")
+    var source = (container: "-0.021000", video: "0.000000")
+    var exitCode: Int32 = 0
+
+    func run(_ executable: URL, _ arguments: [String]) async -> (exitCode: Int32, output: String) {
+        let starts = arguments.last!.hasPrefix("/") && arguments.last!.contains("candidate") ? candidate : source
+        return (exitCode, """
+        {"streams":[{"codec_type":"video","start_time":"\(starts.video)"},{"codec_type":"audio","start_time":"-0.021000"}],
+         "format":{"start_time":"\(starts.container)"}}
+        """)
+    }
+}
+
 struct FakeTranscodeRunner: TranscodeRunner, @unchecked Sendable {
     var exitCode: Int32 = 0
     var candidate = Data("candidate bytes".utf8)
     var delay: TimeInterval = 0
+    var recorder: ArgumentRecorder?
 
     var measurementExitCode: Int32 = 0
 
@@ -319,9 +343,12 @@ struct FakeTranscodeRunner: TranscodeRunner, @unchecked Sendable {
         _ executable: URL, _ arguments: [String], progress: @escaping @Sendable (Double) -> Void
     ) async throws -> (exitCode: Int32, stderr: String) {
         if delay > 0 { try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000)) }
+        recorder?.record(arguments)
         // A measurement names its log inside the filter; write the kind of log libvmaf would.
+        // A token left in the filter is what real ffmpeg would choke on, so this fake does too.
         if let filter = arguments.firstIndex(of: "-lavfi").map({ arguments[$0 + 1] }),
            let range = filter.range(of: "log_path=") {
+            if filter.contains("{{") { return (1, "Invalid argument") }
             let logPath = String(filter[range.upperBound...]).components(separatedBy: ":")[0]
             if measurementExitCode == 0 {
                 try Data(#"{"frames":[{"frameNum":0,"metrics":{"vmaf":96.0}}],"pooled_metrics":{"vmaf":{"min":96.0,"max":96.0,"mean":96.0,"harmonic_mean":96.0}}}"#.utf8)
@@ -337,6 +364,16 @@ struct FakeTranscodeRunner: TranscodeRunner, @unchecked Sendable {
     }
 }
 
+/// A sampled-window measurement as the server now builds it: seeked onto the source's frame grid,
+/// with the candidate's extra lead left for the worker to measure and fill in.
+private let shiftedMeasurementCommand: [String] = [
+    "-nostdin", "-v", "error", "-stats",
+    "-ss", "113.008875", "-i", "{{distorted}}", "-ss", "113.008875", "-i", "{{reference}}",
+    "-lavfi", "[0:v]settb=AVTB,setpts=PTS-{{distortedShift}}*1000000,fps=fps=23.976023976023978:start_time=0,trim=start=4.991125:duration=40,settb=AVTB,setpts=PTS-STARTPTS,scale=1920:1080:flags=bicubic:in_range=auto:out_range=tv,format=yuv420p[dist];[1:v]settb=AVTB,fps=fps=23.976023976023978:start_time=0,trim=start=4.991125:duration=40,settb=AVTB,setpts=PTS-STARTPTS,scale=1920:1080:flags=bicubic:in_range=auto:out_range=tv,format=yuv420p[ref];[dist][ref]libvmaf=model=version=vmaf_v0.6.1:n_threads=8:n_subsample=1:log_fmt=json:log_path={{log}}:shortest=1:repeatlast=0",
+    "-t", "40",
+    "-f", "null", "-",
+]
+
 private let measurementCommand: [String] = [
     "-nostdin", "-v", "error", "-stats",
     "-i", "{{distorted}}", "-i", "{{reference}}",
@@ -344,7 +381,10 @@ private let measurementCommand: [String] = [
     "-f", "null", "-",
 ]
 
-private func assignment(renewWithinSeconds: Int = 30, measure: Bool = false, sourceBytes: Int64 = 4_096) -> Assignment {
+private func assignment(
+    renewWithinSeconds: Int = 30, measure: Bool = false, sourceBytes: Int64 = 4_096,
+    commands: [[String]] = [measurementCommand]
+) -> Assignment {
     Assignment(
         leaseId: "8b1e2c3d-0000-4000-8000-000000000001", jobId: 12, sourceBytes: sourceBytes,
         videoEncoder: "hevc_videotoolbox", renewWithinSeconds: renewWithinSeconds,
@@ -352,7 +392,7 @@ private func assignment(renewWithinSeconds: Int = 30, measure: Bool = false, sou
         quality: QualityRequirement(
             measure: measure, model: "vmaf_v0.6.1", frameSubsample: 1, clipVmaf: false,
             minimumHarmonicMean: 93, minimumMinimum: 80,
-            commands: measure ? [measurementCommand] : [], sampling: "Full file"))
+            commands: measure ? commands : [], sampling: "Full file"))
 }
 
 @Suite("Scratch capacity")
@@ -750,6 +790,38 @@ struct MeasurementCommandTests {
         #expect(throws: MeasurementCommandError.unknownOption("-hwaccel")) { try MeasurementCommand.validate(extra) }
     }
 
+    @Test("the shift token is allowed inside the filter only, and is filled with the measured lead")
+    func shiftToken() throws {
+        let command = try MeasurementCommand.validate(shiftedMeasurementCommand)
+        #expect(command.needsDistortedShift)
+        #expect(!(try MeasurementCommand.validate(measurementCommand)).needsDistortedShift)
+
+        let materialised = command.materialise(
+            distorted: URL(fileURLWithPath: "/tmp/c.mp4"), reference: URL(fileURLWithPath: "/tmp/s.mkv"),
+            log: URL(fileURLWithPath: "/tmp/v.json"), distortedShift: "0.02")
+        #expect(materialised[13].contains("setpts=PTS-0.02*1000000,fps="))
+        #expect(!materialised[13].contains("{{"))
+
+        var stray = shiftedMeasurementCommand
+        stray[5] = "{{distortedShift}}"
+        #expect(throws: MeasurementCommandError.strayPlaceholder("{{distortedShift}}")) {
+            try MeasurementCommand.validate(stray)
+        }
+    }
+
+    @Test("a picture lead is the video start less the container start, and the shift is their difference")
+    func leadAndShift() {
+        let json = """
+        {"streams":[{"codec_type":"audio","start_time":"-0.021000"},{"codec_type":"video","start_time":"0.000000"}],
+         "format":{"start_time":"-0.021000"}}
+        """
+        #expect(TimelineLead.parse(json) == 0.021)
+        #expect(TimelineLead.parse(#"{"streams":[],"format":{}}"#) == nil)
+        #expect(TimelineLead.shift(candidate: 0.041, source: 0.021) == "0.02")
+        #expect(TimelineLead.shift(candidate: 0.0, source: 0.021) == "-0.021")
+        #expect(TimelineLead.shift(candidate: 0.5, source: 0.5) == "0")
+    }
+
     @Test("the filter must name the log token exactly once and nothing else may")
     func requiresOneLogToken() {
         var none = measurementCommand
@@ -783,6 +855,51 @@ struct MeasurementFlowTests {
         let logs = try #require(report["logs"] as? [String])
         #expect(logs.count == 1)
         #expect(logs[0].contains("harmonic_mean"))
+    }
+
+    @Test("a sampled measurement fills in the candidate's lead from both files before running")
+    func fillsInTheShift() async throws {
+        let server = FakeWorkerServer(sourceBytes: Data(repeating: 7, count: 4_096))
+        let recorder = ArgumentRecorder()
+        var fake = FakeTranscodeRunner()
+        fake.recorder = recorder
+        let runner = JobRunner(
+            client: SidecarClient(transport: server),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            ffprobe: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: fake,
+            leadProbe: FakeLeadProbe(),
+            scratchRoot: scratch(),
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        let outcome = await runner.execute(
+            assignment(measure: true, commands: [shiftedMeasurementCommand]), pairing: pairing) { _ in }
+
+        #expect(outcome == .delivered(jobId: 12, bytes: 15))
+        let report = try #require(server.qualityReport)
+        #expect((report["logs"] as? [String])?.count == 1)
+        let measurement = try #require(recorder.all.first { $0.contains("-lavfi") })
+        // The candidate's picture sits 41 ms into its container, the source's 21 ms: 20 ms to remove.
+        #expect(measurement[13].contains("setpts=PTS-0.02*1000000,fps="))
+    }
+
+    @Test("a sampled measurement with no ffprobe to measure the lead reports nothing")
+    func noProbeNoEvidence() async throws {
+        let server = FakeWorkerServer(sourceBytes: Data(repeating: 7, count: 4_096))
+        let runner = JobRunner(
+            client: SidecarClient(transport: server),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            ffprobe: nil,
+            runner: FakeTranscodeRunner(),
+            scratchRoot: scratch(),
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        let outcome = await runner.execute(
+            assignment(measure: true, commands: [shiftedMeasurementCommand]), pairing: pairing) { _ in }
+
+        // Half an answer is worse than none: the server measures for itself.
+        #expect(outcome == .delivered(jobId: 12, bytes: 15))
+        #expect(server.qualityReport == nil)
     }
 
     @Test("a measurement that cannot be made reports nothing and the candidate is still delivered")

--- a/src/Optimisarr.Api/Queue/QueueDispatcher.cs
+++ b/src/Optimisarr.Api/Queue/QueueDispatcher.cs
@@ -1218,6 +1218,18 @@ public sealed class QueueDispatcher(
             ? (work.Spec.CropTo?.Width ?? picture.Width, work.Spec.CropTo?.Height ?? picture.Height)
             : (0, 0);
 
+        // The measurement seeks on the source's frame grid, which needs to know where its first
+        // picture sits relative to its container start. That is not kept on the media record, so
+        // the source is probed here; a failed probe only costs the grid alignment, not the plan.
+        double? referenceContainerLead = null;
+        if (work.SourcePicture is not null && work.VerificationPolicy.QualityGateEnabled)
+        {
+            await using var scope = scopeFactory.CreateAsyncScope();
+            var sourceProbe = await scope.ServiceProvider
+                .GetRequiredService<MediaProbeService>()
+                .ProbeAsync(work.Original.Path, cancellationToken);
+            referenceContainerLead = ContainerLeadSeconds(sourceProbe);
+        }
         var quality = work.SourcePicture is { } source
             ? RemoteQualityPlanner.Plan(
                 work.VerificationPolicy,
@@ -1227,6 +1239,7 @@ public sealed class QueueDispatcher(
                 work.Original.HdrConvertedToSdr,
                 work.DurationSeconds,
                 work.Spec.TargetFrameRate ?? work.VideoFrameRate,
+                referenceContainerLead,
                 work.Spec.CropTo,
                 work.Spec.FrameRate)
             : null;
@@ -1728,6 +1741,15 @@ public sealed class QueueDispatcher(
     /// The decoder a worker's command may use: VideoToolbox, when the worker proved it and the
     /// encoder is VideoToolbox too. Other families are not paired with a worker decoder yet.
     /// </summary>
+    /// <summary>
+    /// How far into its container a file's first picture sits, or null when ffprobe reported no
+    /// usable starts. Shared with local verification so both measure the same quantity.
+    /// </summary>
+    internal static double? ContainerLeadSeconds(MediaProbeResult probe) =>
+        probe.Success && probe.VideoStartSeconds is { } video && probe.ContainerStartSeconds is { } container
+            ? video - container
+            : null;
+
     private static string? RemoteHardwareDecoder(WorkerCapabilities worker, string? videoEncoder) =>
         videoEncoder is not null
         && videoEncoder.EndsWith("_videotoolbox", StringComparison.OrdinalIgnoreCase)

--- a/src/Optimisarr.Api/Queue/VerificationService.cs
+++ b/src/Optimisarr.Api/Queue/VerificationService.cs
@@ -169,6 +169,10 @@ public sealed class VerificationService(
                         reference,
                         outputPath,
                         originalProbe,
+                        // A preview's stream-copied clip is not the file VMAF reads, so its
+                        // container lead says nothing about the reference actually decoded.
+                        clip is null ? QueueDispatcher.ContainerLeadSeconds(originalProbe) : null,
+                        clip is null ? QueueDispatcher.ContainerLeadSeconds(outputProbe) : null,
                         quality,
                         // A preview's cheap stream-copy clip is suitable for duration/stream checks,
                         // but can retain keyframe pre-roll. VMAF decodes the full original from the
@@ -434,6 +438,8 @@ public sealed class VerificationService(
         OriginalSnapshot reference,
         string outputPath,
         MediaProbeResult originalProbe,
+        double? referenceContainerLeadSeconds,
+        double? distortedContainerLeadSeconds,
         QualityScoreService quality,
         string qualityReferencePath,
         int? referenceStartSeconds,
@@ -467,7 +473,9 @@ public sealed class VerificationService(
             Acceleration: acceleration,
             ReferenceFrameRate: reference.FrameRate?.TargetFps ?? originalProbe.VideoFrameRate,
             ReferenceCrop: reference.Crop,
-            ReferenceDecimation: reference.FrameRate);
+            ReferenceDecimation: reference.FrameRate,
+            ReferenceContainerLeadSeconds: referenceContainerLeadSeconds,
+            DistortedContainerLeadSeconds: distortedContainerLeadSeconds);
         var result = await quality.MeasureAsync(
             qualityReferencePath,
             outputPath,

--- a/src/Optimisarr.Api/Workers/RemoteQualityPlanner.cs
+++ b/src/Optimisarr.Api/Workers/RemoteQualityPlanner.cs
@@ -27,6 +27,7 @@ internal static class RemoteQualityPlanner
         bool hdrConvertedToSdr,
         double? durationSeconds,
         double? referenceFrameRate,
+        double? referenceContainerLeadSeconds,
         CropRect? crop,
         FrameRateDecimation? decimation)
     {
@@ -58,7 +59,9 @@ internal static class RemoteQualityPlanner
                 Acceleration: VmafAcceleration.None,
                 ReferenceFrameRate: referenceFrameRate,
                 ReferenceCrop: crop,
-                ReferenceDecimation: decimation);
+                ReferenceDecimation: decimation,
+                ReferenceContainerLeadSeconds: referenceContainerLeadSeconds,
+                DistortedShiftToken: RemoteQualityContract.DistortedShiftPlaceholder);
             var command = QualityScoreCommandBuilder.Build(
                 RemoteQualityContract.DistortedPlaceholder,
                 RemoteQualityContract.ReferencePlaceholder,

--- a/src/Optimisarr.Core/Library/MediaProbeService.cs
+++ b/src/Optimisarr.Core/Library/MediaProbeService.cs
@@ -43,7 +43,11 @@ public sealed record MediaProbeResult(
     bool? IsVariableFrameRate,
     string? VideoProfile,
     string? Error,
-    double? VideoFrameRate = null)
+    double? VideoFrameRate = null,
+    // Where the container itself begins: the earliest timestamp of any stream. FFmpeg seeks and
+    // reports timestamps relative to this, so the video's start alone does not say where a picture
+    // will appear in a filter graph. Null when ffprobe did not report it.
+    double? ContainerStartSeconds = null)
 {
     public static MediaProbeResult Failure(string error) =>
         new(false, null, null, null, null, null, null, null, Array.Empty<string>(), Array.Empty<AudioTrackInfo>(),
@@ -141,6 +145,7 @@ public sealed class MediaProbeService : IMediaProbeService
         double? duration = null;
         string? optimisedMarker = null;
         int? formatBitrateKbps = null;
+        double? containerStart = null;
         var formatTags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         if (root.TryGetProperty("format", out var format))
@@ -151,6 +156,7 @@ public sealed class MediaProbeService : IMediaProbeService
             }
 
             formatBitrateKbps = ReadBitrateKbps(format);
+            containerStart = ReadStartTime(format);
 
             if (format.TryGetProperty("duration", out var durationElement) &&
                 durationElement.ValueKind == JsonValueKind.String &&
@@ -347,7 +353,8 @@ public sealed class MediaProbeService : IMediaProbeService
             isVariableFrameRate,
             videoProfile,
             null,
-            videoFrameRate);
+            videoFrameRate,
+            containerStart);
     }
 
     // A cover-art / attached-picture stream is flagged by its disposition; it is a still

--- a/src/Optimisarr.Core/Verification/QualityScoreCommandBuilder.cs
+++ b/src/Optimisarr.Core/Verification/QualityScoreCommandBuilder.cs
@@ -52,7 +52,19 @@ public sealed record QualityMeasurementContext(
     // How a capped encode thinned its frames, so the reference is thinned by the same index rule
     // before any timestamp handling. Decimating by nearest timestamp instead can keep different
     // frames than the encode kept, and then the comparison is of neighbours, not of the same frame.
-    Queue.FrameRateDecimation? ReferenceDecimation = null);
+    Queue.FrameRateDecimation? ReferenceDecimation = null,
+    // How far into its own container each file's first picture sits (video start minus container
+    // start). FFmpeg seeks and stamps frames relative to the container start, which is the earliest
+    // stream, so two files whose pictures match frame for frame still present them at different
+    // instants when one carries audio priming the other does not. Half a frame of that is enough
+    // for the cadence filter to round the same picture into neighbouring slots and then score frame
+    // N against frame N+1. The reference's lead places the seek on its frame grid; the difference
+    // between the two leads is taken off the distorted timeline before rounding.
+    double? ReferenceContainerLeadSeconds = null,
+    double? DistortedContainerLeadSeconds = null,
+    // A remote worker measures the candidate's lead itself once it has encoded, so the server
+    // hands it this token to substitute rather than a number.
+    string? DistortedShiftToken = null);
 
 /// <summary>A complete, shell-free FFmpeg VMAF invocation and its selected measurement policy.</summary>
 public sealed record QualityScoreCommand(
@@ -151,18 +163,24 @@ public static class QualityScoreCommandBuilder
         var pixelFormat = context.ReferenceIsHdr && !context.HdrConvertedToSdr
             ? "yuv420p10le"
             : "yuv420p";
-        var distortedInputStart = InputSeek(context.DistortedStartSeconds, context.MeasureDurationSeconds);
-        var referenceInputStart = InputSeek(context.ReferenceStartSeconds, context.MeasureDurationSeconds);
+        var distortedInputStart = InputSeek(
+            context.DistortedStartSeconds, context.MeasureDurationSeconds,
+            context.ReferenceFrameRate, context.ReferenceContainerLeadSeconds);
+        var referenceInputStart = InputSeek(
+            context.ReferenceStartSeconds, context.MeasureDurationSeconds,
+            context.ReferenceFrameRate, context.ReferenceContainerLeadSeconds);
         var distortedTimeline = TimelinePreparation(
             context.DistortedStartSeconds,
             distortedInputStart,
             context.MeasureDurationSeconds,
-            context.ReferenceFrameRate);
+            context.ReferenceFrameRate,
+            DistortedShift(context));
         var referenceTimeline = TimelinePreparation(
             context.ReferenceStartSeconds,
             referenceInputStart,
             context.MeasureDurationSeconds,
-            context.ReferenceFrameRate);
+            context.ReferenceFrameRate,
+            shift: null);
         var normalise = $"{scale},format={pixelFormat}";
         var referencePreparation = context.ReferenceIsHdr && context.HdrConvertedToSdr
             ? $"{HdrToneMap.Filter},{normalise}"
@@ -208,7 +226,7 @@ public static class QualityScoreCommandBuilder
         if (distortedInputStart is > 0)
         {
             arguments.Add("-ss");
-            arguments.Add(distortedInputStart.Value.ToString());
+            arguments.Add(FormatSeconds(distortedInputStart.Value));
         }
         AppendInputAcceleration(arguments, acceleration);
         // libvmaf requires distorted first and reference second.
@@ -220,7 +238,7 @@ public static class QualityScoreCommandBuilder
         if (referenceInputStart is > 0)
         {
             arguments.Add("-ss");
-            arguments.Add(referenceInputStart.Value.ToString());
+            arguments.Add(FormatSeconds(referenceInputStart.Value));
         }
         AppendInputAcceleration(arguments, acceleration);
         arguments.Add("-i");
@@ -281,18 +299,61 @@ public static class QualityScoreCommandBuilder
             $"log_fmt=json:log_path={logPath}:shortest=1:repeatlast=0";
     }
 
-    private static int? InputSeek(int? windowStartSeconds, int? windowDurationSeconds) =>
-        windowStartSeconds is not { } start
-            ? null
-            : windowDurationSeconds is > 0
-                ? Math.Max(0, start - SampleSeekPrerollSeconds)
-                : start;
+    private static double? InputSeek(
+        int? windowStartSeconds,
+        int? windowDurationSeconds,
+        double? referenceFrameRate,
+        double? referenceContainerLeadSeconds)
+    {
+        if (windowStartSeconds is not { } start)
+        {
+            return null;
+        }
+        if (windowDurationSeconds is not > 0)
+        {
+            return start;
+        }
+        var target = Math.Max(0, start - SampleSeekPrerollSeconds);
+        if (target == 0 || referenceFrameRate is not { } frameRate || referenceContainerLeadSeconds is not { } lead)
+        {
+            return target;
+        }
+        // A whole-second target usually falls between two reference pictures, leaving every retained
+        // picture some fraction of a frame from a cadence slot centre; at half a frame the rounding
+        // is a tie, and the half-millisecond of container timestamp rounding decides it differently
+        // for each input. Seeking to the nearest picture instant instead puts the pictures on the
+        // slot centres, where nothing that small can move them.
+        var frameSeconds = 1 / frameRate;
+        var snapped = Math.Round((target - lead) / frameSeconds) * frameSeconds + lead;
+        return Math.Round(Math.Max(0, snapped), 6);
+    }
+
+    // The distorted timeline shift: how much later than the reference the candidate presents the
+    // same picture, as a filter expression value. Nothing when there is nothing to remove.
+    private static string? DistortedShift(QualityMeasurementContext context)
+    {
+        if (context.DistortedShiftToken is { Length: > 0 } token)
+        {
+            return token;
+        }
+        if (context.DistortedContainerLeadSeconds is not { } distorted
+            || context.ReferenceContainerLeadSeconds is not { } reference)
+        {
+            return null;
+        }
+        var shift = Math.Round(distorted - reference, 6);
+        return Math.Abs(shift) < 0.0005 ? null : FormatSeconds(shift);
+    }
+
+    private static string FormatSeconds(double seconds) =>
+        seconds.ToString("0.######", CultureInfo.InvariantCulture);
 
     private static string TimelinePreparation(
         int? windowStartSeconds,
-        int? inputStartSeconds,
+        double? inputStartSeconds,
         int? windowDurationSeconds,
-        double? referenceFrameRate)
+        double? referenceFrameRate,
+        string? shift)
     {
         // An input seek leaves each decoder's first retained PTS relative to the common
         // pre-roll target. Different GOP layouts can therefore begin at different positive PTS
@@ -301,15 +362,24 @@ public static class QualityScoreCommandBuilder
         // their container origins first. The final reset leaves libvmaf with zero-based timelines.
         const string origin = "settb=AVTB,setpts=PTS-STARTPTS";
         var inputTimeline = inputStartSeconds is > 0 ? "settb=AVTB" : origin;
+        // A seeked input keeps its container-relative timestamps until fps has rounded them, so
+        // this is where the candidate's extra lead over the reference has to come off. A rebased
+        // (unseeked) timeline has already discarded both origins and needs no shift.
+        // settb=AVTB has just put the timestamps in microseconds, so the shift in seconds is scaled
+        // rather than divided by TB: a remote worker refuses any filter value containing a slash,
+        // since that is how a path would smuggle itself in, and the expression need not use one.
+        var lead = shift is not null && inputStartSeconds is > 0
+            ? $"setpts=PTS-{shift}*1000000,"
+            : string.Empty;
         var cadence = referenceFrameRate is { } frameRate
             ? $"fps=fps={frameRate.ToString("G17", CultureInfo.InvariantCulture)}:start_time=0,"
             : string.Empty;
         var alignment = windowStartSeconds is { } start && windowDurationSeconds is > 0
-            ? $"trim=start={start - (inputStartSeconds ?? 0)}:duration={windowDurationSeconds.Value},"
+            ? $"trim=start={FormatSeconds(start - (inputStartSeconds ?? 0))}:duration={windowDurationSeconds.Value},"
             : string.Empty;
         return cadence.Length == 0 && alignment.Length == 0
             ? origin
-            : $"{inputTimeline},{cadence}{alignment}{origin}";
+            : $"{inputTimeline},{lead}{cadence}{alignment}{origin}";
     }
 
     private static string DescribePreprocessing(

--- a/src/Optimisarr.Core/Workers/RemoteQualityContract.cs
+++ b/src/Optimisarr.Core/Workers/RemoteQualityContract.cs
@@ -20,6 +20,10 @@ public sealed record RemoteQualityContract(
     public const string DistortedPlaceholder = "{{distorted}}";
     public const string ReferencePlaceholder = "{{reference}}";
     public const string LogPlaceholder = "{{log}}";
+    // Substituted by the worker inside the filter graph with the seconds by which its candidate
+    // presents each picture later than the source, measured from both files' container and video
+    // starts once the encode exists. See QualityMeasurementContext.DistortedShiftToken.
+    public const string DistortedShiftPlaceholder = "{{distortedShift}}";
 
     public int WindowCount => Commands.Count;
 }

--- a/tests/Optimisarr.Tests/MediaProbeParseTests.cs
+++ b/tests/Optimisarr.Tests/MediaProbeParseTests.cs
@@ -37,6 +37,28 @@ public sealed class MediaProbeParseTests
     }
 
     [Fact]
+    public void Parse_keeps_the_container_start_so_a_picture_lead_can_be_measured()
+    {
+        // Audio priming puts the container start 21 ms before the first picture. FFmpeg seeks and
+        // timestamps relative to that container start, so the lead matters for frame alignment.
+        const string json = """
+        {
+          "streams": [
+            { "codec_type": "video", "codec_name": "h264", "width": 1920, "height": 1080, "start_time": "0.000000" },
+            { "codec_type": "audio", "codec_name": "aac", "start_time": "-0.021000" }
+          ],
+          "format": { "format_name": "matroska,webm", "duration": "1389.674000", "start_time": "-0.021000" }
+        }
+        """;
+
+        var result = MediaProbeService.Parse(json);
+
+        Assert.Equal(0.0, result.VideoStartSeconds);
+        Assert.Equal(-0.021, result.ContainerStartSeconds);
+        Assert.Null(MediaProbeService.Parse(SampleJson).ContainerStartSeconds);
+    }
+
+    [Fact]
     public void Parse_retains_the_average_video_frame_rate_for_frame_aligned_quality_measurement()
     {
         const string json = """

--- a/tests/Optimisarr.Tests/QualityScoreCommandBuilderTests.cs
+++ b/tests/Optimisarr.Tests/QualityScoreCommandBuilderTests.cs
@@ -183,6 +183,89 @@ public sealed class QualityScoreCommandBuilderTests
     }
 
     [Fact]
+    public void Sampled_measurement_snaps_the_seek_to_the_reference_frame_grid_and_removes_the_distorted_lead()
+    {
+        var command = QualityScoreCommandBuilder.Build(
+            "/work/output.mp4", "/data/original.mkv", "/tmp/vmaf.json",
+            new QualityMeasurementContext(
+                1920, 1080, ReferenceIsHdr: false, HdrConvertedToSdr: false,
+                DistortedStartSeconds: 118, ReferenceStartSeconds: 118, MeasureDurationSeconds: 40,
+                ReferenceFrameRate: 24000d / 1001d,
+                // The original's audio leads its video by 21 ms; the encode's video starts 41 ms
+                // into its container. Frame for frame the pictures are the same.
+                ReferenceContainerLeadSeconds: 0.021, DistortedContainerLeadSeconds: 0.041),
+            threads: 4);
+        var args = command.Arguments;
+        // 113 s falls between two reference pictures. Seeking to the nearest picture instant
+        // (2709 frames plus the 21 ms lead) puts every retained picture on a cadence slot centre,
+        // where a half-millisecond of container rounding cannot move it to the neighbouring slot.
+        Assert.Equal("113.008875", ValueAfter(args, "-ss", occurrence: 1));
+        Assert.Equal("113.008875", ValueAfter(args, "-ss", occurrence: 2));
+        // The 20 ms by which the encode presents each picture later than the original is removed
+        // before cadence rounding; the reference timeline is untouched. Both trim the same span.
+        Assert.Contains(
+            "[0:v]settb=AVTB,setpts=PTS-0.02*1000000,fps=fps=23.976023976023978:start_time=0,trim=start=4.991125:duration=40,",
+            command.FilterGraph);
+        Assert.Contains(
+            "[1:v]settb=AVTB,fps=fps=23.976023976023978:start_time=0,trim=start=4.991125:duration=40,",
+            command.FilterGraph);
+    }
+
+    [Fact]
+    public void Sampled_measurement_hands_a_remote_worker_a_token_for_the_lead_it_will_measure_itself()
+    {
+        var command = QualityScoreCommandBuilder.Build(
+            "{{distorted}}", "{{reference}}", "{{log}}",
+            new QualityMeasurementContext(
+                1920, 1080, ReferenceIsHdr: false, HdrConvertedToSdr: false,
+                DistortedStartSeconds: 118, ReferenceStartSeconds: 118, MeasureDurationSeconds: 40,
+                ReferenceFrameRate: 24000d / 1001d,
+                ReferenceContainerLeadSeconds: 0.021, DistortedShiftToken: "{{distortedShift}}"),
+            threads: 8);
+        Assert.Equal("113.008875", ValueAfter(command.Arguments, "-ss", occurrence: 1));
+        Assert.Contains("[0:v]settb=AVTB,setpts=PTS-{{distortedShift}}*1000000,fps=", command.FilterGraph);
+        Assert.DoesNotContain("[1:v]settb=AVTB,setpts=PTS-{{distortedShift}}", command.FilterGraph);
+    }
+
+    [Fact]
+    public void Equal_container_leads_add_no_shift_and_an_unknown_lead_keeps_the_whole_second_seek()
+    {
+        var equal = QualityScoreCommandBuilder.Build(
+            "/work/output.mp4", "/data/original.mkv", "/tmp/vmaf.json",
+            new QualityMeasurementContext(
+                1920, 1080, ReferenceIsHdr: false, HdrConvertedToSdr: false,
+                DistortedStartSeconds: 118, ReferenceStartSeconds: 118, MeasureDurationSeconds: 40,
+                ReferenceFrameRate: 24000d / 1001d,
+                ReferenceContainerLeadSeconds: 0.041, DistortedContainerLeadSeconds: 0.041),
+            threads: 4);
+        Assert.DoesNotContain("setpts=PTS-0", equal.FilterGraph);
+
+        var unknown = QualityScoreCommandBuilder.Build(
+            "/work/output.mp4", "/data/original.mkv", "/tmp/vmaf.json",
+            new QualityMeasurementContext(
+                1920, 1080, ReferenceIsHdr: false, HdrConvertedToSdr: false,
+                DistortedStartSeconds: 118, ReferenceStartSeconds: 118, MeasureDurationSeconds: 40,
+                ReferenceFrameRate: 24000d / 1001d),
+            threads: 4);
+        Assert.Equal("113", ValueAfter(unknown.Arguments, "-ss", occurrence: 1));
+        Assert.Contains("trim=start=5:duration=40", unknown.FilterGraph);
+    }
+
+    [Fact]
+    public void Full_file_measurement_rebases_both_origins_so_no_lead_shift_is_needed()
+    {
+        var command = QualityScoreCommandBuilder.Build(
+            "/work/output.mp4", "/data/original.mkv", "/tmp/vmaf.json",
+            new QualityMeasurementContext(
+                1920, 1080, ReferenceIsHdr: false, HdrConvertedToSdr: false,
+                ReferenceFrameRate: 25,
+                ReferenceContainerLeadSeconds: 0.021, DistortedContainerLeadSeconds: 0.041),
+            threads: 4);
+        Assert.DoesNotContain("setpts=PTS-0.02", command.FilterGraph);
+        Assert.DoesNotContain("-ss", command.Arguments);
+    }
+
+    [Fact]
     public void Full_file_cadence_alignment_rebases_each_container_origin_before_fps_rounding()
     {
         var command = QualityScoreCommandBuilder.Build(

--- a/tests/Optimisarr.Tests/RemoteQualityPlannerTests.cs
+++ b/tests/Optimisarr.Tests/RemoteQualityPlannerTests.cs
@@ -1,0 +1,51 @@
+using Optimisarr.Api.Workers;
+using Optimisarr.Core.Verification;
+using Optimisarr.Core.Workers;
+
+namespace Optimisarr.Tests;
+
+public sealed class RemoteQualityPlannerTests
+{
+    [Fact]
+    public void Sampled_commands_seek_on_the_reference_grid_and_leave_the_distorted_lead_to_the_worker()
+    {
+        var policy = VerificationPolicy.Default with { QualityGateEnabled = true, ClipVmafEnabled = true };
+
+        var contract = RemoteQualityPlanner.Plan(
+            policy,
+            referenceWidth: 1920,
+            referenceHeight: 1080,
+            referenceIsHdr: false,
+            hdrConvertedToSdr: false,
+            durationSeconds: 1389.638,
+            referenceFrameRate: 24000d / 1001d,
+            referenceContainerLeadSeconds: 0.021,
+            crop: null,
+            decimation: null);
+
+        Assert.NotNull(contract);
+        Assert.Equal(3, contract!.WindowCount);
+        var first = contract.Commands[0];
+        // The worker has both files once it has encoded, so it is the one that can measure how far
+        // into its container the candidate's first picture sits. The server leaves it that token.
+        var filter = first[first.ToList().IndexOf("-lavfi") + 1];
+        Assert.Contains($"[0:v]settb=AVTB,setpts=PTS-{RemoteQualityContract.DistortedShiftPlaceholder}*1000000,fps=", filter);
+        Assert.Single(filter.Split(RemoteQualityContract.DistortedShiftPlaceholder).Skip(1));
+        // The reference's lead is the server's to know, so the seek is already on its frame grid.
+        Assert.Equal("113.008875", first[first.ToList().IndexOf("-ss") + 1]);
+    }
+
+    [Fact]
+    public void An_unknown_reference_lead_still_plans_but_keeps_the_whole_second_seek()
+    {
+        var policy = VerificationPolicy.Default with { QualityGateEnabled = true, ClipVmafEnabled = true };
+
+        var contract = RemoteQualityPlanner.Plan(
+            policy, 1920, 1080, false, false, 1389.638, 24000d / 1001d, null, null, null);
+
+        Assert.NotNull(contract);
+        var first = contract!.Commands[0];
+        Assert.Equal("113", first[first.ToList().IndexOf("-ss") + 1]);
+        Assert.Contains(RemoteQualityContract.DistortedShiftPlaceholder, first[first.ToList().IndexOf("-lavfi") + 1]);
+    }
+}


### PR DESCRIPTION
## Outcome

Sampled-window VMAF compared frame N of the candidate with frame N+1 of the source whenever the two files' video streams start at different offsets inside their containers. On the first real remote job (2026-09-13, job 5845) this scored every attempt at "lowest frame 0, mean ~85", the decoder-corruption check re-encoded it with software decode, and it failed anyway. The encode was fine.

## Cause

Both inputs are seeked to the same whole second and paired by timestamp, but FFmpeg stamps frames relative to the container start (the earliest stream). Source: audio at -0.021 s, video at 0. Candidate: audio at 0, video at 0.041 s. Same pictures, presented 20 ms apart, which is half a frame at 23.976 fps and exactly the `fps` filter's rounding tie. Which way it fell depended on the seek position, so some windows aligned and others did not.

## Fix

- `QualityScoreCommandBuilder`: the pre-roll seek snaps to the nearest source picture instant (needs the reference frame rate and its container lead), so retained frames sit on slot centres. The distorted timeline gets `setpts=PTS-<shift>*1000000` after `settb=AVTB`, removing the candidate's extra lead before cadence rounding. No slash, because the worker refuses slashes in filter values.
- `MediaProbeResult` gains `ContainerStartSeconds`; a lead is video start minus container start.
- Local verification passes both leads from its probes. Remote plans carry the source lead (probed at claim time) and leave `{{distortedShift}}` for the worker.
- Sidecar: `MeasurementCommand` accepts the token inside the filter only; `TimelineLead` measures both files with the bundled ffprobe; a command needing the shift with no ffprobe reports no evidence. New `bundledFfprobe()`.

Not changed: the decoder-corruption heuristic. It will no longer fire on this signature once the measurement is right, but it remains a heuristic.

## Verification

- Real ffmpeg on the job's source and a fresh VideoToolbox encode, the builder's exact windowed command: window 118 harmonic 0.3 (59 frames under 5) before; after, windows 118/300/674/1230/1349 all harmonic 93.4 to 94.4 with no frame under 70.
- `dotnet test`: 1914 passed (4 new builder tests, 2 planner tests, 1 probe test).
- `swift test`: 87 passed (token contract, lead parsing and formatting, shift filled in from both files, no ffprobe means no evidence).

## Risk

Any sampled measurement's seek value and trim start become fractional when the lead is known. Full-file measurements are untouched. An older sidecar receiving the new token refuses the command and returns no evidence, and the server measures locally with the corrected command.
