### PR TITLE
Prove every encoder before the sidecar advertises it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,13 @@
 
 ### Fixed
 
+- **The macOS sidecar proves every encoder before advertising it, CPU ones included.** It used
+  to trust `ffmpeg -encoders` for software encoders and only test-encode the VideoToolbox ones. The
+  bundled libx265 segfaults on its first frame on Apple Silicon, and the sidecar advertised it
+  anyway, so the server could have chosen an encoder that would never finish a job. Every listed
+  encoder now has to complete a three-frame throwaway encode at launch, and a crash counts as a
+  refusal. The ffmpeg build script also takes its tags and extra x265 cmake flags from the
+  environment, so a rebuild can be tried without editing it.
 - **Sampled VMAF no longer scores a candidate against its own neighbouring frames.** Both inputs
   of a sampled window are seeked to the same whole second and then paired by timestamp, but FFmpeg
   stamps frames relative to each file's container start, which is the earliest stream. A source

--- a/sidecars/macos/Sources/SidecarCore/CapabilityProber.swift
+++ b/sidecars/macos/Sources/SidecarCore/CapabilityProber.swift
@@ -34,7 +34,7 @@ public struct ProcessCommandRunner: CommandRunner {
 /// Works out what this Mac can actually do.
 ///
 /// Two stages, matching the server's `HardwareCapabilityService`: parse `ffmpeg -encoders` for a
-/// cheap first pass, then confirm each hardware encoder with a real throwaway encode. Every Apple
+/// cheap first pass, then confirm every encoder with a real throwaway encode. Every Apple
 /// ffmpeg build lists VideoToolbox whether or not this particular machine can open it, so listing
 /// alone would have the sidecar advertise encoders that fail on first use — and a job scheduled
 /// against a false capability is a job that can only fail.
@@ -86,11 +86,10 @@ public struct CapabilityProber: Sendable {
         }
 
         var proved: [String] = []
-        for encoder in EncoderListParser.parse(listing.output) {
-            if EncoderListParser.needsConfirmation(encoder) {
-                let probe = await runner.run(ffmpeg, EncoderProbeCommand.arguments(for: encoder))
-                guard probe.exitCode == 0 else { continue }
-            }
+        for encoder in EncoderListParser.parse(listing.output) where EncoderListParser.needsConfirmation(encoder) {
+            // A crash surfaces as a signal status rather than a clean error, and counts the same.
+            let probe = await runner.run(ffmpeg, EncoderProbeCommand.arguments(for: encoder))
+            guard probe.exitCode == 0 else { continue }
             proved.append(encoder)
         }
 

--- a/sidecars/macos/Sources/SidecarCore/EncoderProbe.swift
+++ b/sidecars/macos/Sources/SidecarCore/EncoderProbe.swift
@@ -43,10 +43,14 @@ public enum EncoderListParser {
         return found
     }
 
-    /// True when the encoder runs on the GPU and therefore needs proving rather than trusting.
-    /// CPU encoders are taken from the listing, matching how the server treats them.
+    /// Every encoder needs proving. Listing only says ffmpeg was compiled with it: a VideoToolbox
+    /// encoder can fail to open on a given machine, and a bundled software encoder can be broken
+    /// outright — the vendored libx265 segfaulted on its first frame on 2026-09-13 while this
+    /// sidecar, trusting the listing for CPU encoders, went on advertising it. The throwaway
+    /// encode costs well under a second per encoder and runs once per launch.
     public static func needsConfirmation(_ encoder: String) -> Bool {
-        encoder.hasSuffix("_videotoolbox")
+        _ = encoder
+        return true
     }
 }
 

--- a/sidecars/macos/Tests/SidecarCoreTests/CapabilityProberTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/CapabilityProberTests.swift
@@ -62,9 +62,27 @@ struct CapabilityProberTests {
 
         #expect(capabilities.videoEncoders.contains("hevc_videotoolbox"))
         #expect(runner.probedEncoders.contains("hevc_videotoolbox"))
-        // CPU encoders are trusted from the listing, exactly as the server treats them.
-        #expect(!runner.probedEncoders.contains("libx265"))
+        // CPU encoders get the same treatment: proved by an encode, not trusted from the listing.
+        #expect(runner.probedEncoders.contains("libx265"))
         #expect(capabilities.videoEncoders.contains("libx265"))
+    }
+
+    @Test("a listed but crashing CPU encoder is not advertised")
+    func rejectsBrokenSoftwareEncoder() async {
+        // The bundled libx265 segfaulted on its first frame on 2026-09-13 while the sidecar still
+        // advertised it, because CPU encoders were taken from the listing on trust. A crash is a
+        // signal exit, not a clean non-zero status, and must count as a refusal just the same.
+        let runner = ScriptedRunner([
+            "encoders": (0, listing),
+            "filters": (0, "libvmaf"),
+            "hevc_videotoolbox": (0, ""),
+            "libx265": (139, ""),
+        ])
+
+        let capabilities = await prober(runner).probe(name: "Mac")
+
+        #expect(!capabilities.videoEncoders.contains("libx265"))
+        #expect(capabilities.videoEncoders.contains("hevc_videotoolbox"))
     }
 
     @Test("a listed but broken VideoToolbox encoder is not advertised")

--- a/sidecars/macos/Tests/SidecarCoreTests/EncoderProbeTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/EncoderProbeTests.swift
@@ -52,14 +52,17 @@ struct EncoderListParserTests {
         #expect(EncoderListParser.parse("ffmpeg: command not found").isEmpty)
     }
 
-    @Test("hardware encoders must be proved, CPU encoders may be trusted")
+    @Test("every encoder must be proved, CPU ones included")
     func confirmationPolicy() {
-        // The distinction that matters: ffmpeg lists what it was compiled with, and every Apple
-        // build lists VideoToolbox whether or not this machine can actually open it.
+        // ffmpeg lists what it was compiled with. Every Apple build lists VideoToolbox whether or
+        // not this machine can open it, and a bundled libx265 that segfaults on its first frame
+        // (seen 2026-09-13) is listed just the same. Trusting the listing for CPU encoders let the
+        // sidecar advertise an encoder that could never finish a job.
         #expect(EncoderListParser.needsConfirmation("hevc_videotoolbox"))
         #expect(EncoderListParser.needsConfirmation("h264_videotoolbox"))
-        #expect(!EncoderListParser.needsConfirmation("libx265"))
-        #expect(!EncoderListParser.needsConfirmation("libx264"))
+        #expect(EncoderListParser.needsConfirmation("libx265"))
+        #expect(EncoderListParser.needsConfirmation("libx264"))
+        #expect(EncoderListParser.needsConfirmation("libsvtav1"))
     }
 }
 

--- a/sidecars/macos/scripts/build-ffmpeg.sh
+++ b/sidecars/macos/scripts/build-ffmpeg.sh
@@ -21,10 +21,14 @@ BUILD="$(pwd)/.build-ffmpeg"
 PREFIX="${BUILD}/prefix"
 
 # Pinned. Moving any of these is a deliberate act, not a drift.
-X264_TAG="stable"
-X265_TAG="4.2"
-VMAF_TAG="v3.0.0"
-FFMPEG_TAG="n7.1"
+# Each tag can be overridden from the environment for a one-off experiment; the defaults are
+# the pinned build.
+X264_TAG="${X264_TAG:-stable}"
+X265_TAG="${X265_TAG:-4.2}"
+VMAF_TAG="${VMAF_TAG:-v3.0.0}"
+FFMPEG_TAG="${FFMPEG_TAG:-n7.1}"
+# Extra cmake flags for x265, e.g. -DENABLE_ASSEMBLY=OFF while chasing a crash.
+X265_CMAKE_FLAGS="${X265_CMAKE_FLAGS:-}"
 
 JOBS="$(sysctl -n hw.ncpu)"
 
@@ -72,7 +76,7 @@ if [[ ! -f "${PREFIX}/lib/libx265.a" ]]; then
   # minimum-version half.
   (cd "${BUILD}/x265/build" && cmake ../source -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-      -DENABLE_SHARED=OFF -DENABLE_CLI=OFF >/dev/null && make -j"${JOBS}" >/dev/null && make install >/dev/null)
+      -DENABLE_SHARED=OFF -DENABLE_CLI=OFF ${X265_CMAKE_FLAGS} >/dev/null && make -j"${JOBS}" >/dev/null && make install >/dev/null)
 fi
 
 if [[ ! -f "${PREFIX}/lib/libvmaf.a" ]]; then


### PR DESCRIPTION
## Outcome

The macOS sidecar no longer advertises an encoder it cannot run. Every listed encoder must complete the three-frame throwaway encode at launch; before, only VideoToolbox encoders were tested and CPU encoders were trusted from `ffmpeg -encoders`.

## Why now

The vendored ffmpeg's libx265 segfaults on its first frame on Apple Silicon (any resolution, assembly on or off, x265 4.2). The sidecar advertised libx265 regardless, so the server could have chosen it for a job that could never finish. A signal exit now counts as a refusal like any non-zero status.

## Scope

- `EncoderListParser.needsConfirmation` returns true for every encoder; `CapabilityProber` probes each one.
- `build-ffmpeg.sh` takes its tags and extra x265 cmake flags from the environment, so a rebuild can be tried without editing it. Defaults unchanged.
- Tests: the policy test now expects every encoder to need confirmation; a new prober test lists a crashing libx265 and expects it not to be advertised.
- CHANGELOG entry under Unreleased → Fixed.

Excluded: the libx265 crash itself. The wrapper crashes inside ffmpeg's `libx265_encode_frame`; a rebuild against x265 3.6 is being tried and will come separately.

## Verification

- `swift test`: 88 tests in 19 suites passed. The policy test failed before the change.

## Risk

A Mac whose libx265 is broken now advertises one encoder fewer, which is the truth. Launch takes a fraction of a second longer for the extra probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
