### PR TITLE
Record the worker's command on a leased job and log why its evidence was refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,13 @@
 
 ### Fixed
 
+- **The queue shows the command a remote worker will actually run.** A job leased to a worker
+  kept whatever ffmpeg arguments and encoder this server last used for it, so the first real remote
+  job displayed a stale QSV command while the Mac was encoding with VideoToolbox. Claiming now
+  records the worker's encoder and arguments on the job.
+- **Why a worker's VMAF evidence was refused is now in the server log.** The worker's card keeps
+  only its latest problem, and a verification verdict overwrote the refusal within minutes, leaving
+  no trace of the reason. Both the refusal, with its objections, and an acceptance are logged.
 - **Sampled VMAF no longer scores a candidate against its own neighbouring frames.** Both inputs
   of a sampled window are seeked to the same whole second and then paired by timestamp, but FFmpeg
   stamps frames relative to each file's container start, which is the earliest stream. A source

--- a/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
+++ b/src/Optimisarr.Api/Endpoints/WorkerLeaseEndpoints.cs
@@ -243,6 +243,10 @@ internal static class WorkerLeaseEndpoints
 
                 // The exclusion that matters: off the queue, so this machine will not also run it.
                 job.Status = JobStatus.Leased;
+                // The queue shows these for every job. For a remote job they must be what the
+                // worker will actually run, not whatever this server last ran for it.
+                job.VideoEncoder = assignment.VideoEncoder;
+                job.FfmpegArguments = string.Join(' ', assignment.Arguments);
 
                 try
                 {

--- a/src/Optimisarr.Api/Queue/QueueDispatcher.cs
+++ b/src/Optimisarr.Api/Queue/QueueDispatcher.cs
@@ -738,6 +738,12 @@ public sealed class QueueDispatcher(
             if (delivered.WasAsked && delivered.Accepted is null
                 && work.Value.VerificationPolicy.RequiresVmaf(work.Value.Spec.Kind, work.Value.Original.VideoReencoded))
             {
+                // The worker's card keeps only its latest problem, and a later verdict overwrites
+                // this one within minutes. The log is where the reason survives.
+                logger.LogWarning(
+                    "Job {JobId}: quality evidence from {Worker} was not accepted, measuring VMAF locally: {Objections}",
+                    jobId, deliveredBy.Name,
+                    delivered.Objections.Count > 0 ? string.Join(" ", delivered.Objections) : "no evidence was returned");
                 await RecordWorkerProblemAsync(
                     deliveredBy.Id,
                     $"Its quality evidence for {Path.GetFileName(work.Value.Original.Path)} was not accepted, so this server measured VMAF itself: "
@@ -745,6 +751,12 @@ public sealed class QueueDispatcher(
                     cancellationToken);
             }
 
+            if (delivered.Accepted is not null)
+            {
+                logger.LogInformation(
+                    "Job {JobId}: quality evidence from {Worker} accepted; VMAF will not be re-measured here",
+                    jobId, deliveredBy.Name);
+            }
             var disposition = await VerifyAndFinishAsync(
                 jobId, candidatePath, work.Value, cancellationToken,
                 // A worker's hardware decode can corrupt frames as a local one can; the retry

--- a/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
+++ b/tests/Optimisarr.Tests/WorkerLeaseEndpointTests.cs
@@ -246,6 +246,26 @@ public sealed class WorkerLeaseEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Claiming_records_the_worker_command_on_the_job()
+    {
+        // The queue shows a job's ffmpeg arguments. For a remote job they used to be whatever this
+        // server last ran for it, which on the first real remote job meant a stale QSV command
+        // from a previous local attempt while the Mac was actually encoding with VideoToolbox.
+        await EnableRemoteWorkers();
+        var worker = await PairWorkerWithEncoders("Recorder", "hevc_videotoolbox");
+        var jobId = await QueueAJob();
+
+        using var claim = await worker.PostAsJsonAsync("/api/workers/claim", new { });
+        Assert.Equal(HttpStatusCode.OK, claim.StatusCode);
+        var assignment = await claim.Content.ReadFromJsonAsync<JsonElement>();
+        var arguments = assignment.GetProperty("arguments").EnumerateArray().Select(a => a.GetString()!).ToList();
+
+        var row = await JobRow(jobId);
+        Assert.Equal("hevc_videotoolbox", row.GetProperty("videoEncoder").GetString());
+        Assert.Equal(string.Join(' ', arguments), row.GetProperty("ffmpegArguments").GetString());
+    }
+
+    [Fact]
     public async Task Renewing_reports_where_the_worker_is_and_moves_the_queue_bar()
     {
         // The worker only knows ffmpeg's out_time; the server owns the duration, so the fraction


### PR DESCRIPTION
## Outcome

The queue row for a remote job shows the command the worker will actually run, and the server log keeps the reason a worker's VMAF evidence was refused.

## Scope

- `WorkerLeaseEndpoints` claim: writes the assignment's encoder and arguments onto the job when the lease is issued. Before, a job leased to a worker kept whatever this server last ran for it; on job 5845 that was a stale 0.2.11 QSV command while the Mac encoded with VideoToolbox.
- `QueueDispatcher`: a warning with the objections when delivered evidence is not accepted and the server measures locally, and an information line when it is accepted. The worker's single "last problem" slot was overwritten by the verdict within minutes, so on 2026-09-13 the refusal reason was unrecoverable.
- CHANGELOG entries under Unreleased → Fixed.

Excluded: a per-worker problem history; the decoder-corruption heuristic.

## Verification

- New test `Claiming_records_the_worker_command_on_the_job` fails before, passes after.
- `dotnet test Optimisarr.slnx`: 1915 passed.

## Risk

Two columns on the job row change meaning for remote jobs, to the truthful value. Logging only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
