### PR TITLE
Show what the Mac is doing, and stop the Keychain prompting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- **The macOS sidecar's menu shows what this Mac is actually doing.** A running job gets a
+  time-lapse of the frames going through the encoder, with a strip beneath showing the run, and a
+  real progress bar for the two stages that have one: bytes received while a source downloads and
+  bytes sent while a candidate is delivered. A GPU reading sits alongside, stating plainly that
+  VideoToolbox encodes on the media engine that macOS does not report. Frames and GPU are sampled
+  only while the menu is open. The menu itself is grouped into cards with a status colour carried
+  from the header, and `--render-menu` writes a picture of every state so a layout change can be
+  reviewed without a paired server and a running job.
 - **A dropped source download resumes instead of starting a multi-gigabyte file again.** The macOS
   sidecar fetches sources in bounded 64 MB byte ranges, keeps every complete range across transient
   failures, and asks for the next missing byte. It validates each `Content-Range`, requires the
@@ -101,6 +109,14 @@
 
 ### Fixed
 
+- **The macOS sidecar stops asking for Keychain access over and over.** An ad-hoc signature is
+  derived from the binary, so it changes on every build and the Keychain treats each rebuilt copy
+  as a different application; reaching the stored pairing then raised a password prompt that kept
+  coming back. `make-app.sh` now takes a `SIGNING_IDENTITY` and signs with a real certificate,
+  whose identity is stable across rebuilds, applying the hardened runtime and a timestamp and
+  signing the bundled ffmpeg and ffprobe first. The credential store also tries the data protection
+  keychain before the legacy one, and an item it cannot read without a prompt is removed and
+  reported as "not paired" rather than asked for again.
 - **Sampled VMAF no longer scores a candidate against its own neighbouring frames.** Both inputs
   of a sampled window are seeked to the same whole second and then paired by timestamp, but FFmpeg
   stamps frames relative to each file's container start, which is the earliest stream. A source

--- a/sidecars/macos/README.md
+++ b/sidecars/macos/README.md
@@ -172,5 +172,20 @@ its next check-in, discards the dead credential, and says so.
 
 ## Signing
 
-`make-app.sh` applies an ad-hoc signature, which is enough to run locally. Distribution needs a real
-Developer ID and notarisation, and neither is set up yet.
+`make-app.sh` applies an ad-hoc signature by default, which is enough to run locally. Set
+`SIGNING_IDENTITY` to sign with a real certificate:
+
+```bash
+security find-identity -v -p codesigning          # what this Mac holds
+SIGNING_IDENTITY="Developer ID Application: You (TEAMID)" ./scripts/make-app.sh release
+```
+
+A real certificate is worth using even for local work. An ad-hoc signature is derived from the
+binary, so it changes on **every build**, and the Keychain — which decides access by signature —
+sees each rebuilt copy as a different application. The pairing then cannot be read, and on the
+legacy keychain macOS asks for a password to reach it. With a certificate the signature is stable
+and a pairing survives rebuilds.
+
+Signing applies the hardened runtime and a secure timestamp, and signs the bundled `ffmpeg` and
+`ffprobe` first, both of which notarisation requires. Notarisation itself, and attaching a release
+build to a GitHub Release, are still to do.

--- a/sidecars/macos/Sources/OptimisarrSidecar/FilmStripView.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/FilmStripView.swift
@@ -1,0 +1,80 @@
+import SidecarCore
+import SwiftUI
+
+/// A time-lapse of the frames this Mac has been seen encoding.
+///
+/// One still every second or so is not much to look at, and it cannot distinguish a job that is
+/// moving from one that has quietly stopped. Played back at a steady tick the same frames become
+/// a small moving picture of the film going through the encoder, with the strip beneath showing
+/// where in that run the current frame sits.
+struct FilmStripView: View {
+    let strip: FilmStrip
+
+    /// Playback speed. Fast enough to read as motion, slow enough that a short strip is not a
+    /// flicker.
+    private static let framesPerSecond = 6.0
+
+    @State private var tick = 0
+    private let timer = Timer.publish(
+        every: 1 / framesPerSecond, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(spacing: 5) {
+            hero
+            thumbnails
+        }
+        .onReceive(timer) { _ in
+            guard !strip.isEmpty else { return }
+            tick &+= 1
+        }
+    }
+
+    private var hero: some View {
+        // A fixed 16:9 well, so the menu does not jump about as frames of different aspect
+        // ratios arrive, and there is something to look at before the first one does.
+        ZStack {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.black.opacity(0.35))
+
+            if let data = strip.frame(atTick: tick), let image = NSImage(data: data) {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .transition(.opacity)
+            } else {
+                Image(systemName: "film")
+                    .font(.title3)
+                    .foregroundStyle(.white.opacity(0.25))
+            }
+        }
+        .frame(height: 96)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6).strokeBorder(.white.opacity(0.08))
+        )
+        .accessibilityLabel("A time-lapse of the frames being encoded")
+    }
+
+    @ViewBuilder
+    private var thumbnails: some View {
+        if strip.frames.count > 1 {
+            let showing = ((tick % strip.frames.count) + strip.frames.count) % strip.frames.count
+            HStack(spacing: 2) {
+                ForEach(Array(strip.frames.enumerated()), id: \.offset) { index, data in
+                    if let image = NSImage(data: data) {
+                        Image(nsImage: image)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(height: 16)
+                            .frame(maxWidth: .infinity)
+                            .clipped()
+                            .clipShape(RoundedRectangle(cornerRadius: 1.5))
+                            .opacity(index == showing ? 1 : 0.35)
+                    }
+                }
+            }
+            .frame(height: 16)
+            .accessibilityHidden(true)
+        }
+    }
+}

--- a/sidecars/macos/Sources/OptimisarrSidecar/MenuRenderer.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/MenuRenderer.swift
@@ -1,0 +1,88 @@
+import AppKit
+import SidecarCore
+import SwiftUI
+
+/// Renders the menu in each state worth looking at, to PNGs, and exits.
+///
+/// The menu is the whole product, and most of its states — mid-transfer, encoding with a strip of
+/// frames, revoked — need a paired server and a running job to reach. Judging a layout change by
+/// waiting for one is slow enough that it does not happen, so the states are posed and rendered
+/// instead:
+///
+///     OptimisarrSidecar --render-menu /tmp/menu
+@MainActor
+enum MenuRenderer {
+    static let flag = "--render-menu"
+
+    /// The states the layout has to hold up in. A change that only looks right while idle is not
+    /// a change that has been reviewed.
+    static func render(into directory: URL) {
+        let strip = FilmStrip(frames: sampleFrames())
+        let poses: [(String, SidecarSession)] = [
+            ("unpaired", .posed(status: .unpaired, serverAddress: "")),
+            ("connected-idle", .posed(
+                status: .connected(workerId: 1, lastCheckIn: Date()),
+                lastOutcome: .delivered(jobId: 5845, bytes: 394_256_442))),
+            ("receiving", .posed(
+                status: .working(jobId: 5846, progress: .fetchingSource(received: 182_000_000, total: 493_040_520)),
+                activeJobs: [5846: .fetchingSource(received: 182_000_000, total: 493_040_520)],
+                gpu: GpuUsage(device: 0.04, memoryInUse: 700_000_000))),
+            ("encoding", .posed(
+                status: .working(jobId: 5846, progress: .encoding(encodedSeconds: 751)),
+                activeJobs: [5846: .encoding(encodedSeconds: 751)],
+                filmStrips: [5846: strip],
+                gpu: GpuUsage(device: 0.31, memoryInUse: 1_253_064_704))),
+            ("sending", .posed(
+                status: .working(jobId: 5846, progress: .delivering(sent: 300_000_000, total: 394_256_442)),
+                activeJobs: [5846: .delivering(sent: 300_000_000, total: 394_256_442)],
+                filmStrips: [5846: strip],
+                gpu: GpuUsage(device: 0.06, memoryInUse: 900_000_000))),
+            ("two-jobs", .posed(
+                status: .working(jobId: 5846, progress: .encoding(encodedSeconds: 751)),
+                activeJobs: [
+                    5846: .encoding(encodedSeconds: 751),
+                    5847: .measuring,
+                ],
+                filmStrips: [5846: strip],
+                gpu: GpuUsage(device: 0.62, memoryInUse: 2_100_000_000))),
+            ("revoked", .posed(status: .revoked)),
+            ("unreachable", .posed(
+                status: .unreachable(reason: "optimisarr.pownet.uk could not be reached."))),
+        ]
+
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        for (name, session) in poses {
+            let renderer = ImageRenderer(content: SidecarMenu(session: session).frame(width: 340))
+            // Retina, so the PNG is worth looking at closely rather than a blurry approximation.
+            renderer.scale = 2
+            guard let image = renderer.nsImage,
+                  let tiff = image.tiffRepresentation,
+                  let bitmap = NSBitmapImageRep(data: tiff),
+                  let png = bitmap.representation(using: .png, properties: [:])
+            else {
+                FileHandle.standardError.write(Data("could not render \(name)\n".utf8))
+                continue
+            }
+            let file = directory.appendingPathComponent("\(name).png")
+            try? png.write(to: file)
+            print(file.path)
+        }
+    }
+
+    /// Stand-in frames: a colour ramp, so the strip and its playback are visibly a sequence rather
+    /// than one picture repeated.
+    private static func sampleFrames() -> [Data] {
+        (0..<8).compactMap { index in
+            let size = NSSize(width: 320, height: 180)
+            let image = NSImage(size: size)
+            image.lockFocus()
+            NSColor(hue: CGFloat(index) / 8, saturation: 0.55, brightness: 0.7, alpha: 1).setFill()
+            NSRect(origin: .zero, size: size).fill()
+            image.unlockFocus()
+            guard let tiff = image.tiffRepresentation,
+                  let bitmap = NSBitmapImageRep(data: tiff)
+            else { return nil }
+            return bitmap.representation(using: .jpeg, properties: [:])
+        }
+    }
+}

--- a/sidecars/macos/Sources/OptimisarrSidecar/Meter.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/Meter.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// A slim progress bar drawn from shapes rather than the stock `ProgressView`.
+///
+/// Two reasons. It sits better in a menu-bar popover, where the system bar is too tall and too
+/// pale against a card; and being pure SwiftUI it renders offscreen, so `--render-menu` produces
+/// a picture of the real thing instead of a placeholder where an AppKit control would be.
+struct Meter: View {
+    /// 0...1, or nil for work whose remaining time is genuinely unknown.
+    var value: Double?
+    var tint: Color
+
+    private static let height: CGFloat = 5
+
+    @State private var sweep = false
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color.primary.opacity(0.1))
+
+                if let value {
+                    Capsule()
+                        .fill(tint)
+                        .frame(width: max(Self.height, geometry.size.width * min(max(value, 0), 1)))
+                        .animation(.easeOut(duration: 0.25), value: value)
+                } else {
+                    // Indeterminate: a short bar sweeping across says "running, no estimate",
+                    // where a full bar would claim progress nobody has measured.
+                    Capsule()
+                        .fill(tint.opacity(0.85))
+                        .frame(width: geometry.size.width * 0.3)
+                        .offset(x: sweep ? geometry.size.width * 0.7 : 0)
+                        .animation(
+                            .easeInOut(duration: 1.1).repeatForever(autoreverses: true),
+                            value: sweep)
+                        .onAppear { sweep = true }
+                }
+            }
+        }
+        .frame(height: Self.height)
+        .accessibilityValue(value.map { "\(Int(($0 * 100).rounded())) percent" } ?? "in progress")
+    }
+}

--- a/sidecars/macos/Sources/OptimisarrSidecar/OptimisarrSidecarApp.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/OptimisarrSidecarApp.swift
@@ -35,6 +35,16 @@ struct OptimisarrSidecarApp: App {
     }
 
     init() {
+        // A design pass over the menu, rather than the app: render its states and stop before any
+        // pairing, network or menu bar work begins.
+        let arguments = CommandLine.arguments
+        if let flag = arguments.firstIndex(of: MenuRenderer.flag), flag + 1 < arguments.count {
+            MainActor.assumeIsolated {
+                MenuRenderer.render(into: URL(fileURLWithPath: arguments[flag + 1]))
+            }
+            exit(0)
+        }
+
         // Accessory rather than regular: no Dock icon, no app switcher entry. Set in code so the
         // package behaves correctly even when run straight from the build directory.
         NSApplication.shared.setActivationPolicy(.accessory)

--- a/sidecars/macos/Sources/OptimisarrSidecar/SidecarMenu.swift
+++ b/sidecars/macos/Sources/OptimisarrSidecar/SidecarMenu.swift
@@ -1,10 +1,13 @@
 import SidecarCore
 import SwiftUI
 
-/// The whole interface: what state we are in, and the one action that state allows.
+/// The whole interface: what state we are in, what this Mac is doing, and the actions that state
+/// allows.
 ///
-/// Deliberately small. This app has exactly two jobs — pair, and report honestly — and a menu that
-/// offers more than that would imply capabilities it does not have.
+/// Small on purpose. This app pairs, works, and reports honestly; a menu offering more than that
+/// would imply capabilities it does not have. What it does show, it shows properly — a running job
+/// gets the frames going through the encoder and a real progress bar, because "Encoding" on its
+/// own cannot tell a working Mac from a stuck one.
 struct SidecarMenu: View {
     @ObservedObject var session: SidecarSession
 
@@ -15,10 +18,8 @@ struct SidecarMenu: View {
     @State private var isPairing = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 10) {
             header
-
-            Divider()
 
             switch session.status {
             case .unpaired, .pairingFailed:
@@ -28,37 +29,51 @@ struct SidecarMenu: View {
             }
 
             Divider()
-
-            Button("Quit Optimisarr Sidecar") {
-                NSApplication.shared.terminate(nil)
-            }
-            .keyboardShortcut("q")
+            footer
         }
         .padding(14)
-        .frame(width: 320)
+        .frame(width: 340)
         .onAppear {
             session.restore()
             if serverAddress.isEmpty { serverAddress = session.serverAddress }
+            // Frame grabs and GPU readings cost something, so they run only while this is on
+            // screen. A menu-bar window is closed far more of the time than it is open.
+            session.setPreviewsWanted(true)
         }
+        .onDisappear { session.setPreviewsWanted(false) }
     }
+
+    // MARK: - Header
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text("Optimisarr Sidecar").font(.headline)
-            Text(session.status.summary)
-                .font(.subheadline)
-                .foregroundStyle(session.status.isHealthy ? .secondary : .primary)
+        HStack(alignment: .firstTextBaseline, spacing: 7) {
+            Circle()
+                .fill(session.status.tint)
+                .frame(width: 7, height: 7)
+                .accessibilityHidden(true)
 
-            // The reason matters more than the state name — "Pairing failed" is not actionable,
-            // but "that code has expired" is.
-            if let detail = session.status.detail {
-                Text(detail)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Optimisarr Sidecar")
+                    .font(.system(size: 13, weight: .semibold))
+                Text(session.status.summary)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+
+                // The reason matters more than the state name — "Pairing failed" is not
+                // actionable, but "that code has expired" is.
+                if let detail = session.status.detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(session.status.tint == .red ? .red : .secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 2)
+                }
             }
+            Spacer(minLength: 0)
         }
     }
+
+    // MARK: - Pairing
 
     private var pairingForm: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -80,8 +95,8 @@ struct SidecarMenu: View {
                     isPairing = true
                     await session.pair(serverAddress: serverAddress, pin: pin)
                     isPairing = false
-                    // Only cleared on success. Leaving a rejected code in place lets someone fix a
-                    // typo instead of retyping the whole thing.
+                    // Only cleared on success. Leaving a rejected code in place lets someone fix
+                    // a typo instead of retyping the whole thing.
                     if case .connected = session.status { pin = "" }
                 }
             }
@@ -90,33 +105,25 @@ struct SidecarMenu: View {
         }
     }
 
+    // MARK: - Paired
+
     private var pairedDetail: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            LabeledContent("Server", value: session.serverAddress)
-                .font(.caption)
-
-            if case let .connected(workerId, lastCheckIn) = session.status {
-                LabeledContent("Worker", value: "#\(workerId)").font(.caption)
-                LabeledContent("Last check-in", value: lastCheckIn.formatted(date: .omitted, time: .standard))
-                    .font(.caption)
-            }
-
-            ForEach(session.activeJobs.keys.sorted(), id: \.self) { jobId in
-                if let progress = session.activeJobs[jobId] {
-                    LabeledContent("Job #\(jobId)", value: progress.label).font(.caption)
+        VStack(alignment: .leading, spacing: 10) {
+            if session.activeJobs.isEmpty {
+                idleCard
+            } else {
+                ForEach(session.activeJobs.keys.sorted(), id: \.self) { jobId in
+                    if let progress = session.activeJobs[jobId] {
+                        jobCard(jobId: jobId, progress: progress)
+                    }
+                }
+                if let gpu = session.gpu {
+                    gpuCard(gpu)
                 }
             }
 
-            // Takes effect on the next check-in; a running job is never stopped to fit.
-            Picker("Jobs at once", selection: Binding(
-                get: { session.jobConcurrency },
-                set: { session.setJobConcurrency($0) })) {
-                ForEach(Array(SidecarSession.concurrencyRange), id: \.self) { count in
-                    Text("\(count)").tag(count)
-                }
-            }
-            .pickerStyle(.segmented)
-            .font(.caption)
+            connectionCard
+            concurrencyPicker
 
             if let outcome = session.lastOutcome {
                 Text(outcome.label)
@@ -125,13 +132,130 @@ struct SidecarMenu: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            // Said plainly: a delivered candidate is a proposal. Optimisarr verifies it against the
-            // original before anything is replaced, and this machine never sees that decision.
-            Text("Encodes are delivered to Optimisarr for verification; nothing is replaced from here.")
-                .font(.caption)
+            // Said plainly: a delivered candidate is a proposal. Optimisarr verifies it against
+            // the original before anything is replaced, and this machine never sees that decision.
+            Label(
+                "Encodes go to Optimisarr for verification. Nothing is replaced from here.",
+                systemImage: "checkmark.shield")
+                .font(.caption2)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+        }
+    }
 
+    private var idleCard: some View {
+        Card {
+            HStack(spacing: 8) {
+                Image(systemName: "moon.zzz")
+                    .foregroundStyle(.secondary)
+                Text("Waiting for work")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    /// One running job: the frames going through it, what stage it is at, and how far along.
+    private func jobCard(jobId: Int, progress: JobProgress) -> some View {
+        Card {
+            VStack(alignment: .leading, spacing: 7) {
+                if let strip = session.filmStrips[jobId], !strip.isEmpty {
+                    FilmStripView(strip: strip)
+                }
+
+                HStack(spacing: 6) {
+                    Image(systemName: progress.symbol)
+                        .font(.caption)
+                        .foregroundStyle(progress.tint)
+                        .frame(width: 13)
+                    Text("Job #\(jobId)")
+                        .font(.system(size: 11, weight: .medium))
+                    Spacer(minLength: 4)
+                    Text(progress.label)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                // A bar only where there is a real fraction to draw. An encode reports seconds of
+                // output, not a fraction, because only the server knows the source's duration.
+                Meter(value: progress.fraction, tint: progress.tint)
+            }
+        }
+    }
+
+    /// The GPU figure, with the caveat stated rather than left for someone to discover.
+    private func gpuCard(_ gpu: GpuUsage) -> some View {
+        Card {
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 6) {
+                    Image(systemName: "cpu")
+                        .font(.caption)
+                        .foregroundStyle(.purple)
+                        .frame(width: 13)
+                    Text("GPU").font(.system(size: 11, weight: .medium))
+                    Spacer(minLength: 4)
+                    Text("\(Int((gpu.device * 100).rounded()))%")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+                Meter(value: gpu.device, tint: .purple)
+                Text("VideoToolbox encodes on the media engine, which macOS does not report. This covers the GPU only.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var connectionCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 3) {
+                detailRow("Server", session.serverAddress)
+                if case let .connected(workerId, lastCheckIn) = session.status {
+                    detailRow("Worker", "#\(workerId)")
+                    detailRow("Last check-in", lastCheckIn.formatted(date: .omitted, time: .standard))
+                }
+            }
+        }
+    }
+
+    private func detailRow(_ name: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(name)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 8)
+            Text(value)
+                .font(.caption.monospacedDigit())
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    private var concurrencyPicker: some View {
+        // Takes effect on the next check-in; a running job is never stopped to fit.
+        HStack(spacing: 8) {
+            Text("Jobs at once")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Picker("", selection: Binding(
+                get: { session.jobConcurrency },
+                set: { session.setJobConcurrency($0) })) {
+                ForEach(Array(SidecarSession.concurrencyRange), id: \.self) { count in
+                    Text("\(count)").tag(count)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        VStack(alignment: .leading, spacing: 6) {
             Toggle("Start at login", isOn: Binding(
                 get: { startAtLogin },
                 set: { wanted in
@@ -145,29 +269,99 @@ struct SidecarMenu: View {
                     }
                 }))
                 .font(.caption)
+                .toggleStyle(.checkbox)
+
             if let loginItemError {
-                Text(loginItemError).font(.caption).foregroundStyle(.red)
+                Text(loginItemError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            Button("Forget this pairing") {
-                session.unpair()
-                pin = ""
+            HStack(spacing: 8) {
+                if case .unpaired = session.status {} else {
+                    Button("Forget this pairing") {
+                        session.unpair()
+                        pin = ""
+                    }
+                    .controlSize(.small)
+                }
+                Spacer(minLength: 0)
+                Button("Quit") { NSApplication.shared.terminate(nil) }
+                    .controlSize(.small)
+                    .keyboardShortcut("q")
             }
         }
+    }
+}
+
+/// A grouped panel. Menu-bar windows have no chrome of their own, so without something to sit in,
+/// every row reads at the same weight and the eye has nowhere to land.
+private struct Card<Content: View>: View {
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        content
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(Color.primary.opacity(0.05)))
     }
 }
 
 private extension JobProgress {
     var label: String {
         switch self {
-        case .fetchingSource: return "Fetching the source"
+        case let .fetchingSource(received, total):
+            return Self.transferred(received, total)
         case let .encoding(seconds):
             let whole = Int(seconds)
-            return String(format: "Encoding · %d:%02d:%02d of output", whole / 3600, whole % 3600 / 60, whole % 60)
-        case .measuring: return "Measuring quality (VMAF)"
-        case .delivering: return "Delivering the candidate"
+            return String(format: "%d:%02d:%02d encoded", whole / 3600, whole % 3600 / 60, whole % 60)
+        case .measuring:
+            return "Measuring quality"
+        case let .delivering(sent, total):
+            return Self.transferred(sent, total)
         }
+    }
+
+    var symbol: String {
+        switch self {
+        case .fetchingSource: return "arrow.down.circle"
+        case .encoding: return "wand.and.stars"
+        case .measuring: return "waveform.badge.magnifyingglass"
+        case .delivering: return "arrow.up.circle"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .fetchingSource: return .teal
+        case .encoding: return .blue
+        case .measuring: return .orange
+        case .delivering: return .green
+        }
+    }
+
+    /// How far through the transfer, or nil for a stage with no honest fraction to show.
+    var fraction: Double? {
+        switch self {
+        case let .fetchingSource(done, total), let .delivering(done, total):
+            guard total > 0 else { return nil }
+            return min(max(Double(done) / Double(total), 0), 1)
+        case .encoding, .measuring:
+            return nil
+        }
+    }
+
+    /// "182 MB of 1.2 GB". The total is dropped while it is still unknown rather than shown as
+    /// zero, which would read as a finished transfer of nothing.
+    static func transferred(_ done: Int64, _ total: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        let doneText = formatter.string(fromByteCount: done)
+        guard total > 0 else { return doneText }
+        return "\(doneText) of \(formatter.string(fromByteCount: total))"
     }
 }
 
@@ -186,10 +380,14 @@ private extension JobOutcome {
 }
 
 private extension SidecarStatus {
-    var isHealthy: Bool {
+    /// One colour for the whole menu's sense of health, used by the dot and by error text.
+    var tint: Color {
         switch self {
-        case .connected, .working: return true
-        default: return false
+        case .working: return .blue
+        case .connected: return .green
+        case .unreachable, .disabledOnServer: return .orange
+        case .pairingFailed, .revoked: return .red
+        default: return .secondary
         }
     }
 

--- a/sidecars/macos/Sources/SidecarCore/CredentialStore.swift
+++ b/sidecars/macos/Sources/SidecarCore/CredentialStore.swift
@@ -29,80 +29,121 @@ public struct StoredPairing: Codable, Sendable, Equatable {
 ///
 /// The credential is a long-lived secret that authorises a remote machine against someone's media
 /// server, so it belongs in the Keychain and nowhere else — never `UserDefaults`, never a plist,
-/// never a log line. `kSecAttrAccessibleAfterFirstUnlock` lets the app resume checking in after a
-/// reboot without the user being present, while still keeping the secret encrypted at rest.
+/// never a log line.
+///
+/// **Two keychains, deliberately.** A properly signed build uses the data protection keychain,
+/// where access is decided by the code signature and no dialog is ever raised. An ad-hoc build has
+/// no team identifier, so that keychain refuses it outright (`errSecMissingEntitlement`), and it
+/// falls back to the legacy file keychain. The legacy one guards items with an access control list
+/// naming the exact binary that wrote them, and an ad-hoc signature changes with every rebuild —
+/// so a rebuilt development build is a different application to it, and asks the operator for a
+/// password it should never be asking for. That was seen on 2026-09-13 as a prompt that would not
+/// stop. Reads therefore refuse interaction, and an item that cannot be read without it is removed
+/// and reported as "not paired" so the operator pairs once more instead of being nagged forever.
 public struct KeychainCredentialStore: CredentialStore {
     private let service: String
     private let account: String
+    private let accessGroup: String?
 
-    public init(service: String = "uk.optimisarr.sidecar", account: String = "worker-credential") {
+    public init(
+        service: String = "uk.optimisarr.sidecar",
+        account: String = "worker-credential",
+        accessGroup: String? = nil
+    ) {
         self.service = service
         self.account = account
+        self.accessGroup = accessGroup
     }
 
-    private var baseQuery: [String: Any] {
-        [
+    /// The data protection keychain first; the legacy one only where it is not available.
+    private var keychains: [Bool] { [true, false] }
+
+    private func baseQuery(dataProtection: Bool) -> [String: Any] {
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
         ]
+        if dataProtection {
+            query[kSecUseDataProtectionKeychain as String] = true
+            if let accessGroup { query[kSecAttrAccessGroup as String] = accessGroup }
+        }
+        return query
     }
 
     public func load() throws -> StoredPairing? {
-        var query = baseQuery
-        query[kSecReturnData as String] = true
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        for dataProtection in keychains {
+            var query = baseQuery(dataProtection: dataProtection)
+            query[kSecReturnData as String] = true
+            query[kSecMatchLimit as String] = kSecMatchLimitOne
 
-        // Never allow the Keychain to put a dialog on screen.
-        //
-        // An ad-hoc signature is not stable across builds, so a rebuilt app is a *different*
-        // application as far as the Keychain is concerned, and reading an item the previous build
-        // created raises an authorisation prompt. That prompt is modal, and this call sits on the
-        // launch path — so the app hangs behind it with no menu bar icon and no window, looking for
-        // all the world like it failed to start. Asking for the item without interaction turns that
-        // into an ordinary error we can handle instead.
-        let context = LAContext()
-        context.interactionNotAllowed = true
-        query[kSecUseAuthenticationContext as String] = context
+            // Never let the Keychain put a dialog on screen. This call is on the launch path, and
+            // a modal prompt there hangs an app that has no window and no Dock icon to show for
+            // it — it simply looks as though it failed to start.
+            if !dataProtection {
+                let context = LAContext()
+                context.interactionNotAllowed = true
+                query[kSecUseAuthenticationContext as String] = context
+            }
 
-        var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
+            var item: CFTypeRef?
+            let status = SecItemCopyMatching(query as CFDictionary, &item)
 
-        if status == errSecItemNotFound { return nil }
+            switch status {
+            case errSecSuccess:
+                guard let data = item as? Data else { throw KeychainError.unexpectedStatus(status) }
+                return try JSONDecoder().decode(StoredPairing.self, from: data)
 
-        // Present but unreadable — typically an item written by a previous build of this app.
-        // Treated as "not paired" rather than as a failure: the credential is unrecoverable either
-        // way, and asking the operator to pair again is far better than blocking the app or
-        // nagging them for a password they should not be typing into an unsigned build.
-        if status == errSecInteractionNotAllowed || status == errSecAuthFailed {
-            return nil
+            case errSecItemNotFound, errSecMissingEntitlement:
+                // Nothing here, or this keychain is not open to this build. Try the other.
+                continue
+
+            case errSecInteractionNotAllowed, errSecAuthFailed:
+                // Present but unreadable: written by a previous build of this app, whose signature
+                // this one no longer matches. Take it away rather than leave it to prompt on every
+                // future attempt; the secret is unrecoverable either way and pairing again is a
+                // few seconds' work.
+                SecItemDelete(baseQuery(dataProtection: dataProtection) as CFDictionary)
+                return nil
+
+            default:
+                throw KeychainError.unexpectedStatus(status)
+            }
         }
-
-        guard status == errSecSuccess, let data = item as? Data else {
-            throw KeychainError.unexpectedStatus(status)
-        }
-        return try JSONDecoder().decode(StoredPairing.self, from: data)
+        return nil
     }
 
     public func save(_ pairing: StoredPairing) throws {
         let data = try JSONEncoder().encode(pairing)
+        var lastStatus: OSStatus = errSecSuccess
 
-        // Replace rather than update-or-insert: pairing again should not leave a stale secret
-        // behind if the previous item was written by an older build with different attributes.
-        SecItemDelete(baseQuery as CFDictionary)
+        for dataProtection in keychains {
+            // Replace rather than update-or-insert: pairing again should not leave a stale secret
+            // behind if the previous item was written by an older build with different attributes.
+            SecItemDelete(baseQuery(dataProtection: dataProtection) as CFDictionary)
 
-        var query = baseQuery
-        query[kSecValueData as String] = data
-        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+            var query = baseQuery(dataProtection: dataProtection)
+            query[kSecValueData as String] = data
+            query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
 
-        let status = SecItemAdd(query as CFDictionary, nil)
-        guard status == errSecSuccess else { throw KeychainError.unexpectedStatus(status) }
+            let status = SecItemAdd(query as CFDictionary, nil)
+            if status == errSecSuccess { return }
+            lastStatus = status
+            // A build without the entitlement cannot use the data protection keychain at all.
+            if status != errSecMissingEntitlement { break }
+        }
+        throw KeychainError.unexpectedStatus(lastStatus)
     }
 
     public func clear() throws {
-        let status = SecItemDelete(baseQuery as CFDictionary)
-        guard status == errSecSuccess || status == errSecItemNotFound else {
-            throw KeychainError.unexpectedStatus(status)
+        for dataProtection in keychains {
+            let status = SecItemDelete(baseQuery(dataProtection: dataProtection) as CFDictionary)
+            guard status == errSecSuccess
+                || status == errSecItemNotFound
+                || status == errSecMissingEntitlement
+            else {
+                throw KeychainError.unexpectedStatus(status)
+            }
         }
     }
 }

--- a/sidecars/macos/Sources/SidecarCore/FramePreview.swift
+++ b/sidecars/macos/Sources/SidecarCore/FramePreview.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Builds the throwaway ffmpeg command that grabs one frame of the source as a small JPEG.
+///
+/// The frame comes from the **source**, not from the candidate being written. A partially written
+/// MP4 has no index yet and cannot be decoded reliably, whereas the source is complete on this
+/// machine's own disk. Seeking it to the encoder's current output position shows the picture the
+/// encoder is working on, which is the thing worth watching.
+public enum FramePreviewCommand {
+    /// `-ss` before `-i` so the seek is a cheap keyframe jump rather than a decode from the top.
+    public static func arguments(source: URL, atSeconds seconds: Double, width: Int) -> [String] {
+        [
+            "-hide_banner", "-v", "error",
+            "-ss", String(format: "%.2f", max(0, seconds)),
+            "-i", source.path,
+            "-frames:v", "1",
+            "-vf", "scale=\(max(16, width)):-2",
+            "-f", "mjpeg", "-",
+        ]
+    }
+}
+
+/// Runs a command and hands back its raw standard output, which a JPEG needs and a `String` would
+/// corrupt.
+public protocol BinaryCommandRunner: Sendable {
+    func run(_ executable: URL, _ arguments: [String]) async -> (exitCode: Int32, output: Data)
+}
+
+public struct ProcessBinaryCommandRunner: BinaryCommandRunner {
+    public init() {}
+
+    public func run(_ executable: URL, _ arguments: [String]) async -> (exitCode: Int32, output: Data) {
+        await withCheckedContinuation { continuation in
+            let process = Process()
+            let pipe = Pipe()
+            process.executableURL = executable
+            process.arguments = arguments
+            process.standardOutput = pipe
+            process.standardError = FileHandle.nullDevice
+            do {
+                try process.run()
+            } catch {
+                continuation.resume(returning: (-1, Data()))
+                return
+            }
+            // Read before waiting: a frame larger than the pipe buffer would otherwise deadlock.
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            continuation.resume(returning: (process.terminationStatus, data))
+        }
+    }
+}
+
+/// Grabs preview frames, on demand and never faster than its own interval.
+///
+/// Rate limiting lives here rather than at the call site because the encoder reports progress many
+/// times a second and a frame grab is a whole process launch. Nothing is sampled unless something
+/// is actually watching, which the caller decides.
+public actor FramePreviewSampler {
+    private let ffmpeg: URL
+    private let runner: BinaryCommandRunner
+    private let interval: TimeInterval
+    private let width: Int
+    private var lastSampled: Date?
+
+    public init(
+        ffmpeg: URL,
+        runner: BinaryCommandRunner = ProcessBinaryCommandRunner(),
+        interval: TimeInterval = 1.5,
+        width: Int = 320
+    ) {
+        self.ffmpeg = ffmpeg
+        self.runner = runner
+        self.interval = interval
+        self.width = width
+    }
+
+    /// A JPEG of the source at that position, or nil when it is too soon to sample again or the
+    /// grab failed. A failure is silent on purpose: a missing preview must never disturb a job.
+    public func frame(from source: URL, atSeconds seconds: Double, now: Date = Date()) async -> Data? {
+        if let lastSampled, now.timeIntervalSince(lastSampled) < interval { return nil }
+        lastSampled = now
+        let result = await runner.run(
+            ffmpeg, FramePreviewCommand.arguments(source: source, atSeconds: seconds, width: width))
+        guard result.exitCode == 0, !result.output.isEmpty else { return nil }
+        return result.output
+    }
+}
+
+/// A bounded, ordered run of the frames a job has been seen encoding.
+///
+/// Kept as a strip rather than a single still because one picture every second or so is not much
+/// to look at, while a run of them played back is a time-lapse of the encode: it shows the film
+/// moving, and it shows at a glance that work is actually progressing.
+public struct FilmStrip: Sendable, Equatable {
+    /// Enough for a few seconds of playback without holding megabytes of JPEG per job.
+    public static let capacity = 24
+
+    public private(set) var frames: [Data] = []
+
+    public init() {}
+
+    public init(frames: [Data]) {
+        self.frames = Array(frames.suffix(Self.capacity))
+    }
+
+    /// Oldest frames fall off the front, so the strip is always the most recent run.
+    public mutating func append(_ frame: Data) {
+        frames.append(frame)
+        if frames.count > Self.capacity {
+            frames.removeFirst(frames.count - Self.capacity)
+        }
+    }
+
+    public var isEmpty: Bool { frames.isEmpty }
+
+    /// The frame to show at a given tick of playback, cycling. Nil while the strip is empty.
+    public func frame(atTick tick: Int) -> Data? {
+        guard !frames.isEmpty else { return nil }
+        return frames[((tick % frames.count) + frames.count) % frames.count]
+    }
+}
+
+/// Whether anything is currently watching for preview frames.
+///
+/// A shared box rather than a flag on the session because the runner is built before the session
+/// exists and reads this from ffmpeg's progress callback, which is neither the main actor nor a
+/// place to reach back into the UI.
+public final class PreviewGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var wanted = false
+
+    public init() {}
+
+    public var isWanted: Bool { lock.withLock { wanted } }
+
+    public func set(_ wanted: Bool) { lock.withLock { self.wanted = wanted } }
+}

--- a/sidecars/macos/Sources/SidecarCore/GpuMonitor.swift
+++ b/sidecars/macos/Sources/SidecarCore/GpuMonitor.swift
@@ -1,0 +1,71 @@
+import Foundation
+import IOKit
+
+/// What the GPU is doing right now, as a fraction from 0 to 1.
+public struct GpuUsage: Sendable, Equatable {
+    /// The accelerator's overall busy figure.
+    public let device: Double
+    /// Bytes of system memory the accelerator currently holds.
+    public let memoryInUse: Int64
+
+    public init(device: Double, memoryInUse: Int64) {
+        self.device = device
+        self.memoryInUse = memoryInUse
+    }
+}
+
+/// Reads `PerformanceStatistics` out of an IOAccelerator registry entry.
+///
+/// Split from the IOKit walk so the arithmetic and the missing-key cases can be tested without a
+/// GPU. Apple publishes no contract for these keys, so every one of them is treated as optional
+/// and a dictionary that does not carry a utilisation figure yields nothing rather than a zero
+/// that would read as "idle".
+public enum GpuStatisticsParser {
+    public static func parse(_ statistics: [String: Any]) -> GpuUsage? {
+        guard let percent = number(statistics["Device Utilization %"]) else { return nil }
+        return GpuUsage(
+            device: min(max(percent / 100, 0), 1),
+            memoryInUse: Int64(number(statistics["In use system memory"]) ?? 0))
+    }
+
+    /// The registry hands these back as `NSNumber`, but a build that reports a string should not
+    /// take the reading down with it.
+    private static func number(_ value: Any?) -> Double? {
+        switch value {
+        case let n as NSNumber: return n.doubleValue
+        case let s as String: return Double(s)
+        default: return nil
+        }
+    }
+}
+
+/// Samples the GPU, so the menu can say whether this Mac is actually working.
+///
+/// **What this does not cover.** VideoToolbox encodes on the media engine, a fixed-function block
+/// that is not the GPU's shader cores and is not exposed by any public interface. A hardware
+/// encode can therefore read low here while the Mac is entirely busy. The number is honest about
+/// the GPU; the menu says which encoder is running so the two are read together.
+public enum GpuMonitor {
+    public static func sample() -> GpuUsage? {
+        var iterator: io_iterator_t = 0
+        guard IOServiceGetMatchingServices(
+            kIOMainPortDefault, IOServiceMatching("IOAccelerator"), &iterator) == KERN_SUCCESS
+        else { return nil }
+        defer { IOObjectRelease(iterator) }
+
+        // A Mac can list more than one accelerator. The first that reports a utilisation figure is
+        // taken; on Apple Silicon there is exactly one that does.
+        while case let entry = IOIteratorNext(iterator), entry != 0 {
+            defer { IOObjectRelease(entry) }
+            var properties: Unmanaged<CFMutableDictionary>?
+            guard IORegistryEntryCreateCFProperties(
+                entry, &properties, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+                let dictionary = properties?.takeRetainedValue() as? [String: Any],
+                let statistics = dictionary["PerformanceStatistics"] as? [String: Any],
+                let usage = GpuStatisticsParser.parse(statistics)
+            else { continue }
+            return usage
+        }
+        return nil
+    }
+}

--- a/sidecars/macos/Sources/SidecarCore/JobRunner.swift
+++ b/sidecars/macos/Sources/SidecarCore/JobRunner.swift
@@ -88,11 +88,17 @@ public enum JobOutcome: Sendable, Equatable {
 }
 
 /// What is happening inside a running job, for the menu.
+///
+/// The two transfer stages carry byte counts because they are the ones that can take a long time
+/// with nothing else to show: a multi-gigabyte source over a home network looks identical to a
+/// stalled one unless the bytes are counted. A total of zero means it is not known yet, which is
+/// true for the moment before the first range comes back and for a server that answers with the
+/// whole file and no range header.
 public enum JobProgress: Sendable, Equatable {
-    case fetchingSource
+    case fetchingSource(received: Int64, total: Int64)
     case encoding(encodedSeconds: Double)
     case measuring
-    case delivering
+    case delivering(sent: Int64, total: Int64)
 }
 
 /// The most recent progress, shared between the ffmpeg reader and the renewal loop. A lock
@@ -120,11 +126,16 @@ private enum LeaseOperation<T: Sendable>: Sendable {
 }
 
 /// Executes assignments, so the session can be driven in tests without an ffmpeg or a server.
+///
+/// `preview` carries an occasional JPEG of the frame being encoded. It is separate from `progress`
+/// so the stage enum stays small and cheap to compare: previews arrive rarely and are worth
+/// several kilobytes each, while progress arrives many times a second.
 public protocol WorkExecutor: Sendable {
     func execute(
         _ assignment: Assignment,
         pairing: StoredPairing,
-        progress: @escaping @Sendable (JobProgress) -> Void
+        progress: @escaping @Sendable (JobProgress) -> Void,
+        preview: @escaping @Sendable (Data) -> Void
     ) async -> JobOutcome
 }
 
@@ -144,6 +155,9 @@ public struct JobRunner: WorkExecutor {
     private let runner: TranscodeRunner
     private let leadProbe: CommandRunner
     private let scratchRoot: URL
+    private let chunkBytes: Int64
+    private let previewSampler: FramePreviewSampler?
+    private let wantsPreviews: @Sendable () -> Bool
     private let availableScratchBytes: @Sendable (URL) -> Int64?
     private let sleep: @Sendable (TimeInterval) async throws -> Void
 
@@ -154,6 +168,9 @@ public struct JobRunner: WorkExecutor {
         runner: TranscodeRunner = ProcessTranscodeRunner(),
         leadProbe: CommandRunner = ProcessCommandRunner(),
         scratchRoot: URL = JobRunner.defaultScratchRoot(),
+        chunkBytes: Int64 = JobRunner.defaultChunkBytes,
+        previewSampler: FramePreviewSampler? = CapabilityProber.bundledFfmpeg().map { FramePreviewSampler(ffmpeg: $0) },
+        wantsPreviews: @escaping @Sendable () -> Bool = { false },
         availableScratchBytes: @escaping @Sendable (URL) -> Int64? = JobRunner.availableScratchBytes,
         sleep: @escaping @Sendable (TimeInterval) async throws -> Void = { seconds in
             try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
@@ -165,6 +182,9 @@ public struct JobRunner: WorkExecutor {
         self.runner = runner
         self.leadProbe = leadProbe
         self.scratchRoot = scratchRoot
+        self.chunkBytes = max(1, chunkBytes)
+        self.previewSampler = previewSampler
+        self.wantsPreviews = wantsPreviews
         self.availableScratchBytes = availableScratchBytes
         self.sleep = sleep
     }
@@ -194,13 +214,15 @@ public struct JobRunner: WorkExecutor {
     public func execute(
         _ assignment: Assignment,
         pairing: StoredPairing,
-        progress: @escaping @Sendable (JobProgress) -> Void
+        progress: @escaping @Sendable (JobProgress) -> Void,
+        preview: @escaping @Sendable (Data) -> Void = { _ in }
     ) async -> JobOutcome {
         let scratch = scratchRoot.appendingPathComponent("lease-\(assignment.leaseId)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: scratch) }
 
         do {
-            let outcome = try await run(assignment, pairing: pairing, scratch: scratch, progress: progress)
+            let outcome = try await run(
+                assignment, pairing: pairing, scratch: scratch, progress: progress, preview: preview)
             return outcome
         } catch let error as SidecarError {
             switch error {
@@ -220,7 +242,7 @@ public struct JobRunner: WorkExecutor {
 
     /// Bytes per chunk of a resumable upload. Large enough that a film is a few dozen requests,
     /// small enough that a dropped connection loses a minute, not an hour.
-    static let chunkBytes: Int64 = 64 * 1024 * 1024
+    public static let defaultChunkBytes: Int64 = 64 * 1024 * 1024
 
     /// How many times a chunk may fail before the delivery is given up.
     static let maxChunkFailures = 20
@@ -231,7 +253,8 @@ public struct JobRunner: WorkExecutor {
     static let maxSourceFailures = 20
 
     private func fetchSource(
-        _ assignment: Assignment, pairing: StoredPairing, destination: URL
+        _ assignment: Assignment, pairing: StoredPairing, destination: URL,
+        progress: @escaping @Sendable (Int64, Int64) -> Void
     ) async throws -> String {
         var failures = 0
         while true {
@@ -239,7 +262,7 @@ public struct JobRunner: WorkExecutor {
             do {
                 return try await client.fetchSource(
                     serverAddress: pairing.serverAddress, credential: pairing.credential,
-                    leaseId: assignment.leaseId, to: destination)
+                    leaseId: assignment.leaseId, to: destination, progress: progress)
             } catch SidecarError.transferFailed {
                 failures += 1
                 guard failures <= Self.maxSourceFailures else {
@@ -286,15 +309,20 @@ public struct JobRunner: WorkExecutor {
     /// after a failure; a server that predates resumable delivery gets the whole file at once.
     private func deliver(
         _ assignment: Assignment, pairing: StoredPairing, candidate: URL,
-        sourceSha256: String, candidateSha256: String
+        sourceSha256: String, candidateSha256: String,
+        progress: @escaping @Sendable (Int64, Int64) -> Void
     ) async throws -> DeliveryReceipt {
         guard var offset = try await client.uploadOffset(
             serverAddress: pairing.serverAddress, credential: pairing.credential, leaseId: assignment.leaseId)
         else {
-            return try await client.deliver(
+            // An older server takes the whole file in one request, so there is nothing to count
+            // along the way; the bar fills when it lands.
+            let receipt = try await client.deliver(
                 serverAddress: pairing.serverAddress, credential: pairing.credential,
                 leaseId: assignment.leaseId, file: candidate,
                 sourceSha256: sourceSha256, candidateSha256: candidateSha256)
+            progress(receipt.bytes, receipt.bytes)
+            return receipt
         }
 
         let size = (try? FileManager.default.attributesOfItem(atPath: candidate.path)[.size] as? NSNumber)?.int64Value ?? 0
@@ -305,7 +333,7 @@ public struct JobRunner: WorkExecutor {
         while offset < size {
             try Task.checkCancellation()
             try handle.seek(toOffset: UInt64(offset))
-            let length = Int(min(Self.chunkBytes, size - offset))
+            let length = Int(min(chunkBytes, size - offset))
             guard let chunk = try handle.read(upToCount: length), !chunk.isEmpty else {
                 throw SidecarError.transferFailed(reason: "The candidate could not be read at offset \(offset).")
             }
@@ -313,6 +341,7 @@ public struct JobRunner: WorkExecutor {
                 offset = try await client.uploadChunk(
                     serverAddress: pairing.serverAddress, credential: pairing.credential,
                     leaseId: assignment.leaseId, offset: offset, chunk: chunk)
+                progress(offset, size)
             } catch let SidecarError.uploadOffsetMismatch(serverHolds) {
                 // The server is the authority on what arrived; carry on from its number.
                 offset = serverHolds
@@ -367,7 +396,8 @@ public struct JobRunner: WorkExecutor {
         _ assignment: Assignment,
         pairing: StoredPairing,
         scratch: URL,
-        progress: @escaping @Sendable (JobProgress) -> Void
+        progress: @escaping @Sendable (JobProgress) -> Void,
+        preview: @escaping @Sendable (Data) -> Void
     ) async throws -> JobOutcome {
         guard let ffmpeg else {
             return await release(assignment, pairing: pairing, reason: "This build has no ffmpeg to run.")
@@ -399,13 +429,17 @@ public struct JobRunner: WorkExecutor {
         }
         let source = scratch.appendingPathComponent("source", isDirectory: false)
         let candidate = scratch.appendingPathComponent("candidate.\(assignment.outputExtension)", isDirectory: false)
-        let latest = LatestProgress(.fetchingSource)
+        let latest = LatestProgress(.fetchingSource(received: 0, total: assignment.sourceBytes))
 
-        progress(.fetchingSource)
+        progress(.fetchingSource(received: 0, total: assignment.sourceBytes))
         let declaredSourceHash = try await whileRenewingLease(
             assignment, pairing: pairing, progress: latest.get
         ) {
-            try await fetchSource(assignment, pairing: pairing, destination: source)
+            try await fetchSource(assignment, pairing: pairing, destination: source) { received, total in
+                let stage = JobProgress.fetchingSource(received: received, total: total)
+                latest.set(stage)
+                progress(stage)
+            }
         }
         let actualSourceHash = try Self.sha256(of: source)
         guard actualSourceHash.caseInsensitiveCompare(declaredSourceHash) == .orderedSame else {
@@ -418,9 +452,17 @@ public struct JobRunner: WorkExecutor {
         let encode = try await whileRenewingLease(
             assignment, pairing: pairing, progress: latest.get
         ) {
-            try await runner.run(ffmpeg, arguments) { seconds in
+            try await runner.run(ffmpeg, arguments) { [previewSampler, wantsPreviews] seconds in
                 latest.set(.encoding(encodedSeconds: seconds))
                 progress(.encoding(encodedSeconds: seconds))
+                // Only while someone has the menu open, and never faster than the sampler's own
+                // interval: a frame grab is a whole process, and the encode is the job here.
+                guard let previewSampler, wantsPreviews() else { return }
+                Task {
+                    if let frame = await previewSampler.frame(from: source, atSeconds: seconds) {
+                        preview(frame)
+                    }
+                }
             }
         }
 
@@ -451,14 +493,21 @@ public struct JobRunner: WorkExecutor {
             }
         }
 
-        progress(.delivering)
-        latest.set(.delivering)
+        let candidateBytes = (try? FileManager.default
+            .attributesOfItem(atPath: candidate.path)[.size] as? NSNumber)?.int64Value ?? 0
+        progress(.delivering(sent: 0, total: candidateBytes))
+        latest.set(.delivering(sent: 0, total: candidateBytes))
         let receipt = try await whileRenewingLease(
             assignment, pairing: pairing, progress: latest.get
         ) {
             try await deliver(
                 assignment, pairing: pairing, candidate: candidate,
-                sourceSha256: declaredSourceHash, candidateSha256: candidateHash)
+                sourceSha256: declaredSourceHash, candidateSha256: candidateHash
+            ) { sent, total in
+                let stage = JobProgress.delivering(sent: sent, total: total)
+                latest.set(stage)
+                progress(stage)
+            }
         }
         return .delivered(jobId: receipt.jobId, bytes: receipt.bytes)
     }

--- a/sidecars/macos/Sources/SidecarCore/SidecarClient.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarClient.swift
@@ -355,7 +355,8 @@ public struct SidecarClient: Sendable {
     /// Fetches the source for a lease to a file and returns the hash the server declared for it,
     /// so the caller can prove the transfer arrived intact before encoding a byte of it.
     public func fetchSource(
-        serverAddress: String, credential: String, leaseId: String, to destination: URL
+        serverAddress: String, credential: String, leaseId: String, to destination: URL,
+        progress: @escaping @Sendable (_ received: Int64, _ total: Int64) -> Void = { _, _ in }
     ) async throws -> String {
         var offset = Self.fileSize(destination)
         var declaredHash: String?
@@ -378,6 +379,9 @@ public struct SidecarClient: Sendable {
 
             switch response.statusCode {
             case 200:
+                // The whole file in one body: nothing to count on the way, so report it complete.
+                let size = Self.fileSize(destination)
+                progress(size, size)
                 return try Self.sourceHash(response, status: 200)
             case 206:
                 let hash = try Self.sourceHash(response, status: 206)
@@ -396,6 +400,7 @@ public struct SidecarClient: Sendable {
                     try? Self.truncate(destination, to: offset)
                     throw SidecarError.transferFailed(reason: "The source range did not arrive in full.")
                 }
+                progress(expectedSize, range.total)
                 if expectedSize == range.total {
                     return hash
                 }

--- a/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
+++ b/sidecars/macos/Sources/SidecarCore/SidecarSession.swift
@@ -37,14 +37,21 @@ public enum SidecarStatus: Equatable, Sendable {
 /// reason for this to be concurrent; the work it does is network I/O, not computation.
 @MainActor
 public final class SidecarSession: ObservableObject {
-    @Published public private(set) var status: SidecarStatus = .unpaired
-    @Published public private(set) var serverAddress: String = ""
+    @Published public internal(set) var status: SidecarStatus = .unpaired
+    @Published public internal(set) var serverAddress: String = ""
 
     /// How the last job ended, kept so the menu can say what this machine last did for the server.
-    @Published public private(set) var lastOutcome: JobOutcome?
+    @Published public internal(set) var lastOutcome: JobOutcome?
 
     /// Every job in flight and where it has got to, keyed by job id.
-    @Published public private(set) var activeJobs: [Int: JobProgress] = [:]
+    @Published public internal(set) var activeJobs: [Int: JobProgress] = [:]
+
+    /// The recent frames each running job was seen encoding. Only collected while the menu is
+    /// open, and dropped as soon as the job ends.
+    @Published public internal(set) var filmStrips: [Int: FilmStrip] = [:]
+
+    /// The GPU reading taken alongside the last preview, when this Mac publishes one.
+    @Published public internal(set) var gpu: GpuUsage?
 
     /// How many jobs this Mac takes at once. Chosen by the operator, reported to the server on
     /// every check-in, and the ceiling the claim loop fills up to.
@@ -53,6 +60,9 @@ public final class SidecarSession: ObservableObject {
     public static let concurrencyRange = 1...4
 
     private let client: SidecarClient
+    /// True only for a session built by `posed(...)`.
+    var isPosed = false
+    private let previewGate: PreviewGate
     private let store: CredentialStore
     private let prober: CapabilityProber?
     private let executor: WorkExecutor?
@@ -73,7 +83,8 @@ public final class SidecarSession: ObservableObject {
         store: CredentialStore = KeychainCredentialStore(),
         capabilities: SidecarCapabilities = .provenToday(name: Host.current().localizedName ?? "Mac"),
         prober: CapabilityProber? = CapabilityProber(),
-        executor: WorkExecutor? = JobRunner(),
+        previewGate: PreviewGate = PreviewGate(),
+        executor: WorkExecutor? = nil,
         scratchCapacity: @escaping @Sendable () -> Int64 = {
             JobRunner.availableScratchBytes(at: JobRunner.defaultScratchRoot()) ?? 0
         },
@@ -87,7 +98,10 @@ public final class SidecarSession: ObservableObject {
         self.store = store
         self.capabilities = capabilities
         self.prober = prober
-        self.executor = executor
+        self.previewGate = previewGate
+        // Built here rather than as a default argument so the runner can read the same gate this
+        // session hands to the menu.
+        self.executor = executor ?? JobRunner(wantsPreviews: { [previewGate] in previewGate.isWanted })
         self.scratchCapacity = scratchCapacity
         self.jobConcurrency = Self.concurrencyRange.contains(jobConcurrency) ? jobConcurrency : 1
         self.persistConcurrency = persistConcurrency
@@ -112,6 +126,9 @@ public final class SidecarSession: ObservableObject {
     /// without this a relaunched app reported no encoders and zero concurrency — "drained" to the
     /// server — and never took work again until it was paired afresh.
     public func restore() {
+        // A posed session is a still life for previews and `--render-menu`; restoring it would
+        // reach for the Keychain and overwrite the very state being looked at.
+        guard !isPosed else { return }
         guard pairing == nil else { return }
         guard let stored = try? store.load() else {
             status = .unpaired
@@ -173,6 +190,7 @@ public final class SidecarSession: ObservableObject {
         for task in jobTasks.values { task.cancel() }
         jobTasks = [:]
         activeJobs = [:]
+        filmStrips = [:]
         endActivity()
         try? store.clear()
         pairing = nil
@@ -303,7 +321,7 @@ public final class SidecarSession: ObservableObject {
             guard let assignment, jobTasks[assignment.jobId] == nil else { return }
 
             let jobId = assignment.jobId
-            activeJobs[jobId] = .fetchingSource
+            activeJobs[jobId] = .fetchingSource(received: 0, total: assignment.sourceBytes)
             refreshWorkingStatus()
             beginActivity()
             // The task holds the session for the job's duration, which is intended: a job is
@@ -313,6 +331,8 @@ public final class SidecarSession: ObservableObject {
                 guard let self else { return }
                 let outcome = await executor.execute(assignment, pairing: pairing) { progress in
                     Task { @MainActor in self.report(jobId: jobId, progress: progress) }
+                } preview: { frame in
+                    Task { @MainActor in self.report(jobId: jobId, frame: frame) }
                 }
                 self.finish(outcome, jobId: jobId, workerId: workerId)
             }
@@ -323,6 +343,23 @@ public final class SidecarSession: ObservableObject {
         guard jobTasks[jobId] != nil else { return }
         activeJobs[jobId] = progress
         refreshWorkingStatus()
+    }
+
+    private func report(jobId: Int, frame: Data) {
+        guard jobTasks[jobId] != nil else { return }
+        filmStrips[jobId, default: FilmStrip()].append(frame)
+        // Sampled here rather than on a timer of its own: the two readings then describe the same
+        // instant, and nothing runs while no job does.
+        gpu = GpuMonitor.sample()
+    }
+
+    /// Called by the menu as it opens and closes. Nothing is sampled while nobody is looking.
+    public func setPreviewsWanted(_ wanted: Bool) {
+        previewGate.set(wanted)
+        if !wanted {
+            filmStrips = [:]
+            gpu = nil
+        }
     }
 
     /// The menu bar shows one job; the earliest still running stands for the rest, and the menu
@@ -336,6 +373,7 @@ public final class SidecarSession: ObservableObject {
         lastOutcome = outcome
         jobTasks[jobId] = nil
         activeJobs[jobId] = nil
+        filmStrips[jobId] = nil
         if jobTasks.isEmpty {
             endActivity()
         } else {
@@ -396,5 +434,34 @@ extension SidecarStatus {
         case .disabledOnServer: return "Turned off on the server"
         case .pairingFailed: return "Pairing failed"
         }
+    }
+}
+
+public extension SidecarSession {
+    /// A session posed in a given state, for SwiftUI previews and for the app's own
+    /// `--render-menu` mode.
+    ///
+    /// The menu is the whole product here and it is fiddly to judge from code, but every state
+    /// worth looking at — mid-transfer, encoding with a strip of frames, revoked — needs a paired
+    /// server and a running job to reach for real. Posing one is how the layout gets reviewed
+    /// without that, and it is why the published properties are settable from here and nowhere
+    /// else.
+    static func posed(
+        status: SidecarStatus,
+        serverAddress: String = "https://optimisarr.pownet.uk",
+        activeJobs: [Int: JobProgress] = [:],
+        filmStrips: [Int: FilmStrip] = [:],
+        gpu: GpuUsage? = nil,
+        lastOutcome: JobOutcome? = nil
+    ) -> SidecarSession {
+        let session = SidecarSession(prober: nil, executor: nil)
+        session.isPosed = true
+        session.status = status
+        session.serverAddress = serverAddress
+        session.activeJobs = activeJobs
+        session.filmStrips = filmStrips
+        session.gpu = gpu
+        session.lastOutcome = lastOutcome
+        return session
     }
 }

--- a/sidecars/macos/Tests/SidecarCoreTests/LiveDetailTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/LiveDetailTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Testing
+@testable import SidecarCore
+
+@Suite("GPU statistics")
+struct GpuStatisticsTests {
+    @Test("a utilisation percentage becomes a fraction, with memory alongside")
+    func parsesUtilisation() {
+        let usage = GpuStatisticsParser.parse([
+            "Device Utilization %": NSNumber(value: 55),
+            "In use system memory": NSNumber(value: 1_253_064_704),
+        ])
+
+        #expect(usage?.device == 0.55)
+        #expect(usage?.memoryInUse == 1_253_064_704)
+    }
+
+    @Test("a dictionary with no utilisation figure reports nothing rather than idle")
+    func refusesToInventZero() {
+        // Zero would be drawn as a GPU sitting idle, which is a different claim from "this Mac
+        // does not publish the number".
+        #expect(GpuStatisticsParser.parse([:]) == nil)
+        #expect(GpuStatisticsParser.parse(["In use system memory": NSNumber(value: 4)]) == nil)
+    }
+
+    @Test("an out-of-range or oddly typed reading is clamped rather than believed")
+    func clampsAndCoerces() {
+        #expect(GpuStatisticsParser.parse(["Device Utilization %": NSNumber(value: 140)])?.device == 1)
+        #expect(GpuStatisticsParser.parse(["Device Utilization %": NSNumber(value: -3)])?.device == 0)
+        // Some builds hand these back as strings; a reading is better than nothing.
+        #expect(GpuStatisticsParser.parse(["Device Utilization %": "50"])?.device == 0.5)
+    }
+}
+
+@Suite("Frame preview")
+struct FramePreviewTests {
+    @Test("the seek comes before the input so one frame costs a keyframe jump, not a full decode")
+    func seeksBeforeInput() {
+        let arguments = FramePreviewCommand.arguments(
+            source: URL(fileURLWithPath: "/scratch/source"), atSeconds: 61.5, width: 240)
+
+        let seek = arguments.firstIndex(of: "-ss")!
+        let input = arguments.firstIndex(of: "-i")!
+        #expect(seek < input)
+        #expect(arguments[seek + 1] == "61.50")
+        #expect(arguments[input + 1] == "/scratch/source")
+        #expect(arguments.contains("mjpeg"))
+        #expect(arguments.last == "-")
+    }
+
+    @Test("a negative position is clamped rather than passed to ffmpeg")
+    func clampsPosition() {
+        let arguments = FramePreviewCommand.arguments(
+            source: URL(fileURLWithPath: "/scratch/source"), atSeconds: -4, width: 240)
+
+        #expect(arguments[arguments.firstIndex(of: "-ss")! + 1] == "0.00")
+    }
+
+    @Test("sampling is rate limited, so encoder progress cannot launch a process per update")
+    func rateLimits() async {
+        let runner = CountingBinaryRunner(output: Data([0xFF, 0xD8, 0xFF]))
+        let sampler = FramePreviewSampler(
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"), runner: runner, interval: 2)
+        let start = Date()
+        let source = URL(fileURLWithPath: "/scratch/source")
+
+        #expect(await sampler.frame(from: source, atSeconds: 1, now: start) != nil)
+        #expect(await sampler.frame(from: source, atSeconds: 2, now: start.addingTimeInterval(0.5)) == nil)
+        #expect(await sampler.frame(from: source, atSeconds: 3, now: start.addingTimeInterval(2.1)) != nil)
+        #expect(runner.calls == 2)
+    }
+
+    @Test("a failed grab is silent, because a missing picture must never disturb a job")
+    func failureIsSilent() async {
+        let sampler = FramePreviewSampler(
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: CountingBinaryRunner(output: Data(), exitCode: 1))
+
+        #expect(await sampler.frame(from: URL(fileURLWithPath: "/scratch/source"), atSeconds: 1) == nil)
+    }
+}
+
+final class CountingBinaryRunner: BinaryCommandRunner, @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    private let output: Data
+    private let exitCode: Int32
+
+    init(output: Data, exitCode: Int32 = 0) {
+        self.output = output
+        self.exitCode = exitCode
+    }
+
+    var calls: Int { lock.withLock { count } }
+
+    func run(_ executable: URL, _ arguments: [String]) async -> (exitCode: Int32, output: Data) {
+        lock.withLock { count += 1 }
+        return (exitCode, output)
+    }
+}
+
+@Suite("Film strip")
+struct FilmStripTests {
+    private func frame(_ byte: UInt8) -> Data { Data([byte]) }
+
+    @Test("frames accumulate in order so the strip plays forwards")
+    func keepsOrder() {
+        var strip = FilmStrip()
+        strip.append(frame(1))
+        strip.append(frame(2))
+        strip.append(frame(3))
+
+        #expect(strip.frames == [frame(1), frame(2), frame(3)])
+        #expect(strip.frame(atTick: 0) == frame(1))
+        #expect(strip.frame(atTick: 4) == frame(2))
+    }
+
+    @Test("the strip is bounded, so a long encode cannot grow it without limit")
+    func dropsOldest() {
+        // At one frame a second and several jobs at once, an unbounded strip would hold tens of
+        // megabytes of JPEG by the end of a film.
+        var strip = FilmStrip()
+        for byte in 0..<UInt8(FilmStrip.capacity + 10) { strip.append(frame(byte)) }
+
+        #expect(strip.frames.count == FilmStrip.capacity)
+        #expect(strip.frames.first == frame(10))
+        #expect(strip.frames.last == frame(UInt8(FilmStrip.capacity + 9)))
+    }
+
+    @Test("an empty strip has no frame to show rather than crashing on the modulo")
+    func emptyIsSafe() {
+        #expect(FilmStrip().frame(atTick: 3) == nil)
+        #expect(FilmStrip().isEmpty)
+    }
+}
+
+@MainActor
+@Suite("Preview gating")
+struct PreviewGatingTests {
+    @Test("nothing is sampled until the menu asks, and what was sampled is dropped when it closes")
+    func gatesAndClears() {
+        // A frame grab is a process launch beside a running encode. Paying for it with no menu on
+        // screen would be pure waste, and keeping the last frame after the menu closes would show
+        // a stale picture the next time it opens.
+        let gate = PreviewGate()
+        #expect(!gate.isWanted)
+
+        gate.set(true)
+        #expect(gate.isWanted)
+
+        gate.set(false)
+        #expect(!gate.isWanted)
+    }
+}
+
+/// Real ffmpeg, skipped unless `OPTIMISARR_FFMPEG` points at one:
+///
+///     OPTIMISARR_FFMPEG=$(pwd)/vendor/ffmpeg swift test
+@Suite("Live frame preview", .enabled(if: ProcessInfo.processInfo.environment["OPTIMISARR_FFMPEG"] != nil))
+struct LiveFramePreviewTests {
+    @Test("grabs a real JPEG out of a real file")
+    func grabsAJpeg() async throws {
+        let ffmpeg = URL(fileURLWithPath: ProcessInfo.processInfo.environment["OPTIMISARR_FFMPEG"]!)
+        let clip = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preview-source-\(UUID().uuidString).mp4")
+        defer { try? FileManager.default.removeItem(at: clip) }
+
+        let made = await ProcessCommandRunner().run(ffmpeg, [
+            "-hide_banner", "-v", "error", "-y",
+            "-f", "lavfi", "-i", "testsrc2=size=640x360:rate=24", "-t", "4",
+            "-c:v", "libx264", "-preset", "ultrafast", clip.path,
+        ])
+        #expect(made.exitCode == 0)
+
+        let sampler = FramePreviewSampler(ffmpeg: ffmpeg, interval: 0, width: 240)
+        let frame = await sampler.frame(from: clip, atSeconds: 2)
+
+        let bytes = try #require(frame)
+        // JPEG's start-of-image marker: proof this is a picture, not an error page or empty data.
+        #expect(bytes.prefix(2) == Data([0xFF, 0xD8]))
+        #expect(bytes.count > 500)
+    }
+}

--- a/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/SidecarSessionTests.swift
@@ -60,7 +60,8 @@ final class HangingExecutor: WorkExecutor, @unchecked Sendable {
 
     func execute(
         _ assignment: Assignment, pairing: StoredPairing,
-        progress: @escaping @Sendable (JobProgress) -> Void
+        progress: @escaping @Sendable (JobProgress) -> Void,
+        preview: @escaping @Sendable (Data) -> Void
     ) async -> JobOutcome {
         lock.withLock { started = true; startedCount += 1 }
         while !Task.isCancelled {

--- a/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
+++ b/sidecars/macos/Tests/SidecarCoreTests/WorkLoopTests.swift
@@ -305,6 +305,92 @@ struct ResumableSourceDownloadTests {
         #expect(server.sourceOffsets == [0, 64, 64, 128, 192])
         #expect(server.deliveredFile == Data("candidate bytes".utf8))
     }
+
+    @Test("each completed range moves the download bar, and the total is known from the first one")
+    func reportsDownloadProgress() async throws {
+        // Without a byte count the menu can only say "Fetching the source" for however long a
+        // multi-gigabyte transfer takes, which is indistinguishable from being stuck.
+        let bytes = Data((0..<200).map(UInt8.init))
+        let server = FakeWorkerServer(sourceBytes: bytes)
+        server.rangedSource = true
+        let reports = ProgressRecorder()
+        let runner = JobRunner(
+            client: SidecarClient(transport: server, downloadChunkBytes: 64),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: FakeTranscodeRunner(),
+            scratchRoot: scratch(),
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        _ = await runner.execute(assignment(sourceBytes: 200), pairing: pairing) { reports.record($0) }
+
+        // The opening report is the assignment's own declared size, so the bar is drawn at zero
+        // of the right total rather than appearing only once the first range lands.
+        #expect(reports.downloads == [(0, 200), (64, 200), (128, 200), (192, 200), (200, 200)].map(Bytes.init))
+    }
+
+    @Test("a server that sends the whole file at once still reports a finished download")
+    func reportsWholeFileDownload() async throws {
+        // An older server answers 200 with the entire body. There is no range to count, but the
+        // bar must still finish rather than sit at zero until the encode starts.
+        let bytes = Data((0..<200).map(UInt8.init))
+        let server = FakeWorkerServer(sourceBytes: bytes)
+        let reports = ProgressRecorder()
+        let runner = JobRunner(
+            client: SidecarClient(transport: server, downloadChunkBytes: 64),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: FakeTranscodeRunner(),
+            scratchRoot: scratch(),
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        _ = await runner.execute(assignment(sourceBytes: 200), pairing: pairing) { reports.record($0) }
+
+        #expect(reports.downloads.last == Bytes(200, 200))
+    }
+
+    @Test("each delivered chunk moves the upload bar")
+    func reportsUploadProgress() async throws {
+        let server = FakeWorkerServer(sourceBytes: Data((0..<200).map(UInt8.init)))
+        server.resumable = true
+        let reports = ProgressRecorder()
+        let runner = JobRunner(
+            client: SidecarClient(transport: server),
+            ffmpeg: URL(fileURLWithPath: "/usr/bin/true"),
+            runner: FakeTranscodeRunner(candidate: Data(repeating: 7, count: 200)),
+            scratchRoot: scratch(),
+            chunkBytes: 64,
+            sleep: { _ in try await Task.sleep(nanoseconds: 1_000_000) })
+
+        _ = await runner.execute(assignment(sourceBytes: 200), pairing: pairing) { reports.record($0) }
+
+        #expect(reports.uploads == [(0, 200), (64, 200), (128, 200), (192, 200), (200, 200)].map(Bytes.init))
+    }
+}
+
+/// A pair of byte counts, so a test can state the whole expected sequence in one line.
+struct Bytes: Equatable {
+    let done: Int64
+    let total: Int64
+    init(_ done: Int64, _ total: Int64) { self.done = done; self.total = total }
+}
+
+/// Collects the progress a job reported, split by the two transfer stages.
+final class ProgressRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var all: [JobProgress] = []
+
+    func record(_ progress: JobProgress) { lock.withLock { all.append(progress) } }
+
+    var downloads: [Bytes] {
+        lock.withLock {
+            all.compactMap { if case let .fetchingSource(received, total) = $0 { Bytes(received, total) } else { nil } }
+        }
+    }
+
+    var uploads: [Bytes] {
+        lock.withLock {
+            all.compactMap { if case let .delivering(sent, total) = $0 { Bytes(sent, total) } else { nil } }
+        }
+    }
 }
 
 /// Stands in for ffmpeg: writes the candidate the command names, or fails, without encoding.
@@ -625,7 +711,8 @@ final class RecordingExecutor: WorkExecutor, @unchecked Sendable {
 
     func execute(
         _ assignment: Assignment, pairing: StoredPairing,
-        progress: @escaping @Sendable (JobProgress) -> Void
+        progress: @escaping @Sendable (JobProgress) -> Void,
+        preview: @escaping @Sendable (Data) -> Void
     ) async -> JobOutcome {
         executed.append(assignment)
         progress(.encoding(encodedSeconds: 3))

--- a/sidecars/macos/scripts/make-app.sh
+++ b/sidecars/macos/scripts/make-app.sh
@@ -55,11 +55,57 @@ cat > "${BUNDLE}/Contents/Info.plist" <<'PLIST'
 PLIST
 echo '</plist>' >> "${BUNDLE}/Contents/Info.plist"
 
-# Ad-hoc signature so the Keychain gives the bundle a stable identity to store its credential
-# against. Distribution needs a real Developer ID and notarisation; this is enough to run locally.
-codesign --force --sign - "${BUNDLE}" >/dev/null 2>&1 || {
-  echo "warning: ad-hoc codesign failed; the app will still run but Keychain access may prompt" >&2
-}
+# Signing.
+#
+# The Keychain decides what an app may read from the identity in its signature, so a *stable*
+# signature is what lets a paired credential survive a rebuild. An ad-hoc signature is derived
+# from the binary and therefore changes every single build, which makes every rebuilt copy a
+# different application to the Keychain — the credential becomes unreadable and, on the legacy
+# keychain, macOS asks the operator for a password to reach it. Set SIGNING_IDENTITY to a real
+# certificate and that stops for good:
+#
+#     SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)" ./scripts/make-app.sh release
+#
+# `security find-identity -v -p codesigning` lists what this Mac holds. Ad-hoc remains the default
+# so a fresh clone builds and runs with no certificate at all.
+SIGNING_IDENTITY="${SIGNING_IDENTITY:-}"
+
+if [[ -n "${SIGNING_IDENTITY}" ]]; then
+  # keychain-access-groups moves the credential to the data protection keychain, which decides
+  # access by signature and never raises a dialog. It is a restricted entitlement: macOS kills an
+  # ad-hoc binary that claims it, which is exactly why it is written only when signing for real.
+  # No entitlements are claimed.
+  #
+  # keychain-access-groups would move the credential to the data protection keychain, which never
+  # raises a dialog — but it is a restricted entitlement and macOS refuses to launch an app that
+  # claims it without a matching provisioning profile (a bare "Launchd job spawn failed"). It is
+  # not needed: the prompting was caused by the signature changing on every build, and a stable
+  # certificate fixes that on the legacy keychain too. `CredentialStore` tries the data protection
+  # keychain first regardless, so a future profiled build gets it with no code change.
+
+  # Inside out: the bundled ffmpeg and ffprobe are separate Mach-O executables and must each carry
+  # their own signature before the bundle that contains them is sealed. The hardened runtime and a
+  # secure timestamp are both required for notarisation.
+  for tool in ffmpeg ffprobe; do
+    if [[ -f "${BUNDLE}/Contents/Resources/${tool}" ]]; then
+      codesign --force --options runtime --timestamp \
+        --sign "${SIGNING_IDENTITY}" "${BUNDLE}/Contents/Resources/${tool}"
+    fi
+  done
+
+  codesign --force --options runtime --timestamp \
+    --sign "${SIGNING_IDENTITY}" "${BUNDLE}"
+
+  echo "Signed with: ${SIGNING_IDENTITY}"
+  codesign --verify --deep --strict --verbose=2 "${BUNDLE}" 2>&1 | sed 's/^/  /'
+else
+  # Enough to run locally. The signature changes on every build, so a pairing does not survive one.
+  codesign --force --sign - "${BUNDLE}" >/dev/null 2>&1 || {
+    echo "warning: ad-hoc codesign failed; the app will still run but Keychain access may prompt" >&2
+  }
+  echo "Ad-hoc signed (development). A pairing will not survive a rebuild —"
+  echo "set SIGNING_IDENTITY to a real certificate to keep one."
+fi
 
 echo "Built ${BUNDLE}"
 echo "Run it with: open ${BUNDLE}"


### PR DESCRIPTION
## Outcome

The sidecar menu shows a running job properly, and a rebuilt app no longer asks for Keychain access every time.

## The menu

- **Film strip.** A time-lapse of the frames going through the encoder, with a strip of the recent run beneath it. Frames come from the *source* seeked to the encoder's position, not the half-written candidate, which has no index yet and cannot be decoded. Bounded to 24 frames per job.
- **Transfer bars.** Real byte counts for the two stages that have them: received while a source downloads, sent while a candidate is delivered. `JobProgress` carries the counts; the client reports each completed range and the runner each delivered chunk. Encoding stays indeterminate because only the server knows the source's duration.
- **GPU.** Read from `IOAccelerator` unprivileged, with the caveat stated in the UI rather than left to be discovered: VideoToolbox encodes on the media engine, which macOS does not report, so a hardware encode reads low.
- Frames and GPU are sampled only while the menu is open, and never faster than 1.5 s.
- Cards, one status colour carried from the header, and bars drawn from shapes rather than AppKit so they suit a popover and survive an offscreen render.
- `--render-menu <dir>` writes a PNG of every state — unpaired, receiving, encoding, sending, two jobs, revoked, unreachable. Most of those need a paired server and a running job to reach, so they were never being looked at before a change shipped.

## The Keychain

Seen live: the app asked for Keychain access repeatedly. An ad-hoc signature is derived from the binary, so it changes on **every build** — the designated requirement is a `cdhash`, verified here — and the Keychain treats each rebuilt copy as a different application.

- `make-app.sh` takes `SIGNING_IDENTITY` and signs with a real certificate, whose designated requirement is the certificate itself and is stable across rebuilds (also verified). Hardened runtime, secure timestamp, and the bundled `ffmpeg`/`ffprobe` signed first, all of which notarisation needs. Ad-hoc remains the default so a fresh clone still builds.
- `CredentialStore` tries the data protection keychain first and falls back to the legacy one. An item it cannot read without a prompt is deleted and reported as "not paired", so a stale item cannot nag forever.
- No entitlements are claimed. `keychain-access-groups` would give the prompt-free keychain outright, but it is restricted and macOS refuses to launch an app claiming it without a provisioning profile — tried, and the app died with a bare "Launchd job spawn failed". A stable certificate fixes the prompting without it, and the store will pick the better keychain up automatically if a profiled build ever exists.

## Verification

- `swift test`: 102 tests in 24 suites. New cover the byte-count reporting for ranged download, whole-file download and chunked upload; the film strip's ordering, bound and empty case; the GPU parser's clamping, coercion and refusal to invent a zero; the preview command's seek order and rate limiting. A live test grabs a real JPEG with the bundled ffmpeg.
- Signed with a real identity, launched, and confirmed running; the designated requirement is identical across two rebuilds where ad-hoc's is not.
- `swift build -c release` clean.

## Risk

`WorkExecutor.execute` gains a `preview` parameter. `SidecarSession`'s published properties become `internal(set)` so `posed(...)` can build a still life for previews and `--render-menu`; nothing outside the module can set them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
