### PR TITLE
Wait for a condition in the sidecar work-loop tests, not a fixed delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@
 
 ### Fixed
 
+- **The macOS sidecar's work-loop tests wait for a condition instead of a fixed delay.** A test
+  that slept 200 ms and then asserted the job had run failed on a loaded CI runner where the first
+  claim had not yet gone out, reporting a defect that did not exist. The shared `waitFor` helper
+  polls with a generous timeout, so these tests stay fast locally and honest under load.
 - **Sampled VMAF no longer scores a candidate against its own neighbouring frames.** Both inputs
   of a sampled window are seeked to the same whole second and then paired by timestamp, but FFmpeg
   stamps frames relative to each file's container start, which is the earliest stream. A source

--- a/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
@@ -362,17 +362,4 @@ struct SidecarSessionTests {
         #expect(session.lastOutcome == nil)
     }
 
-    /// Polls a condition rather than sleeping a fixed time, so the tests stay fast and are not
-    /// timing-sensitive on a loaded machine.
-    private func waitFor(
-        timeout: TimeInterval = 2,
-        _ condition: @MainActor () -> Bool
-    ) async throws {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if condition() { return }
-            try await Task.sleep(nanoseconds: 5_000_000)
-        }
-        Issue.record("Condition not met within \(timeout)s")
-    }
 }

--- a/sidecars/macos/Tests/SidecarCoreTests/WaitFor.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/WaitFor.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+
+/// Polls a condition instead of sleeping a fixed time.
+///
+/// The session's loop runs on its own tasks, so a test that sleeps "long enough" is really betting
+/// on how loaded the machine is. That bet was lost on a CI runner on 2026-09-13: a 200 ms wait
+/// expired before the first claim had even gone out, and a test that passes in milliseconds
+/// locally failed. Polling makes the fast case fast and the slow case correct.
+@MainActor
+func waitFor(
+    timeout: TimeInterval = 5,
+    _ description: @autoclosure () -> String = "the expected state",
+    _ condition: @MainActor () -> Bool
+) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if condition() { return }
+        try await Task.sleep(nanoseconds: 5_000_000)
+    }
+    Issue.record("Timed out after \(timeout)s waiting for \(description()).")
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
@@ -708,7 +708,11 @@ struct SessionWorkLoopTests {
             sleep: { _ in try await Task.sleep(nanoseconds: 5_000_000) })
 
         session.restore()
-        try await Task.sleep(nanoseconds: 200_000_000)
+        // Poll rather than sleep: the loop's own tasks decide when this is true, and how long
+        // that takes depends on the machine.
+        try await waitFor("the job to be executed and the loop to ask again") {
+            !executor.executed.isEmpty && session.lastOutcome != nil && transport.claims >= 2
+        }
 
         #expect(executor.executed.map(\.jobId) == [12])
         #expect(executor.executed.first?.arguments == serverCommand)
@@ -736,6 +740,9 @@ struct SessionWorkLoopTests {
             sleep: { _ in try await Task.sleep(nanoseconds: 5_000_000) })
 
         session.restore()
+        // Wait for the loop to be demonstrably running before asserting what it did not do;
+        // otherwise this passes simply by looking too early.
+        try await waitFor("the check-in loop to run") { transport.heartbeats > 0 }
         try await Task.sleep(nanoseconds: 50_000_000)
 
         #expect(executor.executed.isEmpty)


### PR DESCRIPTION
## Outcome

The macOS sidecar suite no longer fails on a loaded CI runner. One test slept 200 ms and then asserted that a claim had gone out, the job had been executed and the loop had asked again; on the runner for #137 none of that had happened yet and five expectations failed for a defect that did not exist.

## Scope

- `waitFor` moves out of `SidecarSessionTests` into its own test file, with a 5 s default timeout, and records an issue naming what it waited for when it expires.
- The work-loop test polls for the executed job, the outcome and the second claim.
- The drained-worker test still needs a fixed pause to prove a claim was *not* made, but first waits for the check-in loop to be demonstrably running, so it cannot pass merely by looking too early.
- CHANGELOG entry under Unreleased → Fixed.

## Verification

- `swift test`: 87 tests in 19 suites passed. The two previously fragile tests were run three times in a row, clean each time.

## Risk

Test-only. No product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
